### PR TITLE
topic/snacman#20 load gltf

### DIFF
--- a/.github/workflows/develop-build_test_deploy.yml
+++ b/.github/workflows/develop-build_test_deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.5.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.5.1
     with:
       os: >-
         ["ubuntu-22.04", "windows-2022"]

--- a/.github/workflows/topics-build_tests.yml
+++ b/.github/workflows/topics-build_tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-test:
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.5.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.5.1
     with:
       os: >-
         ["ubuntu-22.04", "windows-2022"]

--- a/.github/workflows/versiontag-build_test_deploy.yml
+++ b/.github/workflows/versiontag-build_test_deploy.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   extract_tag:
-    uses: shredeagle/reusable-workflows/.github/workflows/extract_version_tag.yml@v2.5.0
+    uses: shredeagle/reusable-workflows/.github/workflows/extract_version_tag.yml@v2.5.1
 
   build:
     needs: extract_tag
-    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.5.0
+    uses: shredeagle/reusable-workflows/.github/workflows/main_build.yml@v2.5.1
     with:
       os: >-
         ["ubuntu-22.04", "windows-2022"]

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,9 +23,9 @@ class SnacmanConan(ConanFile):
 
     requires = (
         ("entity/c70230d50e@adnn/develop"),
-        ("graphics/ccf7a97436@adnn/develop"),
+        ("graphics/b7393fd8ab@adnn/develop"),
         ("handy/23244cccb4@adnn/develop"),
-        ("math/1fe9879134@adnn/develop"),
+        ("math/e2f4683040@adnn/develop"),
         ("MarkovJunior.cpp/b90eee270b@adnn/develop"),
 
         ("spdlog/1.11.0"),

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -24,7 +24,7 @@ class SnacmanConan(ConanFile):
     requires = (
         ("entity/c70230d50e@adnn/develop"),
         ("graphics/b7393fd8ab@adnn/develop"),
-        ("handy/23244cccb4@adnn/develop"),
+        ("handy/401faf9024@adnn/develop"),
         ("math/e2f4683040@adnn/develop"),
         ("MarkovJunior.cpp/b90eee270b@adnn/develop"),
 

--- a/conan/workspaces/complete.yml
+++ b/conan/workspaces/complete.yml
@@ -3,11 +3,11 @@ editables:
         path: ../../../MarkovJunior.cpp/conan
     entity/c70230d50e@adnn/develop:
         path: ../../../entity/conan
-    graphics/ccf7a97436@adnn/develop:
+    graphics/b7393fd8ab@adnn/develop:
         path: ../../../graphics/conan
     handy/23244cccb4@adnn/develop:
         path: ../../../handy/conan
-    math/1fe9879134@adnn/develop:
+    math/e2f4683040@adnn/develop:
         path: ../../../math/conan
     snacman/local:
         path: ../../conan

--- a/conan/workspaces/complete.yml
+++ b/conan/workspaces/complete.yml
@@ -5,7 +5,7 @@ editables:
         path: ../../../entity/conan
     graphics/b7393fd8ab@adnn/develop:
         path: ../../../graphics/conan
-    handy/23244cccb4@adnn/develop:
+    handy/401faf9024@adnn/develop:
         path: ../../../handy/conan
     math/e2f4683040@adnn/develop:
         path: ../../../math/conan

--- a/conan/workspaces/default.yml
+++ b/conan/workspaces/default.yml
@@ -2,7 +2,7 @@ editables:
     #upstream/local:
     #    path: ../../../upstream/conan
     snacman/local:
-        path: ../../../conan
+        path: ../../conan
 layout: layout
 workspace_generator: cmake
 root: snacman/local

--- a/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
+++ b/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
@@ -39,12 +39,17 @@ cmc_cpp_all_warnings_as_errors(${TARGET_NAME} ENABLED ${BUILD_CONF_WarningAsErro
 
 cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
 
-
+file(GENERATE 
+     OUTPUT $<TARGET_FILE_DIR:${TARGET_NAME}>/assets.json
+     CONTENT "{\"prefixes\": [\"${REPO_FOLDER}/src/libs/snac-renderer/snac-renderer/\",
+                              \"${REPO_FOLDER}/../snac-assets/\"]}")
 ##
 ## Dependencies
 ##
 
 find_package(Graphics CONFIG REQUIRED graphics imguiui)
+
+find_package(Handy CONFIG REQUIRED plarform resource)
 
 find_package(spdlog CONFIG REQUIRED)
 
@@ -53,6 +58,8 @@ target_link_libraries(${TARGET_NAME}
         ad::snac-renderer
 
         ad::graphics
+        ad::platform
+        ad::resource
 
         spdlog::spdlog
 )

--- a/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
+++ b/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
@@ -39,7 +39,7 @@ cmc_cpp_all_warnings_as_errors(${TARGET_NAME} ENABLED ${BUILD_CONF_WarningAsErro
 
 cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
 
-file(GENERATE 
+file(GENERATE
      OUTPUT $<TARGET_FILE_DIR:${TARGET_NAME}>/assets.json
      CONTENT "{\"prefixes\": [\"${REPO_FOLDER}/src/libs/snac-renderer/snac-renderer/\",
                               \"${REPO_FOLDER}/../snac-assets/\",
@@ -52,7 +52,7 @@ file(GENERATE
 
 find_package(Graphics CONFIG REQUIRED graphics imguiui)
 
-find_package(Handy CONFIG REQUIRED plarform resource)
+find_package(Handy CONFIG REQUIRED platform resource)
 
 find_package(spdlog CONFIG REQUIRED)
 

--- a/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
+++ b/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
@@ -42,7 +42,10 @@ cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
 file(GENERATE 
      OUTPUT $<TARGET_FILE_DIR:${TARGET_NAME}>/assets.json
      CONTENT "{\"prefixes\": [\"${REPO_FOLDER}/src/libs/snac-renderer/snac-renderer/\",
-                              \"${REPO_FOLDER}/../snac-assets/\"]}")
+                              \"${REPO_FOLDER}/../snac-assets/\",
+                              \"${REPO_FOLDER}/../glTF-Sample-Models/2.0/\"
+              ]}"
+)
 ##
 ## Dependencies
 ##

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -129,7 +129,7 @@ inline void Scene::render(Renderer & aRenderer) const
          {BlockSemantic::Viewing, &mCamera.mViewing},
     };
 
-    math::hdr::Rgb_f lightColor =  to_hdr<float>(math::sdr::gBlue);
+    math::hdr::Rgb_f lightColor =  to_hdr<float>(math::sdr::gWhite) * 0.8f;
     math::Position<3, GLfloat> lightPosition{0.f, 0.f, 0.f};
     math::hdr::Rgb_f ambientColor =  math::hdr::Rgb_f{0.1f, 0.2f, 0.1f};
 
@@ -142,7 +142,7 @@ inline void Scene::render(Renderer & aRenderer) const
     clear();
     aRenderer.render(mMesh,
                      mInstances,
-                     uniforms,
+                     std::move(uniforms),
                      uniformBlocks);
 }
 

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -4,6 +4,7 @@
 #include <snac-renderer/Camera.h>
 #include <snac-renderer/Cube.h>
 #include <snac-renderer/Render.h>
+#include <snac-renderer/ResourceLoad.h>
 
 #include <graphics/AppInterface.h>
 
@@ -64,13 +65,13 @@ InstanceStream makeInstances()
 
 struct Scene
 {
-    Scene(graphics::AppInterface & aAppInterface);
+    Scene(graphics::AppInterface & aAppInterface, filesystem::path aProgram);
 
     void update();
 
     void render(Renderer & aRenderer) const;
 
-    Mesh mMesh{makeCube()};
+    Mesh mMesh;
     InstanceStream mInstances{makeInstances()};
     Camera mCamera;
     MouseOrbitalControl mCameraControl;
@@ -79,7 +80,8 @@ struct Scene
 };
 
 
-inline Scene::Scene(graphics::AppInterface & aAppInterface) :
+inline Scene::Scene(graphics::AppInterface & aAppInterface, filesystem::path aProgram) :
+    mMesh{loadCube(loadEffect(aProgram))},
     mCamera{math::getRatio<float>(aAppInterface.getFramebufferSize()), Camera::gDefaults},
     mCameraControl{aAppInterface.getWindowSize(), Camera::gDefaults.vFov}
 {

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -65,7 +65,7 @@ InstanceStream makeInstances()
 
 struct Scene
 {
-    Scene(graphics::AppInterface & aAppInterface, filesystem::path aProgram);
+    Scene(graphics::AppInterface & aAppInterface, Mesh aMesh);
 
     void update();
 
@@ -80,8 +80,8 @@ struct Scene
 };
 
 
-inline Scene::Scene(graphics::AppInterface & aAppInterface, filesystem::path aProgram) :
-    mMesh{loadCube(loadEffect(aProgram))},
+inline Scene::Scene(graphics::AppInterface & aAppInterface, Mesh aMesh) :
+    mMesh{std::move(aMesh)},
     mCamera{math::getRatio<float>(aAppInterface.getFramebufferSize()), Camera::gDefaults},
     mCameraControl{aAppInterface.getWindowSize(), Camera::gDefaults.vFov}
 {
@@ -117,8 +117,17 @@ inline void Scene::render(Renderer & aRenderer) const
          {BlockSemantic::Viewing, &mCamera.mViewing},
     };
 
+    math::hdr::Rgb_f lightColor =  to_hdr<float>(math::sdr::gBlue);
+    math::Position<3, GLfloat> lightPosition{0.f, 0.f, 0.f};
+    math::hdr::Rgb_f ambientColor =  math::hdr::Rgb_f{0.1f, 0.2f, 0.1f};
+
+    snac::UniformRepository uniforms{
+        {snac::Semantic::LightColor, snac::UniformParameter{lightColor}},
+        {snac::Semantic::LightPosition, {lightPosition}},
+        {snac::Semantic::AmbientColor, {ambientColor}},
+    };
+
     clear();
-    snac::UniformRepository uniforms;
     aRenderer.render(mMesh,
                      mInstances,
                      uniforms,

--- a/src/apps/snac-viewer/snac-viewer/main.cpp
+++ b/src/apps/snac-viewer/snac-viewer/main.cpp
@@ -61,7 +61,13 @@ void runApplication()
     //
     // Initialize scene
     //
-    Scene scene{*glfwApp.getAppInterface(), finder.pathFor("shaders/PhongLighting.prog")};
+
+    Scene scene{
+        *glfwApp.getAppInterface(),
+        //loadModel(finder.pathFor("Box/glTF/Box.gltf"),
+        loadModel(finder.pathFor("Avocado/glTF/Avocado.gltf"),
+                  loadEffect(finder.pathFor("shaders/PhongLighting.prog")))
+    };
     Renderer renderer;
 
     //

--- a/src/apps/snac-viewer/snac-viewer/main.cpp
+++ b/src/apps/snac-viewer/snac-viewer/main.cpp
@@ -3,14 +3,43 @@
 
 #include <build_info.h>
 
-#include <snac-renderer/Render.h>
+#include <arte/detail/Json.h>
 
 #include <graphics/ApplicationGlfw.h>
 
-//#include <imguiui/ImguiUi.h>
+#include <platform/Path.h>
+
+#include <resource/ResourceFinder.h>
+
+#include <snac-renderer/Render.h>
+
+#include <fstream>
+
 
 using namespace ad;
 using namespace ad::snac;
+
+
+resource::ResourceFinder makeResourceFinder()
+{
+    filesystem::path assetConfig = platform::getExecutableFileDirectory() / "assets.json";
+    if(exists(assetConfig))
+    {
+        Json config = Json::parse(std::ifstream{assetConfig});
+        
+        // Take the silly long way
+        std::vector<std::string> prefixes{
+            config.at("prefixes").begin(),
+            config.at("prefixes").end()
+        };
+        return resource::ResourceFinder(prefixes.begin(),
+                                        prefixes.end());
+    }
+    else
+    {
+        return resource::ResourceFinder{platform::getExecutableFileDirectory()};
+    }
+}
 
 
 void runApplication()
@@ -27,10 +56,12 @@ void runApplication()
     auto viewportListening = glfwApp.getAppInterface()->listenFramebufferResize(
         [](const math::Size<2, int> & size){ glViewport(0, 0, size.width(), size.height()); });
 
+    resource::ResourceFinder finder = makeResourceFinder();
+
     //
     // Initialize scene
     //
-    Scene scene{*glfwApp.getAppInterface()};
+    Scene scene{*glfwApp.getAppInterface(), finder.pathFor("shaders/PhongLighting.prog")};
     Renderer renderer;
 
     //

--- a/src/apps/snac-viewer/snac-viewer/main.cpp
+++ b/src/apps/snac-viewer/snac-viewer/main.cpp
@@ -66,7 +66,7 @@ void runApplication()
         *glfwApp.getAppInterface(),
         //loadModel(finder.pathFor("Box/glTF/Box.gltf"),
         loadModel(finder.pathFor("Avocado/glTF/Avocado.gltf"),
-                  loadEffect(finder.pathFor("shaders/PhongLighting.prog")))
+                  loadEffect(finder.pathFor("shaders/PhongLightingTextures.prog")))
     };
     Renderer renderer;
 

--- a/src/apps/snacman/snacman/RenderThread.h
+++ b/src/apps/snacman/snacman/RenderThread.h
@@ -358,6 +358,8 @@ private:
             // Render
             //
             mApplication.getAppInterface()->clear();
+            glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Frame");
+            BEGIN_RECURRING(Render, "Frame", frameProfilerScope);
             // renderer.render(*entries.current().state);
             renderer.render(state);
             SELOG(trace)("Render thread: Frame sent to GPU.");
@@ -366,6 +368,8 @@ private:
                 TIME_RECURRING(Render, "ImGui::renderBackend");
                 mImguiUi.renderBackend();
             }
+            END_RECURRING(frameProfilerScope);
+            glPopDebugGroup();
 
             {
                 TIME_RECURRING(Render, "Swap buffers");

--- a/src/apps/snacman/snacman/RenderThread.h
+++ b/src/apps/snacman/snacman/RenderThread.h
@@ -165,7 +165,7 @@ public:
         });
     }
 
-    std::future<std::shared_ptr<snac::Mesh>> loadShape(Resources & aResources)
+    std::future<std::shared_ptr<snac::Mesh>> loadShape(filesystem::path aShape, Resources & aResources)
     {
         // Almost certainly a programming error:
         // There is a risk the calling code will block on the future completion
@@ -176,12 +176,12 @@ public:
         // all captured types must be copyable.
         auto promise = std::make_shared<std::promise<std::shared_ptr<snac::Mesh>>>();
         std::future<std::shared_ptr<snac::Mesh>> future = promise->get_future();
-        push([promise = std::move(promise), &aResources]
+        push([promise = std::move(promise), shape = std::move(aShape), &aResources]
              (T_renderer & aRenderer) 
              {
                 try
                 {
-                    promise->set_value(aRenderer.LoadShape(aResources));
+                    promise->set_value(aRenderer.LoadShape(shape, aResources));
                 }
                 catch(...)
                 {

--- a/src/apps/snacman/snacman/RenderThread.h
+++ b/src/apps/snacman/snacman/RenderThread.h
@@ -167,6 +167,11 @@ public:
 
     std::future<std::shared_ptr<snac::Mesh>> loadShape(Resources & aResources)
     {
+        // Almost certainly a programming error:
+        // There is a risk the calling code will block on the future completion
+        // If the render thread is blocking, the completion will never occur.
+        assert(std::this_thread::get_id() != mThread.get_id());
+
         // std::function require the type-erased functor to be copy constructible.
         // all captured types must be copyable.
         auto promise = std::make_shared<std::promise<std::shared_ptr<snac::Mesh>>>();
@@ -191,6 +196,8 @@ public:
         unsigned int aPixelHeight,
         Resources & aResources)
     {
+        assert(std::this_thread::get_id() != mThread.get_id());
+
         // std::function require the type-erased functor to be copy constructible.
         // all captured types must be copyable.
         auto promise = std::make_shared<std::promise<std::shared_ptr<snac::Font>>>();
@@ -215,6 +222,8 @@ public:
 
     void checkRethrow()
     {
+        assert(std::this_thread::get_id() != mThread.get_id());
+
         if (mThrew)
         {
             std::rethrow_exception(mThreadException);

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -8,15 +8,24 @@ namespace ad {
 namespace snac {
 
 
-std::shared_ptr<Mesh> Resources::getShape()
+std::shared_ptr<Mesh> Resources::getShape(filesystem::path aShape)
 {
-    if(!mCube)
+    // This is bad design, but lazy to get the result quickly
+    if(aShape.string() == "CUBE")
     {
-        mCube = mRenderThread.loadShape(*this)
-            .get(); // synchronize call
+        if (!mCube)
+        {
+            mCube = mRenderThread.loadShape(aShape, *this)
+                .get(); // synchronize call
+        }
+        return mCube;
     }
-    return mCube;
+    else
+    {
+        return mMeshes.load(aShape, mFinder, mRenderThread, *this);
+    }
 }
+
 
 std::shared_ptr<Font> Resources::getFont(filesystem::path aFont, unsigned int aPixelHeight)
 {
@@ -47,6 +56,16 @@ std::shared_ptr<Font> Resources::FontLoader(
 {
     return aRenderThread.loadFont(aResources.getFreetype().load(aFont), aPixelHeight, aResources)
         .get(); // synchronize call
+}
+
+
+std::shared_ptr<Mesh> Resources::MeshLoader(
+    filesystem::path aMesh, 
+    RenderThread<snacgame::Renderer> & aRenderThread,
+    Resources & aResources)
+{
+    return aRenderThread.loadShape(aMesh, aResources)
+            .get(); // synchronize call
 }
 
 

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -1,11 +1,7 @@
 #include "Resources.h"
 
-#include <arte/detail/Json.h>
 
-#include <renderer/ShaderSource.h>
-#include <renderer/utilities/FileLookup.h>
-
-#include <fstream>
+#include <snac-renderer/ResourceLoad.h>
 
 
 namespace ad {
@@ -39,43 +35,7 @@ std::shared_ptr<Effect> Resources::EffectLoader(
     RenderThread<snacgame::Renderer> & aRenderThread,
     Resources & /*aResources*/)
 {
-    // Keep the ShaderSource instance directly, not just a view to an otherwise expired temporary.
-    std::vector<std::pair<const GLenum, graphics::ShaderSource>> shaders;
-
-    Json program = Json::parse(std::ifstream{aProgram});
-    graphics::FileLookup lookup{aProgram};
-    for (auto [shaderStage, shaderFile] : program.items())
-    {
-        GLenum stageEnumerator;
-        if(shaderStage == "vertex")
-        {
-            stageEnumerator = GL_VERTEX_SHADER;
-        }
-        else if (shaderStage == "fragment")
-        {
-            stageEnumerator = GL_FRAGMENT_SHADER;
-        }
-        else
-        {
-            SELOG(critical)("Unable to map shader stage key '{}' to a program stage.", shaderStage);
-            throw std::invalid_argument{"Unhandled shader stage key."};
-        }
-        
-        auto [inputStream, identifier] = lookup(shaderFile);
-        shaders.emplace_back(
-            stageEnumerator,
-            graphics::ShaderSource::Preprocess(*inputStream, identifier, lookup));
-    }
-
-    SELOG(debug)("Compiling shader program from '{}', containing {} stages.", lookup.top(), shaders.size());
-
-    return std::make_shared<Effect>(Effect{
-        .mProgram = IntrospectProgram{
-            graphics::makeLinkedProgram(shaders.begin(), shaders.end()),
-            aProgram.filename().string(),
-        }
-    });
-    
+    return loadEffect(aProgram);
 }
 
 

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<Font> Resources::FontLoader(
     RenderThread<snacgame::Renderer> & aRenderThread,
     Resources & aResources)
 {
-    return aRenderThread.loadFont(aFont, aPixelHeight, aResources)
+    return aRenderThread.loadFont(aResources.getFreetype().load(aFont), aPixelHeight, aResources)
         .get(); // synchronize call
 }
 

--- a/src/apps/snacman/snacman/Resources.h
+++ b/src/apps/snacman/snacman/Resources.h
@@ -24,7 +24,7 @@ public:
         mFinder{std::move(aFinder)}
     {}
 
-    std::shared_ptr<Mesh> getShape();
+    std::shared_ptr<Mesh> getShape(filesystem::path aShape);
 
     std::shared_ptr<Font> getFont(filesystem::path aFont, unsigned int aPixelHeight);
 
@@ -49,8 +49,8 @@ private:
         RenderThread<snacgame::Renderer> & aRenderThread,
         Resources & aResources);
 
-    static std::shared_ptr<Effect> MeshLoader(
-        filesystem::path aProgram, 
+    static std::shared_ptr<Mesh> MeshLoader(
+        filesystem::path aMesh, 
         RenderThread<snacgame::Renderer> & aRenderThread,
         Resources & aResources);
     

--- a/src/apps/snacman/snacman/Resources.h
+++ b/src/apps/snacman/snacman/Resources.h
@@ -34,6 +34,9 @@ public:
     auto find(const filesystem::path & aPath) const
     { return mFinder.find(aPath); }
 
+    const arte::Freetype & getFreetype()
+    { return mFreetype; }
+
 private:
     static std::shared_ptr<Font> FontLoader(
         filesystem::path aFont, 
@@ -52,6 +55,11 @@ private:
     RenderThread<snacgame::Renderer> & mRenderThread;
     resource::ResourceFinder mFinder;
 
+    // Must outlive all FontFaces: 
+    // * it must outlive the EntityManager (which might contain Freetype FontFaces)
+    // * it must outlive the resource managers holding fonts
+    arte::Freetype mFreetype;
+    
     std::shared_ptr<Mesh> mCube = nullptr;
     resource::ResourceManager<std::shared_ptr<Font>, resource::ResourceFinder, &Resources::FontLoader> mFonts;
     resource::ResourceManager<std::shared_ptr<Effect>, resource::ResourceFinder, &Resources::EffectLoader> mEffects;

--- a/src/apps/snacman/snacman/Resources.h
+++ b/src/apps/snacman/snacman/Resources.h
@@ -48,6 +48,11 @@ private:
         filesystem::path aProgram, 
         RenderThread<snacgame::Renderer> & aRenderThread,
         Resources & aResources);
+
+    static std::shared_ptr<Effect> MeshLoader(
+        filesystem::path aProgram, 
+        RenderThread<snacgame::Renderer> & aRenderThread,
+        Resources & aResources);
     
     // There is a smelly circular dependency in this design:
     // Resources knows the RenderThread to request OpenGL related resource loading
@@ -61,8 +66,9 @@ private:
     arte::Freetype mFreetype;
     
     std::shared_ptr<Mesh> mCube = nullptr;
-    resource::ResourceManager<std::shared_ptr<Font>, resource::ResourceFinder, &Resources::FontLoader> mFonts;
+    resource::ResourceManager<std::shared_ptr<Font>,   resource::ResourceFinder, &Resources::FontLoader>   mFonts;
     resource::ResourceManager<std::shared_ptr<Effect>, resource::ResourceFinder, &Resources::EffectLoader> mEffects;
+    resource::ResourceManager<std::shared_ptr<Mesh>,   resource::ResourceFinder, &Resources::MeshLoader>  mMeshes;
 };
 
 

--- a/src/apps/snacman/snacman/detail/Logger.cpp
+++ b/src/apps/snacman/snacman/detail/Logger.cpp
@@ -1,5 +1,6 @@
 #include "Logger.h"
 
+#include <arte/Logging.h>
 #include <snac-renderer/Logging.h>
 
 #include <spdlog/sinks/stdout_color_sinks.h>
@@ -28,6 +29,7 @@ namespace {
 void initializeLogging()
 {
     std::call_once(loggingInitializationOnce, &initializeLogging_impl);
+    arte::initializeLogging();
     renderer::initializeLogging();
     //Note: Initialize all upstream libraries logging here too.
 };

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -28,7 +28,7 @@ void createPill(GameContext & aContext,
         ->add(component::Geometry{
             .mSubGridPosition = math::Position<2, float>::Zero(),
             .mGridPosition = aGridPos,
-            .mScaling = math::Size<3, float>{.3f, .3f, .3f},
+            .mScaling = math::Size<3, float>{30.f, 30.f, 30.f},
             .mLayer = component::GeometryLayer::Player,
             .mOrientation = math::Quaternion<float>{math::UnitVec<3, float>{
                                                         {0.f, 1.f, 0.f}},
@@ -40,7 +40,7 @@ void createPill(GameContext & aContext,
                           .mAngle = math::Degree<float>{60.f}},
         })
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("models/avocado/Avocado.gltf"),
         })
         .add(component::LevelEntity{})
         ;
@@ -60,7 +60,7 @@ createPathEntity(GameContext & aContext,
             .mLayer = component::GeometryLayer::Level,
             .mColor = math::hdr::gWhite<float>})
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("CUBE"),
         })
         ;
     ;
@@ -81,7 +81,7 @@ createPortalEntity(GameContext & aContext,
             .mLayer = component::GeometryLayer::Level,
             .mColor = math::hdr::gRed<float>})
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("CUBE"),
         })
         ;
     return handle;
@@ -100,7 +100,7 @@ createCopPenEntity(GameContext & aContext,
             .mLayer = component::GeometryLayer::Level,
             .mColor = math::hdr::gYellow<float>})
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("CUBE"),
         })
         ;
     return handle;
@@ -119,7 +119,7 @@ createPlayerSpawnEntity(GameContext & aContext,
             .mLayer = component::GeometryLayer::Level,
             .mColor = math::hdr::gCyan<float>})
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("CUBE"),
         })
         ;
     spawner.get(aInit)->add(component::Spawner{.mSpawnPosition = aGridPos});
@@ -138,17 +138,21 @@ void fillSlotWithPlayer(GameContext & aContext,
     playerEntity->add(component::Geometry{
         .mSubGridPosition = math::Position<2, float>::Zero(),
         .mGridPosition = math::Position<2, int>::Zero(),
+        .mScaling = {100.f, 100.f, 100.f},
         .mLayer = component::GeometryLayer::Player,
-        .mColor = math::hdr::gMagenta<float>});
-    playerEntity->add(component::PlayerLifeCycle{.mIsAlive = false});
-    playerEntity->add(component::PlayerMoveState{});
-    playerEntity
-        ->add(component::Controller{
+        .mOrientation = math::Quaternion<float>{math::UnitVec<3, float>{
+                                                    {0.f, 1.f, 0.f}},
+                                                math::Degree<float>{-90.f}},
+        .mColor = math::hdr::gMagenta<float>
+    })
+        .add(component::PlayerLifeCycle{.mIsAlive = false})
+        .add(component::PlayerMoveState{})
+        .add(component::Controller{
             .mType = aControllerType,
             .mControllerId = aControllerId
         })
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("models/avocado/Avocado.gltf"),
         })
         ;
 }
@@ -164,7 +168,7 @@ ent::Handle<ent::Entity> createMenuItem(GameContext & aContext,
             .mLayer = component::GeometryLayer::Menu,
             .mColor = math::hdr::gMagenta<float>})
         .add(component::VisualMesh{
-            .mMesh = aContext.mResources.getShape(),
+            .mMesh = aContext.mResources.getShape("CUBE"),
         })
         ;
 

--- a/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
@@ -16,7 +16,7 @@ namespace snacgame {
 struct GameContext
 {
     snac::Resources mResources; // contains Freetype, which must outlive the entity manager
-    ent::EntityManager & mWorld;
+    ent::EntityManager mWorld;
     snac::RenderThread<Renderer> & mRenderThread;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
@@ -15,9 +15,9 @@ namespace snacgame {
 
 struct GameContext
 {
+    snac::Resources mResources; // contains Freetype, which must outlive the entity manager
     ent::EntityManager & mWorld;
     snac::RenderThread<Renderer> & mRenderThread;
-    snac::Resources mResources;
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -4,6 +4,7 @@
 #include <math/Transformations.h>
 #include <math/VectorUtilities.h>
 
+#include <snac-renderer/ResourceLoad.h>
 #include <snac-renderer/text/Text.h>
 
 #include <snacman/Profiling.h>
@@ -104,6 +105,7 @@ Renderer::Renderer(graphics::AppInterface & aAppInterface) :
     mMeshInstances{initializeInstanceStream()}
 {}
 
+
 void Renderer::resetProjection(float aAspectRatio, snac::Camera::Parameters aParameters)
 {
     mCamera.resetProjection(aAspectRatio, aParameters);
@@ -112,13 +114,15 @@ void Renderer::resetProjection(float aAspectRatio, snac::Camera::Parameters aPar
 
 std::shared_ptr<snac::Mesh> Renderer::LoadShape(snac::Resources & aResources)
 {
-    auto mesh = std::make_shared<snac::Mesh>(snac::Mesh{.mStream = snac::makeCube()}); 
+    return std::make_shared<snac::Mesh>(
+        snac::loadCube(aResources.getShaderEffect("shaders/PhongLighting.prog")));
 
-    mesh->mMaterial = std::make_shared<snac::Material>(snac::Material{
-        .mEffect = aResources.getShaderEffect("shaders/PhongLighting.prog")
-    });
-
-    return mesh;
+    // TODO move out
+    //auto avocado = snac::loadGltf(*aResources.find("models/avocado/Avocado.gltf"));
+    //avocado.mMaterial = std::make_shared<snac::Material>(snac::Material{
+    //    .mEffect = aResources.getShaderEffect("shaders/PhongLighting.prog")
+    //});
+    //return std::make_shared<snac::Mesh>(std::move(avocado));
 }
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -12,6 +12,11 @@
 
 #include <platform/Filesystem.h>
 
+// TODO #generic-render remove once all geometry and shader programs are created outside.
+#include <snac-renderer/Cube.h>
+#include <snac-renderer/gltf/GltfLoad.h>
+#include <renderer/ShaderSource.h>
+
 
 namespace ad {
 namespace snacgame {
@@ -69,7 +74,9 @@ void TextRenderer::render(Renderer & aRenderer,
 
         // TODO should be consolidated, a single call for all string of the same font.
         mGlyphInstances.respecifyData(std::span{textBufferData});
+        glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Draw string");
         aRenderer.mRenderer.render(text.mFont->mGlyphMesh, mGlyphInstances, aUniforms, aUniformBlocks);
+        glPopDebugGroup();
     }
 
 }
@@ -178,11 +185,13 @@ void Renderer::render(const visu::GraphicState & aState)
     };
 
     BEGIN_RECURRING(Render, "Draw_meshes", drawMeshProfile);
+    glPushDebugGroup(GL_DEBUG_SOURCE_APPLICATION, 0, -1, "Draw meshes");
     for (const auto & [mesh, instances] : sortedMeshes)
     {
         mMeshInstances.respecifyData(std::span{instances});
         mRenderer.render(*mesh, mMeshInstances, uniforms, uniformBlocks);
     }
+    glPopDebugGroup();
     END_RECURRING(drawMeshProfile);
 
     //

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -133,13 +133,12 @@ std::shared_ptr<snac::Mesh> Renderer::LoadShape(snac::Resources & aResources)
 }
 
 
-std::shared_ptr<snac::Font> Renderer::loadFont(filesystem::path aFont,
+std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
                                                unsigned int aPixelHeight,
                                                snac::Resources & aResources)
 {
     return std::make_shared<snac::Font>(
-        mFreetype,
-        aFont,
+        std::move(aFontFace),
         aPixelHeight,
         aResources.getShaderEffect("shaders/Text.prog")
     );

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -119,17 +119,18 @@ void Renderer::resetProjection(float aAspectRatio, snac::Camera::Parameters aPar
 }
 
 
-std::shared_ptr<snac::Mesh> Renderer::LoadShape(snac::Resources & aResources)
+std::shared_ptr<snac::Mesh> Renderer::LoadShape(filesystem::path aShape, snac::Resources & aResources)
 {
-    return std::make_shared<snac::Mesh>(
-        snac::loadCube(aResources.getShaderEffect("shaders/PhongLighting.prog")));
-
-    // TODO move out
-    //auto avocado = snac::loadGltf(*aResources.find("models/avocado/Avocado.gltf"));
-    //avocado.mMaterial = std::make_shared<snac::Material>(snac::Material{
-    //    .mEffect = aResources.getShaderEffect("shaders/PhongLighting.prog")
-    //});
-    //return std::make_shared<snac::Mesh>(std::move(avocado));
+    if(aShape.string() == "CUBE")
+    {
+        return std::make_shared<snac::Mesh>(
+            snac::loadCube(aResources.getShaderEffect("shaders/PhongLighting.prog")));
+    }
+    else
+    {
+        return std::make_shared<snac::Mesh>(
+            loadModel(aShape, aResources.getShaderEffect("shaders/PhongLightingTextures.prog")));
+    }
 }
 
 
@@ -168,9 +169,9 @@ void Renderer::render(const visu::GraphicState & aState)
     // Position camera
     mCamera.setWorldToCamera(aState.mCamera.mWorldToCamera);
 
-    math::hdr::Rgb_f lightColor =  to_hdr<float>(math::sdr::gBlue);
+    math::hdr::Rgb_f lightColor =  to_hdr<float>(math::sdr::gWhite) * 0.8f;
     math::Position<3, GLfloat> lightPosition{0.f, 0.f, 0.f};
-    math::hdr::Rgb_f ambientColor =  math::hdr::Rgb_f{0.1f, 0.2f, 0.1f};
+    math::hdr::Rgb_f ambientColor =  math::hdr::Rgb_f{0.1f, 0.1f, 0.1f};
     
     snac::UniformRepository uniforms{
         {snac::Semantic::LightColor, snac::UniformParameter{lightColor}},

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -8,10 +8,6 @@
 
 #include <graphics/AppInterface.h>
 
-// TODO #generic-render remove once all geometry and shader programs are created outside.
-#include <snac-renderer/Cube.h>
-#include <renderer/ShaderSource.h>
-
 
 namespace ad {
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -47,7 +47,7 @@ public:
     // TODO Extend beyond cubes.
     static std::shared_ptr<snac::Mesh> LoadShape(snac::Resources & aResources);
 
-    std::shared_ptr<snac::Font> loadFont(filesystem::path aFont,
+    std::shared_ptr<snac::Font> loadFont(arte::FontFace aFontFace,
                                          unsigned int aPixelHeight,
                                          snac::Resources & aResources);
 
@@ -59,10 +59,6 @@ private:
     snac::Camera mCamera;
     snac::InstanceStream mMeshInstances;
     TextRenderer mTextRenderer;
-
-    // Must outlive all FontFaces, thus it must outlive the EntityManager,
-    // which might contain Freetype FontFaces. 
-    arte::Freetype mFreetype;
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -45,7 +45,7 @@ public:
     void resetProjection(float aAspectRatio, snac::Camera::Parameters aParameters);
 
     // TODO Extend beyond cubes.
-    static std::shared_ptr<snac::Mesh> LoadShape(snac::Resources & aResources);
+    static std::shared_ptr<snac::Mesh> LoadShape(filesystem::path aShape, snac::Resources & aResources);
 
     std::shared_ptr<snac::Font> loadFont(arte::FontFace aFontFace,
                                          unsigned int aPixelHeight,

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -47,9 +47,9 @@ SnacGame::SnacGame(graphics::AppInterface & aAppInterface,
                    RawInput & aInput) :
     mAppInterface{&aAppInterface},
     mGameContext{
+        .mResources = snac::Resources{std::move(aResourceFinder), aRenderThread},
         .mWorld = mWorld,
         .mRenderThread = aRenderThread,
-        .mResources = snac::Resources{std::move(aResourceFinder), aRenderThread},
     },
     mMappingContext{mWorld, mGameContext.mResources},
     mStateMachine{mWorld, mWorld, gAssetRoot / "scenes/scene_description.json",

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -48,24 +48,23 @@ SnacGame::SnacGame(graphics::AppInterface & aAppInterface,
     mAppInterface{&aAppInterface},
     mGameContext{
         .mResources = snac::Resources{std::move(aResourceFinder), aRenderThread},
-        .mWorld = mWorld,
         .mRenderThread = aRenderThread,
     },
-    mMappingContext{mWorld, mGameContext.mResources},
-    mStateMachine{mWorld, mWorld, gAssetRoot / "scenes/scene_description.json",
+    mMappingContext{mGameContext.mWorld, mGameContext.mResources},
+    mStateMachine{mGameContext.mWorld, mGameContext.mWorld, gAssetRoot / "scenes/scene_description.json",
                   mMappingContext},
-    mSystemOrbitalCamera{mWorld, mWorld},
-    mQueryRenderable{mWorld, mWorld},
-    mQueryText{mWorld, mWorld},
+    mSystemOrbitalCamera{mGameContext.mWorld, mGameContext.mWorld},
+    mQueryRenderable{mGameContext.mWorld, mGameContext.mWorld},
+    mQueryText{mGameContext.mWorld, mGameContext.mWorld},
     mImguiUi{aImguiUi}
 {
     ent::Phase init;
 
     // Creating the slot entity those will be used a player entities
-    mWorld.addEntity().get(init)->add(component::PlayerSlot{0, false});
-    mWorld.addEntity().get(init)->add(component::PlayerSlot{1, false});
-    mWorld.addEntity().get(init)->add(component::PlayerSlot{2, false});
-    mWorld.addEntity().get(init)->add(component::PlayerSlot{3, false});
+    mGameContext.mWorld.addEntity().get(init)->add(component::PlayerSlot{0, false});
+    mGameContext.mWorld.addEntity().get(init)->add(component::PlayerSlot{1, false});
+    mGameContext.mWorld.addEntity().get(init)->add(component::PlayerSlot{2, false});
+    mGameContext.mWorld.addEntity().get(init)->add(component::PlayerSlot{3, false});
 
     scene::Scene * scene = mStateMachine->getCurrentScene();
     scene->setup(mGameContext, scene::Transition{}, aInput);

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
@@ -117,8 +117,6 @@ public:
 private:
     graphics::AppInterface * mAppInterface;
 
-    ent::EntityManager mWorld;
-
     GameContext mGameContext;
     
     // TODO use the ent::Wrap

--- a/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
+++ b/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
@@ -66,6 +66,8 @@ cmc_cpp_all_warnings_as_errors(${TARGET_NAME} ENABLED ${BUILD_CONF_WarningAsErro
 if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
     # We use istrstream to interface an array of std::byte with an istream based API.
     target_compile_definitions(${TARGET_NAME} PRIVATE _SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING)
+else()
+    target_compile_options(${TARGET_NAME} PRIVATE "-Wno-deprecated")
 endif ()
 
 cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})

--- a/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
+++ b/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
@@ -14,6 +14,9 @@ set(${TARGET_NAME}_HEADERS
     ShaderResource.h
     UniformParameters.h
 
+    gltf/GltfLoad.h
+    gltf/LoadBuffer.h
+
     text/Text.h
 
     3rdparty/Profiler.hpp
@@ -32,6 +35,9 @@ set(${TARGET_NAME}_SOURCES
     ShaderResource.cpp
 
     text/Text.cpp
+
+    gltf/GltfLoad.cpp
+    gltf/LoadBuffer.cpp
 
     3rdparty/Profiler.cpp
 )
@@ -54,6 +60,11 @@ set_target_properties(${TARGET_NAME} PROPERTIES
 )
 
 cmc_cpp_all_warnings_as_errors(${TARGET_NAME} ENABLED ${BUILD_CONF_WarningAsError})
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # We use istrstream to interface an array of std::byte with an istream based API.
+    target_compile_definitions(${TARGET_NAME} PRIVATE _SILENCE_CXX17_STRSTREAM_DEPRECATION_WARNING)
+endif ()
 
 cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
 

--- a/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
+++ b/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${TARGET_NAME}_HEADERS
     Material.h
     Mesh.h
     Render.h
+    ResourceLoad.h
     Semantic.h
     SetupDrawing.h
     ShaderResource.h
@@ -30,6 +31,7 @@ set(${TARGET_NAME}_SOURCES
     Material.cpp
     Mesh.cpp
     Render.cpp
+    ResourceLoad.cpp
     Semantic.cpp
     SetupDrawing.cpp
     ShaderResource.cpp

--- a/src/libs/snac-renderer/snac-renderer/Camera.h
+++ b/src/libs/snac-renderer/snac-renderer/Camera.h
@@ -41,7 +41,7 @@ struct Camera
 class Orbital
 {
 public:
-    Orbital(float aRadius, math::Radian<float> aPolar = math::Radian<float>{0.f}, math::Radian<float> aAzimuthal = math::Radian<float>{0.f}) :
+    Orbital(float aRadius, math::Radian<float> aPolar = math::Degree<float>{90.f}, math::Radian<float> aAzimuthal = math::Radian<float>{0.f}) :
         mSpherical{aRadius, aPolar, aAzimuthal}
     {}
 

--- a/src/libs/snac-renderer/snac-renderer/Cube.h
+++ b/src/libs/snac-renderer/snac-renderer/Cube.h
@@ -244,7 +244,7 @@ inline VertexStream makeRectangle(math::Rectangle<GLfloat> aRectangle)
             .mOffset = offsetof(PositionUV, uv),
             .mComponentType = GL_FLOAT
         };
-        geometry.mAttributes.emplace(Semantic::TextureCoords, AttributeAccessor{index, uv});
+        geometry.mAttributes.emplace(Semantic::TextureCoords0, AttributeAccessor{index, uv});
     }
 
     geometry.mVertexCount = static_cast<GLsizei>(vertices.size());

--- a/src/libs/snac-renderer/snac-renderer/Logging.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Logging.cpp
@@ -1,5 +1,7 @@
 #include "Logging.h"
 
+#include <arte/Logging.h>
+
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include <mutex>
@@ -29,6 +31,7 @@ namespace renderer {
     void initializeLogging()
     {
         std::call_once(loggingInitializationOnce, &initializeLogging_impl);
+        arte::initializeLogging();
         //Note: Initialize all upstream libraries logging here too.
     };
 

--- a/src/libs/snac-renderer/snac-renderer/Logging.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Logging.cpp
@@ -18,6 +18,7 @@ namespace {
         // Intended for the main game messages
         spdlog::stdout_color_mt(gRenderLogger);
         spdlog::stdout_color_mt(gGltfLogger);
+        spdlog::stdout_color_mt(gResourceLogger);
     }
 
 } // namespace anonymous

--- a/src/libs/snac-renderer/snac-renderer/Logging.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Logging.cpp
@@ -17,6 +17,7 @@ namespace {
     {
         // Intended for the main game messages
         spdlog::stdout_color_mt(gRenderLogger);
+        spdlog::stdout_color_mt(gGltfLogger);
     }
 
 } // namespace anonymous

--- a/src/libs/snac-renderer/snac-renderer/Logging.h
+++ b/src/libs/snac-renderer/snac-renderer/Logging.h
@@ -12,6 +12,7 @@ namespace snac {
 
 constexpr const char * gRenderLogger = "snac-render";
 constexpr const char * gGltfLogger = "gltf-loader";
+constexpr const char * gResourceLogger = "resource-loader";
 
 
 // Add this namespace so initializeLogging() does not clash with the one from snacman.

--- a/src/libs/snac-renderer/snac-renderer/Logging.h
+++ b/src/libs/snac-renderer/snac-renderer/Logging.h
@@ -11,6 +11,7 @@ namespace snac {
 
 
 constexpr const char * gRenderLogger = "snac-render";
+constexpr const char * gGltfLogger = "gltf-loader";
 
 
 // Add this namespace so initializeLogging() does not clash with the one from snacman.

--- a/src/libs/snac-renderer/snac-renderer/Mesh.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Mesh.cpp
@@ -1,0 +1,22 @@
+#include "Mesh.h"
+
+
+namespace ad {
+namespace snac {
+
+
+std::ostream & operator<<(std::ostream & aOut, const Mesh & aMesh)
+{
+    if(aMesh.mName.empty())
+    {
+        return aOut << "unnamed mesh (at " << &aMesh << ")";
+    }
+    else
+    {
+        return aOut << aMesh.mName << "(at " << &aMesh << ")";
+    }
+}
+
+
+} // namespace snac
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/Mesh.h
+++ b/src/libs/snac-renderer/snac-renderer/Mesh.h
@@ -2,6 +2,7 @@
 
 #include "IntrospectProgram.h"
 #include "Semantic.h"
+#include "UniformParameters.h"
 
 #include <math/Box.h>
 
@@ -16,6 +17,12 @@ namespace ad {
 namespace snac {
 
 
+// TODO this approach based on specialized repositories feels cumbersome.
+using TextureRepository = std::map<Semantic, 
+                                   std::variant<std::shared_ptr<graphics::Texture>,
+                                                graphics::Texture *>>;
+
+
 struct Effect
 {
     IntrospectProgram mProgram;
@@ -24,7 +31,8 @@ struct Effect
 
 struct Material
 {
-    std::map<Semantic, const graphics::Texture *> mTextures;
+    TextureRepository mTextures;
+    UniformRepository mUniforms;
     std::shared_ptr<Effect> mEffect;
 };
 
@@ -81,7 +89,11 @@ struct Mesh
 {
     VertexStream mStream;
     std::shared_ptr<Material> mMaterial;
+    std::string mName;
 };
+
+
+std::ostream & operator<<(std::ostream & aOut, const Mesh & aMesh);
 
 
 struct InstanceStream

--- a/src/libs/snac-renderer/snac-renderer/Mesh.h
+++ b/src/libs/snac-renderer/snac-renderer/Mesh.h
@@ -35,6 +35,10 @@ struct Material
 
 struct BufferView
 {
+    // Important: At the moment, we make distinct buffers for each gltf buffer view.
+    // This is whay the BufferView hosts the VertexBufferObject.
+    // We make the bet that interleaved vertex attributes are always modeled 
+    // by distinct accessor on the same buffer view in gltf.
     graphics::VertexBufferObject mBuffer;
     GLsizei mStride{0};
 
@@ -51,15 +55,22 @@ struct AttributeAccessor
     graphics::ClientAttribute mAttribute;
 };
 
+struct IndicesAccessor
+{
+    // Not using a view for the index buffer, since it cannot be interleaved with other data.
+    graphics::IndexBufferObject mIndexBuffer;
+    GLsizei mIndexCount{0};
+    graphics::ClientAttribute mAttribute;
+};
+
 
 struct VertexStream
 {
     std::vector<BufferView> mVertexBuffers;
     std::map<Semantic, AttributeAccessor> mAttributes;
-    GLsizei mVertexCount{0};
+    std::optional<IndicesAccessor> mIndices;
+    GLsizei mVertexCount{0}; // i.e. the number of elements stored in each VBO
     GLenum mPrimitive;
-    // TODO handle indexed rendering
-    //IndexBufferObject mIndexBuffer;
 };
 
 

--- a/src/libs/snac-renderer/snac-renderer/Mesh.h
+++ b/src/libs/snac-renderer/snac-renderer/Mesh.h
@@ -3,6 +3,8 @@
 #include "IntrospectProgram.h"
 #include "Semantic.h"
 
+#include <math/Box.h>
+
 #include <renderer/Shading.h>
 #include <renderer/Texture.h>
 #include <renderer/VertexSpecification.h>
@@ -71,6 +73,7 @@ struct VertexStream
     std::optional<IndicesAccessor> mIndices;
     GLsizei mVertexCount{0}; // i.e. the number of elements stored in each VBO
     GLenum mPrimitive;
+    math::Box<GLfloat> mBoundingBox;
 };
 
 

--- a/src/libs/snac-renderer/snac-renderer/Mesh.h
+++ b/src/libs/snac-renderer/snac-renderer/Mesh.h
@@ -11,6 +11,7 @@
 #include <renderer/VertexSpecification.h>
 
 #include <map>
+#include <optional>
 
 
 namespace ad {
@@ -18,7 +19,7 @@ namespace snac {
 
 
 // TODO this approach based on specialized repositories feels cumbersome.
-using TextureRepository = std::map<Semantic, 
+using TextureRepository = std::map<Semantic,
                                    std::variant<std::shared_ptr<graphics::Texture>,
                                                 graphics::Texture *>>;
 
@@ -47,7 +48,7 @@ struct BufferView
 {
     // Important: At the moment, we make distinct buffers for each gltf buffer view.
     // This is whay the BufferView hosts the VertexBufferObject.
-    // We make the bet that interleaved vertex attributes are always modeled 
+    // We make the bet that interleaved vertex attributes are always modeled
     // by distinct accessor on the same buffer view in gltf.
     graphics::VertexBufferObject mBuffer;
     GLsizei mStride{0};

--- a/src/libs/snac-renderer/snac-renderer/Render.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Render.cpp
@@ -10,13 +10,16 @@ namespace snac {
 
 void Renderer::render(const Mesh & aMesh,
                       const InstanceStream & aInstances,
-                      const UniformRepository & aUniforms,
+                      UniformRepository aUniforms,
                       const UniformBlocks & aUniformBlocks)
 {
     auto depthTest = graphics::scopeFeature(GL_DEPTH_TEST, true);
 
     const IntrospectProgram & program = aMesh.mMaterial->mEffect->mProgram;
-    setUniforms(aUniforms, program);
+
+    // TODO Is there a better way to handle several source for uniform values
+    aUniforms.merge(UniformRepository{aMesh.mMaterial->mUniforms});
+    setUniforms(aUniforms, program, mWarningRepo.get(aMesh, program));
     setTextures(aMesh.mMaterial->mTextures, program);
     setBlocks(aUniformBlocks, program);
 

--- a/src/libs/snac-renderer/snac-renderer/Render.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Render.cpp
@@ -28,6 +28,8 @@ void Renderer::render(const Mesh & aMesh,
     graphics::use(program);
     if(aMesh.mStream.mIndices)
     {
+        // Note: Range commands (providing a range of possible index values) are no longer usefull
+        // see: https://computergraphics.stackexchange.com/a/6199/11110
         glDrawElementsInstanced(aMesh.mStream.mPrimitive,
                                 aMesh.mStream.mIndices->mIndexCount,
                                 aMesh.mStream.mIndices->mAttribute.mComponentType,

--- a/src/libs/snac-renderer/snac-renderer/Render.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Render.cpp
@@ -23,7 +23,21 @@ void Renderer::render(const Mesh & aMesh,
     graphics::ScopedBind boundVAO{mVertexArrayRepo.get(aMesh, aInstances, program)};
 
     graphics::use(program);
-    glDrawArraysInstanced(aMesh.mStream.mPrimitive, 0, aMesh.mStream.mVertexCount, aInstances.mInstanceCount);
+    if(aMesh.mStream.mIndices)
+    {
+        glDrawElementsInstanced(aMesh.mStream.mPrimitive,
+                                aMesh.mStream.mIndices->mIndexCount,
+                                aMesh.mStream.mIndices->mAttribute.mComponentType,
+                                (void*)aMesh.mStream.mIndices->mAttribute.mOffset,
+                                aInstances.mInstanceCount);
+    }
+    else
+    {
+        glDrawArraysInstanced(aMesh.mStream.mPrimitive,
+                              0, 
+                              aMesh.mStream.mVertexCount,
+                              aInstances.mInstanceCount);
+    }
 }
 
 

--- a/src/libs/snac-renderer/snac-renderer/Render.h
+++ b/src/libs/snac-renderer/snac-renderer/Render.h
@@ -8,7 +8,6 @@
 #include <renderer/GL_Loader.h>
 
 
-
 namespace ad {
 namespace snac {
 
@@ -24,11 +23,12 @@ class Renderer
 public:
     void render(const Mesh & aMesh,
                 const InstanceStream & aInstances,
-                const UniformRepository & aUniforms,
+                UniformRepository aUniforms,
                 const UniformBlocks & aUniformBlocks);
 
 private:
     VertexArrayRepository mVertexArrayRepo;
+    WarningRepository mWarningRepo;
 };
 
 

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
@@ -1,0 +1,76 @@
+#include "ResourceLoad.h"
+
+#include "Cube.h"
+#include "Logging.h"
+
+#include <arte/detail/Json.h>
+
+#include <renderer/ShaderSource.h>
+#include <renderer/utilities/FileLookup.h>
+
+#include <fstream>
+
+
+#define SELOG(level) SELOG_LG(::ad::snac::gResourceLogger, level)
+
+
+namespace ad {
+namespace snac {
+
+
+std::shared_ptr<Effect> loadEffect(filesystem::path aProgram)
+{
+    std::vector<std::pair<const GLenum, graphics::ShaderSource>> shaders;
+
+    Json program = Json::parse(std::ifstream{aProgram});
+    graphics::FileLookup lookup{aProgram};
+    for (auto [shaderStage, shaderFile] : program.items())
+    {
+        GLenum stageEnumerator;
+        if(shaderStage == "vertex")
+        {
+            stageEnumerator = GL_VERTEX_SHADER;
+        }
+        else if (shaderStage == "fragment")
+        {
+            stageEnumerator = GL_FRAGMENT_SHADER;
+        }
+        else
+        {
+            SELOG(critical)("Unable to map shader stage key '{}' to a program stage.", shaderStage);
+            throw std::invalid_argument{"Unhandled shader stage key."};
+        }
+        
+        auto [inputStream, identifier] = lookup(shaderFile);
+        shaders.emplace_back(
+            stageEnumerator,
+            graphics::ShaderSource::Preprocess(*inputStream, identifier, lookup));
+    }
+
+    SELOG(debug)("Compiling shader program from '{}', containing {} stages.", lookup.top(), shaders.size());
+
+    return std::make_shared<Effect>(Effect{
+        .mProgram = IntrospectProgram{
+            graphics::makeLinkedProgram(shaders.begin(), shaders.end()),
+            aProgram.filename().string(),
+        }
+    });
+}
+
+
+Mesh loadCube(std::shared_ptr<Effect> aEffect)
+{
+    snac::Mesh mesh{
+        .mStream = makeCube()
+    }; 
+
+    mesh.mMaterial = std::make_shared<snac::Material>(snac::Material{
+        .mEffect = std::move(aEffect)
+    });
+
+    return mesh;
+}
+
+
+} // namespace graphics
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
@@ -66,7 +66,8 @@ Mesh loadCube(std::shared_ptr<Effect> aEffect)
         .mStream = makeCube(),
         .mMaterial = std::make_shared<snac::Material>(snac::Material{
             .mEffect = std::move(aEffect)
-        })
+        }),
+        .mName = "procedural_cube",
     }; 
 
     return mesh;
@@ -75,13 +76,8 @@ Mesh loadCube(std::shared_ptr<Effect> aEffect)
 
 Mesh loadModel(filesystem::path aGltf, std::shared_ptr<Effect> aEffect)
 {
-    snac::Mesh mesh{
-        .mStream = loadGltf(aGltf),
-        .mMaterial = std::make_shared<snac::Material>(snac::Material{
-            .mEffect = std::move(aEffect)
-        })
-    }; 
-
+    snac::Mesh mesh{loadGltf(aGltf)};
+    mesh.mMaterial->mEffect = std::move(aEffect);
     return mesh;
 }
 

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
@@ -3,6 +3,8 @@
 #include "Cube.h"
 #include "Logging.h"
 
+#include "gltf/GltfLoad.h"
+
 #include <arte/detail/Json.h>
 
 #include <renderer/ShaderSource.h>
@@ -61,12 +63,24 @@ std::shared_ptr<Effect> loadEffect(filesystem::path aProgram)
 Mesh loadCube(std::shared_ptr<Effect> aEffect)
 {
     snac::Mesh mesh{
-        .mStream = makeCube()
+        .mStream = makeCube(),
+        .mMaterial = std::make_shared<snac::Material>(snac::Material{
+            .mEffect = std::move(aEffect)
+        })
     }; 
 
-    mesh.mMaterial = std::make_shared<snac::Material>(snac::Material{
-        .mEffect = std::move(aEffect)
-    });
+    return mesh;
+}
+
+
+Mesh loadModel(filesystem::path aGltf, std::shared_ptr<Effect> aEffect)
+{
+    snac::Mesh mesh{
+        .mStream = loadGltf(aGltf),
+        .mMaterial = std::make_shared<snac::Material>(snac::Material{
+            .mEffect = std::move(aEffect)
+        })
+    }; 
 
     return mesh;
 }

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+#include "Mesh.h"
+
+#include <platform/filesystem.h>
+
+#include <memory>
+
+
+namespace ad {
+namespace snac {
+
+
+std::shared_ptr<Effect> loadEffect(filesystem::path aProgram);
+
+
+Mesh loadCube(std::shared_ptr<Effect> aEffect);
+
+
+} // namespace graphics
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
@@ -3,7 +3,7 @@
 
 #include "Mesh.h"
 
-#include <platform/filesystem.h>
+#include <platform/Filesystem.h>
 
 #include <memory>
 

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
@@ -17,6 +17,8 @@ std::shared_ptr<Effect> loadEffect(filesystem::path aProgram);
 
 Mesh loadCube(std::shared_ptr<Effect> aEffect);
 
+Mesh loadModel(filesystem::path aGltf, std::shared_ptr<Effect> aEffect);
+
 
 } // namespace graphics
 } // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/Semantic.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Semantic.cpp
@@ -21,18 +21,22 @@ std::string to_string(Semantic aSemantic)
         MAPPING(Normal)
         MAPPING(Albedo)
         MAPPING(TextureCoords)
+        MAPPING(BaseColorUV)
         MAPPING(LocalToWorld)
         MAPPING(InstancePosition)
         MAPPING(TextureOffset)
         MAPPING(BoundingBox)
         MAPPING(Bearing)
+        MAPPING(BaseColorFactor) 
         MAPPING(AmbientColor) 
         MAPPING(LightColor)
         MAPPING(LightPosition)
         MAPPING(WorldToCamera)
         MAPPING(Projection)
-        MAPPING(FontAtlas)
         MAPPING(FramebufferResolution)
+        MAPPING(BaseColorTexture)
+        MAPPING(MetallicRoughnessTexture)
+        MAPPING(FontAtlas)
         default:
         {
             auto value = static_cast<std::underlying_type_t<Semantic>>(aSemantic);
@@ -64,18 +68,22 @@ Semantic to_semantic(std::string_view aResourceName)
     MAPPING(Normal)
     MAPPING(Albedo)
     MAPPING(TextureCoords)
+    MAPPING(BaseColorUV)
     MAPPING(LocalToWorld)
     MAPPING(InstancePosition)
     MAPPING(TextureOffset)
     MAPPING(BoundingBox)
     MAPPING(Bearing)
+    MAPPING(BaseColorFactor) 
     MAPPING(AmbientColor) 
     MAPPING(LightColor)
     MAPPING(LightPosition)
     MAPPING(WorldToCamera)
     MAPPING(Projection)
-    MAPPING(FontAtlas)
     MAPPING(FramebufferResolution)
+    MAPPING(BaseColorTexture)
+    MAPPING(MetallicRoughnessTexture)
+    MAPPING(FontAtlas)
     else
     {
         throw std::logic_error{
@@ -90,26 +98,34 @@ bool isNormalized(Semantic aSemantic)
     switch(aSemantic)
     {
         case Semantic::Albedo:
-        case Semantic::AmbientColor:
-        case Semantic::LightColor:
         {
             return true;
         }
         case Semantic::Position:
         case Semantic::Normal:
         case Semantic::TextureCoords:
+        case Semantic::BaseColorUV:
         case Semantic::LocalToWorld:
         case Semantic::InstancePosition:
         case Semantic::TextureOffset:
         case Semantic::BoundingBox:
         case Semantic::Bearing:
+        {
+            return false;
+        }
+        case Semantic::BaseColorFactor:
+        case Semantic::AmbientColor:
+        case Semantic::LightColor:
         case Semantic::LightPosition:
         case Semantic::WorldToCamera:
         case Semantic::Projection:
-        case Semantic::FontAtlas:
         case Semantic::FramebufferResolution:
+        case Semantic::BaseColorTexture:
+        case Semantic::MetallicRoughnessTexture:
+        case Semantic::FontAtlas:
         {
-            return false;
+            throw std::logic_error{
+                "Semantic '" + to_string(aSemantic) + "' should be a uniform, normalization is not applicable."};
         }
         default:
         {

--- a/src/libs/snac-renderer/snac-renderer/Semantic.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Semantic.cpp
@@ -31,6 +31,7 @@ std::string to_string(Semantic aSemantic)
         MAPPING(BaseColorFactor) 
         MAPPING(BaseColorUVIndex) 
         MAPPING(NormalUVIndex) 
+        MAPPING(NormalMapScale) 
         MAPPING(AmbientColor) 
         MAPPING(LightColor)
         MAPPING(LightPosition)
@@ -82,6 +83,7 @@ Semantic to_semantic(std::string_view aResourceName)
     MAPPING(BaseColorFactor) 
     MAPPING(BaseColorUVIndex) 
     MAPPING(NormalUVIndex) 
+    MAPPING(NormalMapScale) 
     MAPPING(AmbientColor) 
     MAPPING(LightColor)
     MAPPING(LightPosition)
@@ -125,6 +127,7 @@ bool isNormalized(Semantic aSemantic)
         case Semantic::BaseColorFactor:
         case Semantic::BaseColorUVIndex:
         case Semantic::NormalUVIndex:
+        case Semantic::NormalMapScale:
         case Semantic::AmbientColor:
         case Semantic::LightColor:
         case Semantic::LightPosition:

--- a/src/libs/snac-renderer/snac-renderer/Semantic.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Semantic.cpp
@@ -19,15 +19,18 @@ std::string to_string(Semantic aSemantic)
     {
         MAPPING(Position)
         MAPPING(Normal)
+        MAPPING(Tangent)
         MAPPING(Albedo)
-        MAPPING(TextureCoords)
-        MAPPING(BaseColorUV)
+        MAPPING(TextureCoords0)
+        MAPPING(TextureCoords1)
         MAPPING(LocalToWorld)
         MAPPING(InstancePosition)
         MAPPING(TextureOffset)
         MAPPING(BoundingBox)
         MAPPING(Bearing)
         MAPPING(BaseColorFactor) 
+        MAPPING(BaseColorUVIndex) 
+        MAPPING(NormalUVIndex) 
         MAPPING(AmbientColor) 
         MAPPING(LightColor)
         MAPPING(LightPosition)
@@ -35,6 +38,7 @@ std::string to_string(Semantic aSemantic)
         MAPPING(Projection)
         MAPPING(FramebufferResolution)
         MAPPING(BaseColorTexture)
+        MAPPING(NormalTexture)
         MAPPING(MetallicRoughnessTexture)
         MAPPING(FontAtlas)
         default:
@@ -66,15 +70,18 @@ Semantic to_semantic(std::string_view aResourceName)
     if(false){}
     MAPPING(Position)
     MAPPING(Normal)
+    MAPPING(Tangent)
     MAPPING(Albedo)
-    MAPPING(TextureCoords)
-    MAPPING(BaseColorUV)
+    MAPPING(TextureCoords0)
+    MAPPING(TextureCoords1)
     MAPPING(LocalToWorld)
     MAPPING(InstancePosition)
     MAPPING(TextureOffset)
     MAPPING(BoundingBox)
     MAPPING(Bearing)
     MAPPING(BaseColorFactor) 
+    MAPPING(BaseColorUVIndex) 
+    MAPPING(NormalUVIndex) 
     MAPPING(AmbientColor) 
     MAPPING(LightColor)
     MAPPING(LightPosition)
@@ -82,6 +89,7 @@ Semantic to_semantic(std::string_view aResourceName)
     MAPPING(Projection)
     MAPPING(FramebufferResolution)
     MAPPING(BaseColorTexture)
+    MAPPING(NormalTexture)
     MAPPING(MetallicRoughnessTexture)
     MAPPING(FontAtlas)
     else
@@ -103,8 +111,9 @@ bool isNormalized(Semantic aSemantic)
         }
         case Semantic::Position:
         case Semantic::Normal:
-        case Semantic::TextureCoords:
-        case Semantic::BaseColorUV:
+        case Semantic::Tangent:
+        case Semantic::TextureCoords0:
+        case Semantic::TextureCoords1:
         case Semantic::LocalToWorld:
         case Semantic::InstancePosition:
         case Semantic::TextureOffset:
@@ -114,6 +123,8 @@ bool isNormalized(Semantic aSemantic)
             return false;
         }
         case Semantic::BaseColorFactor:
+        case Semantic::BaseColorUVIndex:
+        case Semantic::NormalUVIndex:
         case Semantic::AmbientColor:
         case Semantic::LightColor:
         case Semantic::LightPosition:
@@ -121,6 +132,7 @@ bool isNormalized(Semantic aSemantic)
         case Semantic::Projection:
         case Semantic::FramebufferResolution:
         case Semantic::BaseColorTexture:
+        case Semantic::NormalTexture:
         case Semantic::MetallicRoughnessTexture:
         case Semantic::FontAtlas:
         {

--- a/src/libs/snac-renderer/snac-renderer/Semantic.h
+++ b/src/libs/snac-renderer/snac-renderer/Semantic.h
@@ -12,9 +12,10 @@ enum class Semantic
     // Usally per vertex
     Position,
     Normal,
+    Tangent,
     Albedo,
-    TextureCoords,
-    BaseColorUV,
+    TextureCoords0,
+    TextureCoords1,
     // Usually per instance
     LocalToWorld,
     InstancePosition,
@@ -23,6 +24,8 @@ enum class Semantic
     Bearing,
     // Usually uniform
     BaseColorFactor,
+    BaseColorUVIndex,
+    NormalUVIndex,
     AmbientColor,
     LightColor,
     LightPosition,
@@ -31,6 +34,7 @@ enum class Semantic
     FramebufferResolution,
     // Usually samplers
     BaseColorTexture,
+    NormalTexture,
     MetallicRoughnessTexture,
     FontAtlas, // TODO should it just be atlas, used for both sprites and fonts?
     //SpriteAtlas,

--- a/src/libs/snac-renderer/snac-renderer/Semantic.h
+++ b/src/libs/snac-renderer/snac-renderer/Semantic.h
@@ -14,6 +14,7 @@ enum class Semantic
     Normal,
     Albedo,
     TextureCoords,
+    BaseColorUV,
     // Usually per instance
     LocalToWorld,
     InstancePosition,
@@ -21,6 +22,7 @@ enum class Semantic
     BoundingBox,
     Bearing,
     // Usually uniform
+    BaseColorFactor,
     AmbientColor,
     LightColor,
     LightPosition,
@@ -28,6 +30,8 @@ enum class Semantic
     Projection,
     FramebufferResolution,
     // Usually samplers
+    BaseColorTexture,
+    MetallicRoughnessTexture,
     FontAtlas, // TODO should it just be atlas, used for both sprites and fonts?
     //SpriteAtlas,
 

--- a/src/libs/snac-renderer/snac-renderer/Semantic.h
+++ b/src/libs/snac-renderer/snac-renderer/Semantic.h
@@ -25,7 +25,8 @@ enum class Semantic
     // Usually uniform
     BaseColorFactor,
     BaseColorUVIndex,
-    NormalUVIndex,
+    NormalUVIndex, // Index of the normal texture coordinates in the array of UV coordinates
+    NormalMapScale,
     AmbientColor,
     LightColor,
     LightPosition,

--- a/src/libs/snac-renderer/snac-renderer/SetupDrawing.h
+++ b/src/libs/snac-renderer/snac-renderer/SetupDrawing.h
@@ -7,6 +7,7 @@
 #include <renderer/VertexSpecification.h>
 
 #include <map>
+#include <set>
 
 
 namespace ad {
@@ -28,10 +29,26 @@ struct VertexArrayRepository
 };
 
 
-void setUniforms(const UniformRepository & aUniforms, const IntrospectProgram & aProgram);
+/// \brief This class is a workaround for the problem of recurring uniforms warning.
+/// (at each frame, when a uniform is not bound, the same warning is emitted)
+/// \todo Identifying the logical situation where "the warning has already been emitted" is not trivial.
+/// For the moment, we use the mesh and the program to be synonymous of the logical situation, but this
+/// might need reworking.
+struct WarningRepository
+{
+    using WarnedUniforms = std::set<std::string>;
 
-// TODO this approach based on specialized repositories feels cumbersome.
-using TextureRepository = std::map<Semantic, const graphics::Texture *>;
+    WarningRepository::WarnedUniforms & get(const Mesh & aMesh,
+                                            const IntrospectProgram & aProgram);
+
+    using Key = std::pair<const Mesh *, const graphics::Program *>;
+    std::map<Key, WarnedUniforms> mWarnings;
+};
+
+
+void setUniforms(const UniformRepository & aUniforms,
+                 const IntrospectProgram & aProgram,
+                 WarningRepository::WarnedUniforms & aWarnedUniforms);
 
 void setTextures(const TextureRepository & aTextures, const IntrospectProgram & aProgram);
 

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
@@ -1,0 +1,198 @@
+#include "GltfLoad.h"
+
+#include "LoadBuffer.h"
+
+#include "../Logging.h"
+#include "../Semantic.h"
+
+#include <arte/gltf/Gltf.h>
+
+#include <map>
+
+using namespace ad::arte;
+
+
+#define SELOG(level) SELOG_LG(gGltfLogger, level)
+
+
+namespace ad {
+namespace snac {
+
+namespace {
+
+    std::optional<Semantic> translateGltfSemantic(std::string_view aGltfSemantic)
+    {
+        #define MAPPING(gltfstring, semantic) \
+            else if(aGltfSemantic == #gltfstring) { return Semantic::semantic; }
+
+        if(false){}
+        MAPPING(POSITION, Position)
+        MAPPING(NORMAL, Normal)
+        else
+        {
+            SELOG(debug)("Gltf semantic \"{}\" is not handled.", aGltfSemantic);
+            return std::nullopt;
+        }
+    }
+
+
+    template <class T_buffer>
+    T_buffer prepareBuffer(Const_Owned<gltf::Accessor> aAccessor,
+                           Const_Owned<gltf::BufferView> aBufferView)
+    {
+        GLenum target = [&]()
+        {
+            if (!aBufferView->target)
+            {
+                const GLenum infered = T_buffer::GLTarget_v;
+                SELOG(info)("Buffer view #{} does not have target defined. Infering {}.",
+                            aBufferView.id(), infered);
+                return infered;
+            }
+            else
+            {
+                assert(*aBufferView->target == T_buffer::GLTarget_v);
+                return *aBufferView->target;
+            }
+        }();
+
+        T_buffer buffer;
+
+        glBindBuffer(target, buffer);
+        glBufferData(target,
+                     aBufferView->byteLength,
+                     // TODO might be even better to only load in main memory the part of the buffer starting
+                     // at bufferView->byteOffset (and also limit the length there, actually).
+                     loadBufferData(aAccessor, aBufferView).data() 
+                         + aBufferView->byteOffset,
+                     GL_STATIC_DRAW);
+        glBindBuffer(target, 0);
+
+        SELOG(debug)
+            ("Loaded {} bytes in target {}, offset in source buffer is {} bytes.",
+            aBufferView->byteLength,
+            target,
+            aBufferView->byteOffset);
+
+        return buffer;
+    }
+
+
+    BufferView prepareBufferView(Const_Owned<gltf::Accessor> aAccessor)
+    {
+        auto gltfBufferView = checkedBufferView(aAccessor);
+        return BufferView{
+            .mBuffer = prepareBuffer<graphics::VertexBufferObject>(aAccessor, gltfBufferView),
+            .mStride = (GLsizei)gltfBufferView->byteStride.value_or(0),
+        };
+    }
+
+
+    Mesh makeFromPrimitive(Const_Owned<gltf::Primitive> aPrimitive)
+    {
+        Mesh mesh;
+
+        mesh.mStream.mPrimitive = aPrimitive->mode;
+
+        GLsizei vertexCount = std::numeric_limits<GLsizei>::max();
+        std::map<gltf::Index<gltf::BufferView>::Value_t, std::size_t/*buffer view index*/> bufferViewMap;
+
+        for(const auto & [gltfSemantic, accessorId] : aPrimitive->attributes)
+        {
+            SELOG(debug)("Semantic \"{}\" is associated to accessor #{}", gltfSemantic, accessorId);
+
+            Const_Owned<gltf::Accessor> accessor = aPrimitive.get(accessorId);
+
+            if(vertexCount != std::numeric_limits<GLsizei>::max() 
+                && vertexCount != accessor->count)
+            {
+                SELOG(critical)
+                    ("Semantic \"{}\", accessor #{} has a count of {}, while previous accessors where {}.",
+                    gltfSemantic, accessorId, accessor->count, vertexCount);
+                throw std::runtime_error{"Inconsistent accessors count."};
+            }
+
+            if(!accessor->bufferView)
+            {
+                SELOG(error)("Skipping semantic \"{}\", associated to accessor #{} which does not have a buffer view.", gltfSemantic, accessorId);
+                continue;
+            }
+
+            std::size_t bufferViewId;
+            auto gltfBufferViewId = accessor->bufferView->value;
+            if(auto found = bufferViewMap.find(gltfBufferViewId);
+                found != bufferViewMap.end())
+            {
+                SELOG(trace)
+                    ("Semantic \"{}\", associated to accessor #{}, reuses mesh buffer view #{}.",
+                    gltfSemantic, accessorId, found->second);
+                bufferViewId = found->second;
+            }
+            else
+            {
+                bufferViewId = mesh.mStream.mVertexBuffers.size();
+                mesh.mStream.mVertexBuffers.push_back(prepareBufferView(accessor));
+                bufferViewMap.emplace(gltfBufferViewId, bufferViewId);
+            }
+
+            if (auto semantic = translateGltfSemantic(gltfSemantic))
+            {
+                mesh.mStream.mAttributes.emplace(
+                    *semantic,
+                    AttributeAccessor{
+                        .mBufferViewIndex = bufferViewId,
+                        .mAttribute = {
+                            .mDimension = getAccessorDimension(accessor->type),
+                            .mOffset = accessor->byteOffset,
+                            .mComponentType = accessor->componentType,
+                        }
+                    }
+                );
+            }
+            else
+            {
+                SELOG(warn)("Skipping semantic \"{}\", associated to accessor #{}, which does not have a translation.", gltfSemantic, accessorId);
+            }
+        }
+
+        mesh.mStream.mVertexCount = vertexCount;
+        return mesh;
+    }
+};
+
+    // Scene iteration logic
+    //auto scene = gltf.getDefaultScene();
+    //if(!scene)
+    //{
+    //    SELOG(error)("The gltf model '{}' does not define a default scene.", aModel);
+    //    throw std::runtime_error{"Gltf file without a default scene (not handled)."};
+    //}
+    //for(auto node : scene->iterate(&arte::gltf::Scene::nodes))
+    //{
+    //    
+    //}
+
+Mesh loadGltf(filesystem::path aModel)
+{
+    arte::Gltf gltf{aModel};
+
+    // TODO this should be extended, to allow picking sub-meshes from a Gltf file
+    // and even support multiple primitives in a Mesh (but the Mesh class will need redesigning) 
+
+    // Get first mesh
+    Owned<gltf::Mesh> gltfMesh = gltf.get(gltf::Index<gltf::Mesh>{0});
+    // Load the first (and only) primitive
+    if(gltfMesh->primitives.size() != 1)
+    {
+        SELOG(error)
+            ("The gltf model '{}' first mesh has {} primitives, exactly 1 is required.",
+            aModel.string(), gltfMesh->primitives.size());
+        throw std::runtime_error{"Gltf file without a single primitive on the first mesh."};
+    }
+
+    return makeFromPrimitive({gltf, gltfMesh->primitives.at(0), 0});
+}
+
+
+} // namespace snac
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
@@ -111,6 +111,7 @@ namespace {
                     gltfSemantic, accessorId, accessor->count, vertexCount);
                 throw std::runtime_error{"Inconsistent accessors count."};
             }
+            vertexCount = (GLsizei)accessor->count;
 
             if(!accessor->bufferView)
             {

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
@@ -312,6 +312,8 @@ namespace {
                         ColorSpace::Linear));
                 material->mUniforms.emplace(Semantic::NormalUVIndex,
                                             normalTexture->texCoord);
+                material->mUniforms.emplace(Semantic::NormalMapScale,
+                                            normalTexture->scale);
             }
         }
 

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
@@ -187,7 +187,7 @@ namespace {
             Const_Owned<gltf::Accessor> accessor = aPrimitive.get(accessorId);
 
             if(vertexCount != std::numeric_limits<GLsizei>::max() 
-                && vertexCount != accessor->count)
+                && vertexCount != (GLsizei)accessor->count)
             {
                 SELOG(critical)
                     ("Semantic \"{}\", accessor #{} has a count of {}, while previous accessors where {}.",

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
@@ -3,7 +3,7 @@
 
 #include "../Mesh.h"
 
-#include <platform/filesystem.h>
+#include <platform/Filesystem.h>
 
 
 namespace ad {

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
@@ -10,7 +10,7 @@ namespace ad {
 namespace snac {
 
 
-Mesh loadGltf(filesystem::path aModel);
+VertexStream loadGltf(filesystem::path aModel);
 
 
 

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
@@ -1,0 +1,18 @@
+#pragma once
+
+
+#include "../Mesh.h"
+
+#include <platform/filesystem.h>
+
+
+namespace ad {
+namespace snac {
+
+
+Mesh loadGltf(filesystem::path aModel);
+
+
+
+} // namespace snac
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.h
@@ -10,7 +10,7 @@ namespace ad {
 namespace snac {
 
 
-VertexStream loadGltf(filesystem::path aModel);
+Mesh loadGltf(filesystem::path aModel);
 
 
 

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
@@ -22,7 +22,8 @@ namespace snac {
 
 namespace {
 
-    // TODO Reading a stream content is a recurring need, should be moved to a more general library.
+    // TODO Should be moved to a more general library. 
+    // Reading a stream content is a recurring need.
     std::vector<std::byte> loadInputStream(std::istream & aInput, std::size_t aByteLength, const std::string & aStreamId)
     {
         constexpr std::size_t gChunkSize = 128 * 1024;
@@ -45,6 +46,7 @@ namespace {
         }
         return result;
     }
+
 
     std::vector<std::byte> loadInputStream(std::istream && aInput, std::size_t aByteLength, const std::string & aStreamId)
     { return loadInputStream(aInput, aByteLength, aStreamId); }
@@ -123,7 +125,7 @@ std::vector<std::byte> loadBufferData(arte::Const_Owned<arte::gltf::Buffer> aBuf
     {
     case arte::gltf::Uri::Type::Data:
     {
-        // TODO implement
+        // TODO implement handling subranges on data Uri.
         if(aByteOffset != 0 || aByteLength != aBuffer->byteLength)
         {
             SELOG(critical)

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
@@ -1,0 +1,309 @@
+#include "LoadBuffer.h"
+
+#include "../Logging.h"
+
+#include <handy/Base64.h>
+#include <handy/Url.h>
+
+#include <span>
+#include <strstream>
+
+#include <renderer/AttributeDimension.h>
+//#include <renderer/GL_Loader.h>
+#include <renderer/MappedGL.h>
+
+
+#define SELOG(level) SELOG_LG(::ad::snac::gGltfLogger, level)
+
+
+namespace ad {
+namespace snac {
+
+
+namespace {
+
+    // TODO Reading a stream content is a recurring need, should be moved to a more general library.
+    std::vector<std::byte> loadInputStream(std::istream & aInput, std::size_t aByteLength, const std::string & aStreamId)
+    {
+        constexpr std::size_t gChunkSize = 128 * 1024;
+
+        std::vector<std::byte> result(aByteLength);
+        std::size_t remainingBytes = aByteLength;
+
+        char * destination = reinterpret_cast<char *>(result.data());
+        while (remainingBytes)
+        {
+            std::size_t readSize = std::min(remainingBytes, gChunkSize);
+            if (!aInput.read(destination, readSize).good())
+            {
+                throw std::runtime_error{"Problem reading '" + aStreamId + "': "
+                    // If stream is not good(), yet converts to 'true', it means only eofbit is set.
+                    + (aInput ? "stream truncated." : "read error.")};
+            }
+            destination += readSize;
+            remainingBytes -= readSize;
+        }
+        return result;
+    }
+
+    std::vector<std::byte> loadInputStream(std::istream && aInput, std::size_t aByteLength, const std::string & aStreamId)
+    { return loadInputStream(aInput, aByteLength, aStreamId); }
+
+    using ElementType = arte::gltf::Accessor::ElementType;
+
+    const std::map<ElementType, graphics::AttributeDimension> gElementTypeToLayout{
+        {ElementType::Scalar, {1}},    
+        {ElementType::Vec2,   {2}},    
+        {ElementType::Vec3,   {3}},    
+        {ElementType::Vec4,   {4}},    
+        {ElementType::Mat2,   {2, 2}},    
+        {ElementType::Mat3,   {3, 3}},    
+        {ElementType::Mat4,   {4, 4}},    
+    };
+
+
+    std::size_t getElementByteSize(arte::Const_Owned<arte::gltf::Accessor> aAccessor)
+    {
+        return getAccessorDimension(aAccessor->type).countComponents()
+            * graphics::getByteSize(aAccessor->componentType);
+    }
+
+} // unnamed namespace
+
+
+graphics::AttributeDimension getAccessorDimension(arte::gltf::Accessor::ElementType aElementType)
+{
+    return gElementTypeToLayout.at(aElementType);
+}
+
+arte::Const_Owned<arte::gltf::BufferView>
+checkedBufferView(arte::Const_Owned<arte::gltf::Accessor> aAccessor)
+{
+    if (!aAccessor->bufferView)
+    {
+        SELOG(critical)
+             ("Unsupported: Accessor #{} does not have a buffer view associated.", aAccessor.id());
+        throw std::logic_error{"Accessor was expected to have a buffer view."};
+    }
+    return aAccessor.get(&arte::gltf::Accessor::bufferView);
+}
+
+
+std::vector<std::byte> loadDataUri(arte::gltf::Uri aUri)
+{
+    constexpr const char * base64Prefix{"base64,"};
+
+    std::string_view encoded{aUri.string};
+    encoded.remove_prefix(encoded.find(base64Prefix) + std::strlen(base64Prefix));
+    return handy::base64::decode(encoded);
+}
+
+
+std::vector<std::byte> loadBufferData(arte::Const_Owned<arte::gltf::Buffer> aBuffer,
+                                      std::size_t aByteOffset,
+                                      std::size_t aByteLength)
+{
+    if (!aBuffer->uri)
+    {
+        SELOG(critical)
+             ("Buffer #{} does not have target defined.", aBuffer.id());
+        throw std::logic_error{"Buffer was expected to have an Uri."};
+    }
+
+    if(aBuffer->byteLength < aByteOffset + aByteLength)
+    {
+        SELOG(critical)
+            ("Attempt to read range [{}, {}] from buffer #{} of length {} bytes.",
+            aByteOffset, aByteLength, aBuffer.id(), aBuffer->byteLength);
+        throw std::out_of_range{"Loading buffer past the end."};
+    }
+
+    auto uri = *aBuffer->uri;
+    switch(uri.type)
+    {
+    case arte::gltf::Uri::Type::Data:
+    {
+        // TODO implement
+        if(aByteOffset != 0 || aByteLength != aBuffer->byteLength)
+        {
+            SELOG(critical)
+                 ("Loading a subset of Uri data buffer #{} is not implemented yet.", aBuffer.id());
+            throw std::invalid_argument{"Loading a subset of Uri data buffer."};
+        }
+        SELOG(trace)("Buffer #{} data is read from a data URI.", aBuffer.id());
+        return loadDataUri(uri);
+    }
+    case arte::gltf::Uri::Type::File:
+    {
+        SELOG(trace)("Buffer #{} data is read from file {}.", aBuffer.id(), uri.string);
+        std::ifstream fileStream{
+            handy::decodeUrl(aBuffer.getFilePath(&arte::gltf::Buffer::uri).string()),
+            std::ios_base::in | std::ios_base::binary
+        };
+        fileStream.seekg(aByteOffset); // Advance by the offset
+        return loadInputStream(
+            fileStream,
+            aByteLength,
+            uri.string);
+    }
+    default:
+        throw std::logic_error{"Invalid uri type."};
+    }
+}
+
+
+// Note: not part of the public interface for the moment
+// I am afraid users will be confused whether the buffer view offset is applied.
+std::vector<std::byte> loadBufferData(arte::Const_Owned<arte::gltf::BufferView> aBufferView)
+{
+    return loadBufferData(
+        aBufferView.get(&arte::gltf::BufferView::buffer),
+        aBufferView->byteOffset,
+        aBufferView->byteLength);
+}
+
+
+template <class T_component>
+std::vector<GLuint> copyIndices(const std::byte * aFirst, std::size_t aCount)
+{
+    const T_component * first = reinterpret_cast<const T_component *>(aFirst);
+    std::vector<GLuint> result;
+    std::copy(first, first + aCount, std::back_inserter(result));
+    return result;
+}
+
+/// \brief Converts all potential indice types to the largest representation.
+std::vector<GLuint>
+loadIndices(arte::Const_Owned<arte::gltf::accessor::Indices> aIndices, std::size_t aCount)
+{
+    auto bufferView = aIndices.get(&arte::gltf::accessor::Indices::bufferView);
+    std::vector<std::byte> buffer = loadBufferData(bufferView);
+
+    std::byte * first = buffer.data() + bufferView->byteOffset + aIndices->byteOffset;
+    switch(aIndices->componentType)
+    {
+    case GL_UNSIGNED_BYTE:
+        return copyIndices<GLubyte>(first, aCount);
+    case GL_UNSIGNED_SHORT:
+        return copyIndices<GLushort>(first, aCount);
+    case GL_UNSIGNED_INT:
+        return copyIndices<GLuint>(first, aCount);
+    }
+
+    throw std::logic_error{std::string{"In "} + __func__
+        + ", unhandled component type: " + std::to_string(aIndices->componentType)};
+}
+
+
+std::vector<std::byte>
+loadBufferData(arte::Const_Owned<arte::gltf::Accessor> aAccessor,
+               arte::Const_Owned<arte::gltf::BufferView> aBufferView)
+{
+    std::vector<std::byte> bufferData = loadBufferData(aBufferView);
+
+    if(aAccessor->sparse)
+    {
+        auto sparse = aAccessor.get(&arte::gltf::Accessor::sparse);
+        std::vector<GLuint> indices =
+            loadIndices(sparse.get(&arte::gltf::accessor::Sparse::indices), sparse->count);
+
+        auto values = sparse.get(&arte::gltf::accessor::Sparse::values);
+        auto valuesBufferView = values.get(&arte::gltf::accessor::Values::bufferView);
+        std::vector<std::byte> differenceBuffer = loadBufferData(valuesBufferView);
+        const std::byte * difference =
+            differenceBuffer.data() + valuesBufferView->byteOffset + values->byteOffset;
+
+        std::byte * element =
+            bufferData.data() + aBufferView->byteOffset + aAccessor->byteOffset;
+        const std::size_t elementSize = getElementByteSize(aAccessor);
+
+        std::size_t iteration = 0;
+        for (auto modifiedIndex : indices)
+        {
+            std::copy(difference + iteration * elementSize,
+                      difference + (iteration + 1) * elementSize,
+                      element + modifiedIndex * elementSize);
+            ++iteration;
+        }
+    }
+
+    return bufferData;
+}
+
+
+const std::map<arte::gltf::Image::MimeType, arte::ImageFormat> gMimeToFormat {
+    {arte::gltf::Image::MimeType::ImageJpeg, arte::ImageFormat::Jpg},
+    {arte::gltf::Image::MimeType::ImagePng, arte::ImageFormat::Png},
+};
+
+
+
+arte::Image<math::sdr::Rgba>
+loadImageFromBytes(std::span<std::byte> aBytes, arte::gltf::Image::MimeType aMime)
+{
+    using Image = arte::Image<math::sdr::Rgba>;
+
+    // TODO Ad 2022/03/23: Replace deprecated istrstream with a proposed alternative
+    // see: https://en.cppreference.com/w/cpp/io/istrstream
+    // see: https://stackoverflow.com/a/12646922/1027706
+    return Image::Read(
+        gMimeToFormat.at(aMime),
+        std::istrstream(reinterpret_cast<const char *>(aBytes.data()), aBytes.size()),
+        arte::ImageOrientation::Unchanged);
+}
+
+
+arte::Image<math::sdr::Rgba>
+loadImageData(arte::Const_Owned<arte::gltf::Image> aImage)
+{
+    using Image = arte::Image<math::sdr::Rgba>;
+
+    if(const arte::gltf::Uri * uri = std::get_if<arte::gltf::Uri>(&aImage->dataSource))
+    {
+        switch(uri->type)
+        {
+        case arte::gltf::Uri::Type::Data:
+        {
+            SELOG(trace)("Image #{} data is read from a data URI.", aImage.id());
+            // TODO handle this situation by reading the magic numbers
+            if (!aImage->mimeType)
+            {
+                SELOG(critical)
+                     ("Unsupported: Image #{} has a data URI but no mime type.", aImage.id());
+                throw std::logic_error{"Image with data URI but no mime type."};
+            }
+            auto bytes = loadDataUri(*uri);
+            return loadImageFromBytes(bytes, *aImage->mimeType);
+        }
+        case arte::gltf::Uri::Type::File:
+        {
+            SELOG(trace)("Image #{} data is read from a file URI.", aImage.id());
+            return Image{handy::decodeUrl(aImage.getFilePath(*uri).string()), arte::ImageOrientation::Unchanged};
+        }
+        default:
+            throw std::logic_error{"Invalid uri type."};
+        }
+    }
+    else
+    {
+        SELOG(trace)("Image #{} data is read from a buffer view.", aImage.id());
+        auto bufferView =
+            aImage.get(std::get<arte::gltf::Index<arte::gltf::BufferView>>(aImage->dataSource));
+
+        if (!aImage->mimeType)
+        {
+            SELOG(critical)
+                 ("Invalid file: Image #{} has a buffer view but no mime type.", aImage.id());
+            throw std::logic_error{"Image with buffer view but no mime type."};
+        }
+
+        auto bytes = loadBufferData(bufferView);
+        return loadImageFromBytes(std::span<std::byte>{bytes}.subspan(bufferView->byteOffset,
+                                                                      bufferView->byteLength),
+                                  *aImage->mimeType);
+    }
+}
+
+
+} // namespace snac
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
@@ -255,10 +255,11 @@ const std::map<arte::gltf::Image::MimeType, arte::ImageFormat> gMimeToFormat {
 
 
 
-arte::Image<math::sdr::Rgba>
+template <class T_pixel>
+arte::Image<T_pixel>
 loadImageFromBytes(std::span<std::byte> aBytes, arte::gltf::Image::MimeType aMime)
 {
-    using Image = arte::Image<math::sdr::Rgba>;
+    using Image = arte::Image<T_pixel>;
 
     // TODO Ad 2022/03/23: Replace deprecated istrstream with a proposed alternative
     // see: https://en.cppreference.com/w/cpp/io/istrstream
@@ -270,10 +271,10 @@ loadImageFromBytes(std::span<std::byte> aBytes, arte::gltf::Image::MimeType aMim
 }
 
 
-arte::Image<math::sdr::Rgba>
-loadImageData(arte::Const_Owned<arte::gltf::Image> aImage)
+template <class T_pixel>
+arte::Image<T_pixel> loadImageData(arte::Const_Owned<arte::gltf::Image> aImage)
 {
-    using Image = arte::Image<math::sdr::Rgba>;
+    using Image = arte::Image<T_pixel>;
 
     if(const arte::gltf::Uri * uri = std::get_if<arte::gltf::Uri>(&aImage->dataSource))
     {
@@ -290,7 +291,7 @@ loadImageData(arte::Const_Owned<arte::gltf::Image> aImage)
                 throw std::logic_error{"Image with data URI but no mime type."};
             }
             auto bytes = loadDataUri(*uri);
-            return loadImageFromBytes(bytes, *aImage->mimeType);
+            return loadImageFromBytes<T_pixel>(bytes, *aImage->mimeType);
         }
         case arte::gltf::Uri::Type::File:
         {
@@ -316,9 +317,18 @@ loadImageData(arte::Const_Owned<arte::gltf::Image> aImage)
 
         auto bytes = loadBufferData(bufferView);
         //return loadImageFromBytes(std::span<std::byte>{bytes}, *aImage->mimeType);
-        return loadImageFromBytes(bytes, *aImage->mimeType);
+        return loadImageFromBytes<T_pixel>(bytes, *aImage->mimeType);
     }
 }
+
+
+
+//
+// Explicit template instanciations
+//
+
+template arte::Image<math::sdr::Rgba> loadImageData(arte::Const_Owned<arte::gltf::Image> aImage);
+template arte::Image<math::sdr::Rgb>  loadImageData(arte::Const_Owned<arte::gltf::Image> aImage);
 
 
 } // namespace snac

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.cpp
@@ -6,6 +6,7 @@
 #include <handy/Url.h>
 
 #include <span>
+
 #include <strstream>
 
 #include <renderer/AttributeDimension.h>
@@ -22,7 +23,7 @@ namespace snac {
 
 namespace {
 
-    // TODO Should be moved to a more general library. 
+    // TODO Should be moved to a more general library.
     // Reading a stream content is a recurring need.
     std::vector<std::byte> loadInputStream(std::istream & aInput, std::size_t aByteLength, const std::string & aStreamId)
     {
@@ -48,19 +49,16 @@ namespace {
     }
 
 
-    std::vector<std::byte> loadInputStream(std::istream && aInput, std::size_t aByteLength, const std::string & aStreamId)
-    { return loadInputStream(aInput, aByteLength, aStreamId); }
-
     using ElementType = arte::gltf::Accessor::ElementType;
 
     const std::map<ElementType, graphics::AttributeDimension> gElementTypeToLayout{
-        {ElementType::Scalar, {1}},    
-        {ElementType::Vec2,   {2}},    
-        {ElementType::Vec3,   {3}},    
-        {ElementType::Vec4,   {4}},    
-        {ElementType::Mat2,   {2, 2}},    
-        {ElementType::Mat3,   {3, 3}},    
-        {ElementType::Mat4,   {4, 4}},    
+        {ElementType::Scalar, {1}},
+        {ElementType::Vec2,   {2}},
+        {ElementType::Vec3,   {3}},
+        {ElementType::Vec4,   {4}},
+        {ElementType::Mat2,   {2, 2}},
+        {ElementType::Mat3,   {3, 3}},
+        {ElementType::Mat4,   {4, 4}},
     };
 
 

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.h
@@ -38,8 +38,8 @@ std::vector<std::byte>
 loadBufferData(arte::Const_Owned<arte::gltf::Accessor> aAccessor,
                arte::Const_Owned<arte::gltf::BufferView> aBufferView);
 
-arte::Image<math::sdr::Rgba>
-loadImageData(arte::Const_Owned<arte::gltf::Image> aImage);
+template <class T_pixel>
+arte::Image<T_pixel> loadImageData(arte::Const_Owned<arte::gltf::Image> aImage);
 
 // TODO Ad 2022/03/15 Implement a way to only load exactly the bytes of an accessor
 // This could notably allow optimization when a contiguous accessor is used as-is.

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.h
@@ -19,6 +19,9 @@ namespace snac {
 arte::Const_Owned<arte::gltf::BufferView>
 checkedBufferView(arte::Const_Owned<arte::gltf::Accessor> aAccessor);
 
+arte::Const_Owned<arte::gltf::Image>
+checkImage(arte::Const_Owned<arte::gltf::Texture> aTexture);
+
 graphics::AttributeDimension getAccessorDimension(arte::gltf::Accessor::ElementType aElementType);
 
 //

--- a/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.h
+++ b/src/libs/snac-renderer/snac-renderer/gltf/LoadBuffer.h
@@ -1,0 +1,46 @@
+#pragma once
+
+
+#include <arte/Image.h>
+#include <arte/gltf/Gltf.h>
+
+#include <renderer/AttributeDimension.h>
+
+
+namespace ad {
+namespace snac {
+
+// TODO would benefit from a subnamespace, but gltf might be confusing with arte::gltf
+
+//
+// Helpers
+//
+/// \brief Returns the buffer view associated to the accessor, or throw if there is none.
+arte::Const_Owned<arte::gltf::BufferView>
+checkedBufferView(arte::Const_Owned<arte::gltf::Accessor> aAccessor);
+
+graphics::AttributeDimension getAccessorDimension(arte::gltf::Accessor::ElementType aElementType);
+
+//
+// Loaders
+//
+std::vector<std::byte> 
+loadBufferData(arte::Const_Owned<arte::gltf::Buffer> aBuffer,
+               std::size_t aByteOffset,
+               std::size_t aByteLength);
+
+/// \brief Unified interface to handle both sparse and non-sparse accessors.
+/// \attention Returns the complete underlying buffer, offset and size are not applied!
+std::vector<std::byte> 
+loadBufferData(arte::Const_Owned<arte::gltf::Accessor> aAccessor,
+               arte::Const_Owned<arte::gltf::BufferView> aBufferView);
+
+arte::Image<math::sdr::Rgba>
+loadImageData(arte::Const_Owned<arte::gltf::Image> aImage);
+
+// TODO Ad 2022/03/15 Implement a way to only load exactly the bytes of an accessor
+// This could notably allow optimization when a contiguous accessor is used as-is.
+
+
+} // namespace snac
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
@@ -2,7 +2,7 @@
 
 in vec3 ex_Position_v;
 in vec3 ex_Normal_v;
-in vec2 ex_BaseColorUV;
+in vec2[2] ex_TextureCoords;
 in vec4 ex_ColorFactor;
 
 uniform sampler2D u_BaseColorTexture;
@@ -10,6 +10,7 @@ uniform sampler2D u_BaseColorTexture;
 uniform vec3 u_LightPosition_v;
 uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8);
 uniform vec3 u_AmbientColor = vec3(0.2, 0.0, 0.2);
+uniform uint u_BaseColorUVIndex;
 
 out vec4 out_Color;
 
@@ -23,7 +24,9 @@ void main(void)
     
     float specularExponent = 32;
 
-    vec4 color = ex_ColorFactor * texture(u_BaseColorTexture, ex_BaseColorUV);
+    vec4 color = 
+        ex_ColorFactor 
+        * texture(u_BaseColorTexture, ex_TextureCoords[u_BaseColorUVIndex]);
 
     vec3 diffuse = 
         color.xyz * (u_AmbientColor + u_LightColor * max(0.f, dot(normal, light)));

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
@@ -14,6 +14,7 @@ uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8);
 uniform vec3 u_AmbientColor = vec3(0.2, 0.0, 0.2);
 uniform uint u_BaseColorUVIndex;
 uniform uint u_NormalUVIndex;
+uniform float u_NormalMapScale;
 
 out vec4 out_Color;
 
@@ -34,9 +35,10 @@ void main(void)
     // Compute the fragment normal
     //
     // The normal in tangent space
-    vec3 normal_tbn =
+    vec3 normal_tbn = normalize(
         // Mapping from [0.0, 1.0] to [-1.0, 1.0]
-        texture(u_NormalTexture, ex_TextureCoords[0]).xyz * 2.0 - vec3(1.0);
+        (texture(u_NormalTexture, ex_TextureCoords[0]).xyz * 2.0 - vec3(1.0))
+        * vec3(u_NormalMapScale, u_NormalMapScale, 1.0));
 
     // MikkT see: http://www.mikktspace.com/
     // Yet, if the tangent and normal were not normalized (as seems to be proposed in mikkt)

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
@@ -1,40 +1,66 @@
 #version 420
 
-in vec3 ex_Position_v;
-in vec3 ex_Normal_v;
+in vec3 ex_Position_c;
+in vec3 ex_Normal_c;
+in vec4 ex_Tangent_c;
 in vec2[2] ex_TextureCoords;
 in vec4 ex_ColorFactor;
 
 uniform sampler2D u_BaseColorTexture;
+uniform sampler2D u_NormalTexture;
 
-uniform vec3 u_LightPosition_v;
+uniform vec3 u_LightPosition_c;
 uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8);
 uniform vec3 u_AmbientColor = vec3(0.2, 0.0, 0.2);
 uniform uint u_BaseColorUVIndex;
+uniform uint u_NormalUVIndex;
 
 out vec4 out_Color;
 
 void main(void)
 {
     // Everything in camera space
-    vec3 light = normalize(u_LightPosition_v - ex_Position_v);
-    vec3 view = vec3(0., 0., 1.);
-    vec3 h = normalize(view + light);
-    vec3 normal = normalize(ex_Normal_v); // cannot normalize in vertex shader, as interpolation changes length.
+    vec3 light_c = normalize(u_LightPosition_c - ex_Position_c);
+    vec3 view_c = vec3(0., 0., 1.);
+    vec3 h_c = normalize(view_c + light_c);
     
     float specularExponent = 32;
 
     vec4 color = 
         ex_ColorFactor 
         * texture(u_BaseColorTexture, ex_TextureCoords[u_BaseColorUVIndex]);
+    
+    //
+    // Compute the fragment normal
+    //
+    // The normal in tangent space
+    vec3 normal_tbn =
+        // Mapping from [0.0, 1.0] to [-1.0, 1.0]
+        texture(u_NormalTexture, ex_TextureCoords[0]).xyz * 2.0 - vec3(1.0);
 
+    // MikkT see: http://www.mikktspace.com/
+    // Yet, if the tangent and normal were not normalized (as seems to be proposed in mikkt)
+    // the result would be abherent with sample gltf assets (e.g. avocado) 
+    vec3 normalBase_c = normalize(ex_Normal_c);
+    vec3 tangent_c = normalize(ex_Tangent_c.xyz);
+    // TODO should it also be normalized? Should the base be "orthogonalized"?
+    vec3 bitangent_c = cross(normalBase_c, tangent_c) * ex_Tangent_c.w;
+    vec3 normal_c = normalize(normal_tbn.x * tangent_c
+        + normal_tbn.y * bitangent_c
+        + normal_tbn.z * normalBase_c);
+
+    //
+    // Phong illumination
+    //
     vec3 diffuse = 
-        color.xyz * (u_AmbientColor + u_LightColor * max(0.f, dot(normal, light)));
+        color.xyz * (u_AmbientColor + u_LightColor * max(0.f, dot(normal_c, light_c)));
     vec3 specular = 
-        u_LightColor * color.xyz * pow(max(0.f, dot(normal, h)), specularExponent);
+        u_LightColor * color.xyz * pow(max(0.f, dot(normal_c, h_c)), specularExponent);
     vec3 phongColor = diffuse + specular;
 
+    //
     // Gamma correction
+    //
     float gamma = 2.2;
     // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
     // (The monitor will do the gamma expansion.)

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
@@ -33,5 +33,7 @@ void main(void)
 
     // Gamma correction
     float gamma = 2.2;
+    // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
+    // (The monitor will do the gamma expansion.)
     out_Color = vec4(pow(phongColor, vec3(1./gamma)), color.w);
 }

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.frag
@@ -1,0 +1,37 @@
+#version 420
+
+in vec3 ex_Position_v;
+in vec3 ex_Normal_v;
+in vec2 ex_BaseColorUV;
+in vec4 ex_ColorFactor;
+
+uniform sampler2D u_BaseColorTexture;
+
+uniform vec3 u_LightPosition_v;
+uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8);
+uniform vec3 u_AmbientColor = vec3(0.2, 0.0, 0.2);
+
+out vec4 out_Color;
+
+void main(void)
+{
+    // Everything in camera space
+    vec3 light = normalize(u_LightPosition_v - ex_Position_v);
+    vec3 view = vec3(0., 0., 1.);
+    vec3 h = normalize(view + light);
+    vec3 normal = normalize(ex_Normal_v); // cannot normalize in vertex shader, as interpolation changes length.
+    
+    float specularExponent = 32;
+
+    vec4 color = ex_ColorFactor * texture(u_BaseColorTexture, ex_BaseColorUV);
+
+    vec3 diffuse = 
+        color.xyz * (u_AmbientColor + u_LightColor * max(0.f, dot(normal, light)));
+    vec3 specular = 
+        u_LightColor * color.xyz * pow(max(0.f, dot(normal, h)), specularExponent);
+    vec3 phongColor = diffuse + specular;
+
+    // Gamma correction
+    float gamma = 2.2;
+    out_Color = vec4(pow(phongColor, vec3(1./gamma)), color.w);
+}

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.prog
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "PhongLightingTextures.vert",
+    "fragment": "PhongLightingTextures.frag"
+}

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
@@ -2,7 +2,8 @@
 
 layout(location=0) in vec3 ve_Position_l;
 layout(location=1) in vec3 ve_Normal_l;
-layout(location=2) in vec2 ve_BaseColorUV_t;
+layout(location=2) in vec2 ve_TextureCoords0;
+layout(location=3) in vec2 ve_TextureCoords1;
 // Not enabled for for the moment (could be taken from COLOR_0 I suppose)
 // because we need a default value of [1, 1, 1, 1]
 // Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
@@ -22,7 +23,7 @@ uniform vec4 u_BaseColorFactor;
 
 out vec3 ex_Position_v;
 out vec3 ex_Normal_v;
-out vec2 ex_BaseColorUV;
+out vec2[2] ex_TextureCoords;
 out vec4 ex_ColorFactor;
 
 void main(void)
@@ -35,5 +36,5 @@ void main(void)
     ex_Normal_v = mat3(localToCamera) * ve_Normal_l;
 
     ex_ColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;
-    ex_BaseColorUV  = ve_BaseColorUV_t;
+    ex_TextureCoords = vec2[](ve_TextureCoords0, ve_TextureCoords1);
 }

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
@@ -2,16 +2,17 @@
 
 layout(location=0) in vec3 ve_Position_l;
 layout(location=1) in vec3 ve_Normal_l;
-layout(location=2) in vec2 ve_TextureCoords0;
-layout(location=3) in vec2 ve_TextureCoords1;
+layout(location=2) in vec4 ve_Tangent_l;
+layout(location=3) in vec2 ve_TextureCoords0;
+layout(location=4) in vec2 ve_TextureCoords1;
 // Not enabled for for the moment (could be taken from COLOR_0 I suppose)
 // because we need a default value of [1, 1, 1, 1]
 // Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
 //layout(location=3) in vec4 in_Albedo;
 
-layout(location=4) in mat4 in_LocalToWorld;
+layout(location=5) in mat4 in_LocalToWorld;
 // Will be required to support non-uniform scaling.
-//layout(location=8) in mat4 in_LocalToWorldInverseTranspose;
+//layout(location=9) in mat4 in_LocalToWorldInverseTranspose;
 
 layout(std140) uniform ViewingBlock
 {
@@ -21,8 +22,9 @@ layout(std140) uniform ViewingBlock
 
 uniform vec4 u_BaseColorFactor;
 
-out vec3 ex_Position_v;
-out vec3 ex_Normal_v;
+out vec3 ex_Position_c;
+out vec3 ex_Normal_c;
+out vec4 ex_Tangent_c;
 out vec2[2] ex_TextureCoords;
 out vec4 ex_ColorFactor;
 
@@ -30,10 +32,11 @@ void main(void)
 {
     // TODO maybe should be pre-multiplied in client code?
     mat4 localToCamera = u_WorldToCamera * in_LocalToWorld;
-    vec4 position_v = localToCamera * vec4(ve_Position_l, 1.f);
-    gl_Position = u_Projection * position_v;
-    ex_Position_v = vec3(position_v);
-    ex_Normal_v = mat3(localToCamera) * ve_Normal_l;
+    vec4 position_c = localToCamera * vec4(ve_Position_l, 1.f);
+    gl_Position = u_Projection * position_c;
+    ex_Position_c = vec3(position_c);
+    ex_Normal_c = mat3(localToCamera) * ve_Normal_l;
+    ex_Tangent_c = vec4(mat3(localToCamera) * ve_Tangent_l.xyz, ve_Tangent_l.w);
 
     ex_ColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;
     ex_TextureCoords = vec2[](ve_TextureCoords0, ve_TextureCoords1);

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
@@ -36,6 +36,8 @@ void main(void)
     gl_Position = u_Projection * position_c;
     ex_Position_c = vec3(position_c);
     ex_Normal_c = mat3(localToCamera) * ve_Normal_l;
+    // Tangents are transformed by the normal localToCamera matrix (unlike normals)
+    // see: https://www.pbr-book.org/3ed-2018/Geometry_and_Transformations/Applying_Transformations
     ex_Tangent_c = vec4(mat3(localToCamera) * ve_Tangent_l.xyz, ve_Tangent_l.w);
 
     ex_ColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLightingTextures.vert
@@ -1,0 +1,39 @@
+#version 420
+
+layout(location=0) in vec3 ve_Position_l;
+layout(location=1) in vec3 ve_Normal_l;
+layout(location=2) in vec2 ve_BaseColorUV_t;
+// Not enabled for for the moment (could be taken from COLOR_0 I suppose)
+// because we need a default value of [1, 1, 1, 1]
+// Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
+//layout(location=3) in vec4 in_Albedo;
+
+layout(location=4) in mat4 in_LocalToWorld;
+// Will be required to support non-uniform scaling.
+//layout(location=8) in mat4 in_LocalToWorldInverseTranspose;
+
+layout(std140) uniform ViewingBlock
+{
+    mat4 u_WorldToCamera;
+    mat4 u_Projection;
+};
+
+uniform vec4 u_BaseColorFactor;
+
+out vec3 ex_Position_v;
+out vec3 ex_Normal_v;
+out vec2 ex_BaseColorUV;
+out vec4 ex_ColorFactor;
+
+void main(void)
+{
+    // TODO maybe should be pre-multiplied in client code?
+    mat4 localToCamera = u_WorldToCamera * in_LocalToWorld;
+    vec4 position_v = localToCamera * vec4(ve_Position_l, 1.f);
+    gl_Position = u_Projection * position_v;
+    ex_Position_v = vec3(position_v);
+    ex_Normal_v = mat3(localToCamera) * ve_Normal_l;
+
+    ex_ColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;
+    ex_BaseColorUV  = ve_BaseColorUV_t;
+}

--- a/src/libs/snac-renderer/snac-renderer/shaders/Text.vert
+++ b/src/libs/snac-renderer/snac-renderer/shaders/Text.vert
@@ -1,7 +1,7 @@
 #version 420
 
 layout(location=0) in vec2 ve_Position_u; // expect a quad, from [0, -1] to [1, 0]
-layout(location=1) in vec2 ve_TextureCoords_u;
+layout(location=1) in vec2 ve_TextureCoords0_u;
 
 layout(location= 4) in mat3  in_LocalToWorld_glyphToScreenPixels;
 layout(location= 8) in vec4  in_Albedo;
@@ -26,6 +26,6 @@ void main(void)
         1.
     );
 
-    ex_AtlasCoords = in_TextureOffset_p + (ve_TextureCoords_u * in_BoundingBox_p);
+    ex_AtlasCoords = in_TextureOffset_p + (ve_TextureCoords0_u * in_BoundingBox_p);
     ex_Albedo = in_Albedo;
 }

--- a/src/libs/snac-renderer/snac-renderer/text/Text.h
+++ b/src/libs/snac-renderer/snac-renderer/text/Text.h
@@ -59,12 +59,11 @@ Mesh makeGlyphMesh(GlyphAtlas & aGlyphAtlas, std::shared_ptr<Effect> aEffect);
 /// Its instances are intended to be shared between entities using this font.
 struct Font
 {
-    Font(const arte::Freetype & aFreetype,
-         const filesystem::path & aFontFile,
+    Font(arte::FontFace aFontFace,
          unsigned int aFontPixelHeight,
          std::shared_ptr<Effect> aEffect) :
         mGlyphAtlas{
-            std::move(aFreetype.load(aFontFile)
+            std::move(aFontFace
                         .setPixelHeight(aFontPixelHeight)
                         .inverseYAxis(true))
         },


### PR DESCRIPTION
closes #20
- nvprofiler: Implement move-only semantic on Section.
- nvprofiler: Extend print to show single shot entries.
- nvprofiler: Make printed time outputs human friendly.
- Add profiling to the code, display timings via DearImGui.
- Display class::method with TIME_RECURRING_CLASSFUNC.
- Fix Clang warning.
- Profile the render thread (in addition to main thread).
- nvprofiler: Fix bug in displaying human timing of the form "n.xyms".
- Implement a Resources class, currently naively load the cube shape.
- Host ResourceFinder instance in Resources class.
- Load font via Resources instance.
- Implement program loading in Resources (via getShaderEffect).
- Rename Cube shaders to PhongLighting, use getShaderEffect in load shape.
- Upgrade to latest handy, graphics, markovjunior.
- Fix initialization order of Resources data members.
- Fix missing <mutex> header for scoped_lock in Profiling.h.
- WIP Implement Gltf asset loading. Load position and normal buffers.
- Move loading of effect and cube to snac-renderer.
- Update snac-viewer to load cube and program using snac-renderer.
- Fix forgot to assign the vertex count to gltf loaded meshes.
- Load gltf index buffer, and update renderer for indexed rendering.
- Get gltf bounding box, use it in viewer to center and scale model.
- Implement base color texturing from gltf material.
- Decode sRGB base color texture to linear space prior to loading.
- Add a few high-level GL debug groups.
- Add detailed top-level profiling to render thread.
- Minor: Add a comment regarding irrelevance of Range drawing functions.
- Fix throwing thread dtor on run_application exception.
- Make dynamic the association of texcoords to sampled texture.
- Fix a path in default workspace.
- Implement normal mapping.
- Handle scale from glTF normal texture info.
- Move Freetype instance out of the Renderer, into Resources.
- Host the EntityManager instance in GameContext.
- Add assertions that async ops on render thread are not issued from it.
- Upgrade graphics and math.
