### PR TITLE
topic/snacman#56 integrate shadows

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,9 +23,9 @@ class SnacmanConan(ConanFile):
 
     requires = (
         ("entity/46a11641b0@adnn/develop"),
-        ("graphics/fe72facd9d@adnn/develop"),
+        ("graphics/8b097360a2@adnn/develop"),
         ("handy/ea306467e6@adnn/develop"),
-        ("math/18338feb20@adnn/develop"),
+        ("math/2e4c0458a2@adnn/develop"),
         ("MarkovJunior.cpp/f21e4306a7@adnn/develop"),
 
         ("spdlog/1.11.0"),

--- a/conan/workspaces/complete.yml
+++ b/conan/workspaces/complete.yml
@@ -3,11 +3,11 @@ editables:
         path: ../../../MarkovJunior.cpp/conan
     entity/46a11641b0@adnn/develop:
         path: ../../../entity/conan
-    graphics/fe72facd9d@adnn/develop:
+    graphics/8b097360a2@adnn/develop:
         path: ../../../graphics/conan
     handy/ea306467e6@adnn/develop:
         path: ../../../handy/conan
-    math/18338feb20@adnn/develop:
+    math/2e4c0458a2@adnn/develop:
         path: ../../../math/conan
     snacman/local:
         path: ../../conan

--- a/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
+++ b/src/apps/snac-viewer/snac-viewer/CMakeLists.txt
@@ -6,7 +6,6 @@ configure_file(build_info.h.in build_info.h @ONLY)
 
 set(${TARGET_NAME}_HEADERS
     detail/Logger.h
-    DrawerShadows.h
     Logging.h
     Scene.h
 )
@@ -15,7 +14,6 @@ set(${TARGET_NAME}_SOURCES
     main.cpp
 
     detail/Logger.cpp
-    DrawerShadows.cpp
 )
 
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR}

--- a/src/apps/snac-viewer/snac-viewer/DrawerShadows.cpp
+++ b/src/apps/snac-viewer/snac-viewer/DrawerShadows.cpp
@@ -77,6 +77,8 @@ void DrawerShadows::draw(
 {
     drawGui();
 
+    auto scopeDepth = graphics::scopeFeature(GL_DEPTH_TEST, true);
+
     // GL_LINEAR seems required to get hardware PCF with sampler2DShadow.
     graphics::setFiltering(depthMap, mDetphMapFilter);
 

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -298,15 +298,21 @@ inline void Scene::render(Renderer & aRenderer)
     ProgramSetup setup{
         .mUniforms{
             {snac::Semantic::LightColor, snac::UniformParameter{lightColor}},
+            // TODO Consolidate the light used in forward phong shading (currently the camera)
+            // with the light used to generate shadow (currently fixed above the scene)
             {snac::Semantic::LightPosition, {lightPosition}},
             {snac::Semantic::AmbientColor, {ambientColor}},
-            {snac::Semantic::NearDistance, -mCamera.getCurrentParameters().zNear},
-            {snac::Semantic::FarDistance,  -mCamera.getCurrentParameters().zFar},
         },
         .mUniformBlocks{
             {BlockSemantic::Viewing, &mCamera.mViewing},
         },
     };
+
+    // Note: assumes a square shadow map ATM
+    Camera shadowLightViewPoint{1, Camera::gDefaults};
+    shadowLightViewPoint.setPose(
+        math::trans3d::rotateX(math::Degree<float>{55.f})
+        * math::trans3d::translate<GLfloat>({0.f, -1.f, -15.f}));
 
     {
         auto scopedUI = mGui.startUI();
@@ -321,7 +327,7 @@ inline void Scene::render(Renderer & aRenderer)
                 drawSideBySide(aRenderer, setup);
                 break;
             case 1:
-                mDrawerShadows.draw(getVisuals(), aRenderer, setup);
+                mDrawerShadows.execute(getVisuals(), shadowLightViewPoint, aRenderer, setup);
                 break;
         }
 

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -260,9 +260,10 @@ std::vector<Pass::Visual> Scene::getVisuals() const
 {
     std::vector<Pass::Visual> visuals;
     visuals.reserve(mEntities.size());
+    // Note: the order in entities is reverses compared to Visual
     for (const auto & [instance, mesh] : mEntities)
     {
-        visuals.push_back({&instance, &mesh});
+        visuals.push_back({&mesh, &instance});
     }
     return visuals;
 }

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -322,6 +322,8 @@ void Scene::drawSideBySide(Renderer & aRenderer,
 {
     clear();
 
+    auto scopeDepth = graphics::scopeFeature(GL_DEPTH_TEST, true);
+
     auto scissorScope = graphics::scopeFeature(GL_SCISSOR_TEST, true);
 
     glViewport(0,

--- a/src/apps/snac-viewer/snac-viewer/Scene.h
+++ b/src/apps/snac-viewer/snac-viewer/Scene.h
@@ -328,6 +328,7 @@ inline void Scene::render(Renderer & aRenderer)
                 break;
             case 1:
                 mDrawerShadows.execute(getVisuals(), shadowLightViewPoint, aRenderer, setup);
+                mDrawerShadows.drawGui();
                 break;
         }
 

--- a/src/apps/snac-viewer/snac-viewer/main.cpp
+++ b/src/apps/snac-viewer/snac-viewer/main.cpp
@@ -64,7 +64,7 @@ void runApplication()
         glfwApp,
         //loadModel(finder.pathFor("Box/glTF/Box.gltf"),
         loadModel(finder.pathFor("Avocado/glTF/Avocado.gltf"),
-                  loadEffect(finder.pathFor("effects/MeshTextures.sefx"), finder)),
+                  loadEffect(finder.pathFor("effects/MeshTextures.sefx"), TechniqueLoader{finder})),
         finder,
     };
     Renderer renderer;

--- a/src/apps/snacman/snacman/RenderThread.h
+++ b/src/apps/snacman/snacman/RenderThread.h
@@ -254,6 +254,11 @@ public:
         return future;
     }
 
+    void continueGui()
+    {
+        assert(!mStop); // It is unsafe to call this while the render thread might be (explicitly) destructing the Renderer.
+        mRenderer->continueGui();
+    }
 
     void checkRethrow()
     {

--- a/src/apps/snacman/snacman/RenderThread.h
+++ b/src/apps/snacman/snacman/RenderThread.h
@@ -244,6 +244,9 @@ public:
                 try
                 {
                     recompilePrograms(aResources);
+                    // Required because the actual interface of the shader might have changed
+                    // (either explicitly by code, or implicitly because optimizer discarded some attributes/uniforms)
+                    aRenderer.resetRepositories();
                     promise->set_value();
                 }
                 catch(...)

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -2,7 +2,6 @@
 
 #include "RenderThread.h"                   // for RenderThread
 #include "simulations/snacgame/Renderer.h"  // for Renderer
-#include <snac-renderer/ResourceLoad.h>
 
 #include <resource/ResourceManager.h>               // for ResourceManager
                                                     //
@@ -49,18 +48,18 @@ std::shared_ptr<Font> Resources::getFont(filesystem::path aFont, unsigned int aP
 }
 
 
-std::shared_ptr<Effect> Resources::getTrivialShaderEffect(filesystem::path aProgram)
+std::shared_ptr<Effect> Resources::getShaderEffect(filesystem::path aEffect)
 {
-    return mEffects.load(aProgram, mFinder, mRenderThread, *this);
+    return mEffects.load(aEffect, mFinder, mRenderThread, *this);
 }
 
 
 std::shared_ptr<Effect> Resources::EffectLoader(
-    filesystem::path aProgram, 
+    filesystem::path aEffect, 
     RenderThread<snacgame::Renderer> & aRenderThread,
-    Resources & /*aResources*/)
+    Resources & aResources)
 {
-    return loadTrivialEffect(aProgram);
+    return loadEffect(aEffect, aResources.getTechniqueLoader());
 }
 
 

--- a/src/apps/snacman/snacman/Resources.h
+++ b/src/apps/snacman/snacman/Resources.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// TODO might become useless once Resources itselfs become the Load<> implementer
+#include <snac-renderer/ResourceLoad.h>
 
 // Note: this is coupling the Resource class to the specifics of snacgame. 
 // But I do not want to template Resource on the renderer...
@@ -44,10 +46,14 @@ public:
     std::shared_ptr<Font> getFont(filesystem::path aFont, unsigned int aPixelHeight = gDefaultPixelHeight);
 
     /// \warning At the moment: intended to be called only from the thread where OpenGL context is active.
-    std::shared_ptr<Effect> getTrivialShaderEffect(filesystem::path aProgram);
+    std::shared_ptr<Effect> getShaderEffect(filesystem::path aEffect);
 
     auto find(const filesystem::path & aPath) const
     { return mFinder.find(aPath); }
+
+    // TODO might become useless once Resources itselfs become the Load<> implementer
+    snac::TechniqueLoader getTechniqueLoader() const
+    { return {mFinder}; }
 
     const arte::Freetype & getFreetype()
     { return mFreetype; }

--- a/src/apps/snacman/snacman/main.cpp
+++ b/src/apps/snacman/snacman/main.cpp
@@ -22,6 +22,8 @@
 
 #include <resource/ResourceFinder.h>
 
+#include <snac-renderer/ResourceLoad.h>
+
 #include <fstream>
 
 using namespace ad;
@@ -87,12 +89,17 @@ void runApplication()
     // This has been a recurring problem, moving this freetype instance up each time to try to outlive all the things.
     arte::Freetype freetype;
 
+    resource::ResourceFinder finder = makeResourceFinder();
+
     //
     // Initialize rendering subsystem
     //
 
     // Initialize the renderer
-    snacgame::Renderer renderer{*glfwApp.getAppInterface()};
+    // TODO we provide a Load<Technique> so the shadow pipeline can use it to load the effects for its cube.
+    // this complicates the interface a lot, and since it does not use the ResourceManager those effects are not hot-recompilable.
+    snac::TechniqueLoader techniqueLoader{finder};
+    snacgame::Renderer renderer{*glfwApp.getAppInterface(), techniqueLoader};
 
     // Context must be removed from this thread before it can be made current on
     // the render thread.
@@ -121,7 +128,7 @@ void runApplication()
         *glfwApp.getAppInterface(),
         renderingThread,
         imguiUi,
-        makeResourceFinder(),
+        std::move(finder),
         freetype,
         input};
 

--- a/src/apps/snacman/snacman/main.cpp
+++ b/src/apps/snacman/snacman/main.cpp
@@ -77,6 +77,10 @@ void runApplication()
                                     // TODO, applicationFlags
     };
 
+    // Ensures the messages are sent synchronously with the event triggering them
+    // This makes debug stepping much more feasible.
+    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+
     imguiui::ImguiUi imguiUi(glfwApp);
 
     ConfigurableSettings configurableSettings;

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -6,11 +6,13 @@
 #include <math/Transformations.h>
 #include <math/VectorUtilities.h>
 #include <platform/Filesystem.h>
-#include <snac-renderer/ResourceLoad.h>
+
 #include <snac-renderer/text/Text.h>
 #include <snac-renderer/Semantic.h>
 #include <snac-renderer/Render.h>
 #include <snac-renderer/Mesh.h>
+#include <snac-renderer/ResourceLoad.h>
+
 #include <snacman/Profiling.h>
 #include <snacman/ProfilingGPU.h>
 #include <snacman/Resources.h>
@@ -109,10 +111,11 @@ snac::InstanceStream initializeInstanceStream()
     return instances;
 }
 
-Renderer::Renderer(graphics::AppInterface & aAppInterface) :
+Renderer::Renderer(graphics::AppInterface & aAppInterface, snac::Load<snac::Technique> & aTechniqueAccess) :
     mAppInterface{aAppInterface},
     mCamera{math::getRatio<float>(mAppInterface.getWindowSize()),
             snac::Camera::gDefaults},
+    mPipelineShadows{aAppInterface, aTechniqueAccess},
     mMeshInstances{initializeInstanceStream()}
 {}
 
@@ -128,12 +131,12 @@ std::shared_ptr<snac::Mesh> Renderer::LoadShape(filesystem::path aShape,
     if (aShape.string() == "CUBE")
     {
         return std::make_shared<snac::Mesh>(
-            snac::loadCube(aResources.getTrivialShaderEffect("shaders/PhongLightingVertexColor.prog")));
+            snac::loadCube(aResources.getShaderEffect("effects/Mesh.sefx")));
     }
     else
     {
         return std::make_shared<snac::Mesh>(
-            loadModel(aShape, aResources.getTrivialShaderEffect("shaders/PhongLightingTextures.prog")));
+            loadModel(aShape, aResources.getShaderEffect("effects/MeshTextures.sefx")));
     }
 }
 
@@ -144,7 +147,7 @@ std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
     return std::make_shared<snac::Font>(
         std::move(aFontFace),
         aPixelHeight,
-        aResources.getTrivialShaderEffect("shaders/Text.prog")
+        aResources.getShaderEffect("effects/Text.sefx")
     );
 }
 
@@ -188,23 +191,30 @@ void Renderer::render(const visu::GraphicState & aState)
         }
     };
 
-    BEGIN_RECURRING_GL("Draw_meshes", drawMeshProfile);
-    for (const auto & [mesh, instances] : sortedMeshes)
     {
-        auto scopeDepth = graphics::scopeFeature(GL_DEPTH_TEST, true);
-        mMeshInstances.respecifyData(std::span{instances});
-        mForwardMeshPass.draw(*mesh, mMeshInstances, mRenderer, programSetup);
+        TIME_RECURRING_GL("Draw_meshes");
+        // Poor man's pool
+        static std::list<snac::InstanceStream> instanceStreams;
+        while(instanceStreams.size() < sortedMeshes.size())
+        {
+            instanceStreams.push_back(initializeInstanceStream());
+        }
+
+        auto streamIt = instanceStreams.begin();
+        std::vector<snac::Pass::Visual> visuals;
+        for (const auto & [mesh, instances] : sortedMeshes)
+        {
+            streamIt->respecifyData(std::span{instances});
+            visuals.push_back({&*streamIt, mesh});
+            ++streamIt;
+        }
+        mPipelineShadows.draw(visuals, mRenderer, programSetup);
     }
-    END_RECURRING_GL(drawMeshProfile);
 
     //
     // Text
     //
-
-    // TODO Why it does not start at 20, but at 32 ????!
-    // graphics::detail::RenderedGlyph glyph = mGlyphAtlas.mGlyphMap.at(90);
-
-    mTextRenderer.render(*this, aState, programSetup);
+    //mTextRenderer.render(*this, aState, programSetup);
 }
 
 } // namespace snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -224,7 +224,7 @@ void Renderer::render(const visu::GraphicState & aState)
     //
     // Text
     //
-    //mTextRenderer.render(*this, aState, programSetup);
+    mTextRenderer.render(*this, aState, programSetup);
 }
 
 } // namespace snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -192,7 +192,12 @@ void Renderer::render(const visu::GraphicState & aState)
     };
 
     {
-        TIME_RECURRING_GL("Draw_meshes");
+        static snac::Camera shadowLightViewPoint{1, snac::Camera::gDefaults};
+        shadowLightViewPoint.setPose(
+            math::trans3d::rotateX(math::Degree<float>{65.f})
+            * math::trans3d::translate<GLfloat>({0.f, -3.f, -3.f}));
+
+            TIME_RECURRING_GL("Draw_meshes");
         // Poor man's pool
         static std::list<snac::InstanceStream> instanceStreams;
         while(instanceStreams.size() < sortedMeshes.size())
@@ -208,7 +213,7 @@ void Renderer::render(const visu::GraphicState & aState)
             visuals.push_back({&*streamIt, mesh});
             ++streamIt;
         }
-        mPipelineShadows.draw(visuals, mRenderer, programSetup);
+        mPipelineShadows.execute(visuals, shadowLightViewPoint, mRenderer, programSetup);
     }
 
     //

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -113,9 +113,9 @@ snac::InstanceStream initializeInstanceStream()
 
 Renderer::Renderer(graphics::AppInterface & aAppInterface, snac::Load<snac::Technique> & aTechniqueAccess) :
     mAppInterface{aAppInterface},
+    mPipelineShadows{aAppInterface, aTechniqueAccess},
     mCamera{math::getRatio<float>(mAppInterface.getWindowSize()),
             snac::Camera::gDefaults},
-    mPipelineShadows{aAppInterface, aTechniqueAccess},
     mMeshInstances{initializeInstanceStream()}
 {}
 
@@ -157,7 +157,6 @@ void Renderer::continueGui()
     // This boolean is only accessed by main thread
     static bool showShadowControls = false;
     ImGui::Checkbox("Shadows", &showShadowControls);
-    showShadowControls = showShadowControls;
     if (showShadowControls)
     {
         mPipelineShadows.drawGui();

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -151,6 +151,22 @@ std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
     );
 }
 
+
+void Renderer::continueGui()
+{
+    static std::atomic<bool> showShadowControls{false};
+    {
+        bool showShadow{showShadowControls};
+        ImGui::Checkbox("Shadows", &showShadow);
+        showShadowControls = showShadow;
+        if (showShadowControls)
+        {
+            mPipelineShadows.drawGui();
+        }
+    }
+}
+
+
 void Renderer::render(const visu::GraphicState & aState)
 {
     TIME_RECURRING(Render, "Render");

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -192,10 +192,15 @@ void Renderer::render(const visu::GraphicState & aState)
     };
 
     {
-        static snac::Camera shadowLightViewPoint{1, snac::Camera::gDefaults};
+        static snac::Camera shadowLightViewPoint{1, 
+            {
+                .vFov = math::Degree<float>(75.f),
+                .zNear = -1.f,
+                .zFar = -50.f,
+            }};
         shadowLightViewPoint.setPose(
             math::trans3d::rotateX(math::Degree<float>{65.f})
-            * math::trans3d::translate<GLfloat>({0.f, -3.f, -3.f}));
+            * math::trans3d::translate<GLfloat>({-8.f, -6.f, -10.f}));
 
             TIME_RECURRING_GL("Draw_meshes");
         // Poor man's pool

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -229,7 +229,7 @@ void Renderer::render(const visu::GraphicState & aState)
         for (const auto & [mesh, instances] : sortedMeshes)
         {
             streamIt->respecifyData(std::span{instances});
-            visuals.push_back({&*streamIt, mesh});
+            visuals.push_back({mesh, &*streamIt});
             ++streamIt;
         }
         mPipelineShadows.execute(visuals, shadowLightViewPoint, mRenderer, programSetup);

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -154,15 +154,13 @@ std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
 
 void Renderer::continueGui()
 {
-    static std::atomic<bool> showShadowControls{false};
+    // This boolean is only accessed by main thread
+    static bool showShadowControls = false;
+    ImGui::Checkbox("Shadows", &showShadowControls);
+    showShadowControls = showShadowControls;
+    if (showShadowControls)
     {
-        bool showShadow{showShadowControls};
-        ImGui::Checkbox("Shadows", &showShadow);
-        showShadowControls = showShadow;
-        if (showShadowControls)
-        {
-            mPipelineShadows.drawGui();
-        }
+        mPipelineShadows.drawGui();
     }
 }
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.cpp
@@ -189,7 +189,7 @@ void Renderer::render(const visu::GraphicState & aState)
     mCamera.setWorldToCamera(aState.mCamera.mWorldToCamera);
 
     const math::AffineMatrix<4, GLfloat> worldToLight = 
-        math::trans3d::rotateX(math::Degree<float>{65.f})
+        math::trans3d::rotateX(math::Degree<float>{65.f}) // this is about the worst angle for shadows, on closest labyrinth row
         * math::trans3d::translate<GLfloat>({-8.f, -6.f, -10.f});
 
     math::Position<3, GLfloat> lightPosition_cam = 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -63,6 +63,10 @@ public:
 
     void render(const visu::GraphicState & aState);
 
+    /// \brief Forwards the request to reset repositories down to the generic renderer.
+    void resetRepositories()
+    { mRenderer.resetRepositories(); }
+
 private:
     graphics::AppInterface & mAppInterface;
     snac::Renderer mRenderer;

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -59,6 +59,8 @@ public:
                                          unsigned int aPixelHeight,
                                          snac::Resources & aResources);
 
+    void continueGui();
+
     void render(const visu::GraphicState & aState);
 
 private:

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -32,8 +32,7 @@ struct TextRenderer
 
     void render(Renderer & aRenderer, 
                 const visu::GraphicState & aState,
-                snac::UniformRepository & aUniforms,
-                snac::UniformBlocks & aUniformBlocks);
+                snac::ProgramSetup & aProgramSetup);
 
     snac::InstanceStream mGlyphInstances;
 };
@@ -60,7 +59,9 @@ public:
 
 private:
     graphics::AppInterface & mAppInterface;
-    snac::RendererDeprecated mRenderer;
+    snac::Renderer mRenderer;
+    snac::Pass mForwardMeshPass{"forward_mesh"};
+    snac::Pass mTextPass{"text"};
     snac::CameraBuffer mCamera;
     snac::InstanceStream mMeshInstances;
     TextRenderer mTextRenderer;

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -3,10 +3,14 @@
 
 #include "GraphicState.h"
 
+#include <snac-renderer/Camera.h>
+#include <snac-renderer/LoadInterface.h>
 #include <snac-renderer/Mesh.h>
 #include <snac-renderer/Render.h>
-#include <snac-renderer/Camera.h>
 #include <snac-renderer/UniformParameters.h>
+
+#include <snac-renderer/pipelines/ForwardShadows.h>
+
 
 #include <filesystem>                         // for path
 #include <memory>                             // for shared_ptr
@@ -44,7 +48,7 @@ class Renderer
 public:
     using GraphicState_t = visu::GraphicState;
 
-    Renderer(graphics::AppInterface & aAppInterface);
+    Renderer(graphics::AppInterface & aAppInterface, snac::Load<snac::Technique> & aTechniqueAccess);
 
     void resetProjection(float aAspectRatio, snac::Camera::Parameters aParameters);
 
@@ -60,7 +64,9 @@ public:
 private:
     graphics::AppInterface & mAppInterface;
     snac::Renderer mRenderer;
-    snac::Pass mForwardMeshPass{"forward_mesh"};
+    // TODO Is it the correct place to host the pipeline instance?
+    // This notably force to instantiate it with the Renderer (before the Resources manager is available).
+    snac::ForwardShadows mPipelineShadows;
     snac::Pass mTextPass{"text"};
     snac::CameraBuffer mCamera;
     snac::InstanceStream mMeshInstances;

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -231,6 +231,8 @@ void SnacGame::drawDebugUi(snac::ConfigurableSettings & aSettings,
                 ImGui::End();
             }};
             recompileShaders = ImGui::Button("Recompile shaders");
+
+            mGameContext.mRenderThread.continueGui();
         }
     }
 

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -302,11 +302,13 @@ std::unique_ptr<visu::GraphicState> SnacGame::makeGraphicState()
         .each([cellSize, &state](ent::Handle<ent::Entity> aHandle,
                                  const component::Geometry & aGeometry,
                                  const component::VisualMesh & aVisualMesh) {
-            float yCoord = static_cast<float>((int)aGeometry.mLayer) * cellSize * 0.1f;
+            // The game defines the grid in the X-Y plane (origin bottom-left)
+            // we convert it to the right-handed GL coordinate system (i.e Y becomes -Z)
+            float height = static_cast<float>((int)aGeometry.mLayer) * cellSize * 0.1f;
             auto worldPosition = math::Position<3, float>{
-                -(float) aGeometry.mPosition.y(),
-                yCoord,
-                -(float) aGeometry.mPosition.x(),
+                (GLfloat)aGeometry.mPosition.x(),
+                height,
+                -(GLfloat)aGeometry.mPosition.y(),
             };
             state->mEntities.insert(aHandle.id(),
                                     visu::Entity{

--- a/src/apps/snacman/snacman/simulations/snacgame/system/SystemOrbitalCamera.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/SystemOrbitalCamera.h
@@ -31,7 +31,7 @@ public:
 private:
     static constexpr math::Spherical<float> gInitialCameraSpherical{
         40.f, math::Radian<float>{0.15f * math::pi<float>},
-        math::Radian<float>{0.5f * math::pi<float>}};
+        math::Radian<float>{0.f}};
     static constexpr math::Vec<2, GLfloat> gMouseControlFactor{1 / 500.f,
                                                                1 / 500.f};
     static constexpr float gScrollFactor = 0.05f;

--- a/src/libs/snac-renderer/snac-renderer/CMakeFinds.cmake.in
+++ b/src/libs/snac-renderer/snac-renderer/CMakeFinds.cmake.in
@@ -1,4 +1,4 @@
-@find_package@(Graphics CONFIG @REQUIRED@ COMPONENTS arte graphics renderer)
+@find_package@(Graphics CONFIG @REQUIRED@ COMPONENTS arte graphics imguiui renderer)
 @find_package@(Handy CONFIG @REQUIRED@ COMPONENTS resource)
 @find_package@(Math CONFIG @REQUIRED@ COMPONENTS math)
 

--- a/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
+++ b/src/libs/snac-renderer/snac-renderer/CMakeLists.txt
@@ -5,6 +5,7 @@ set(${TARGET_NAME}_HEADERS
     Cube.h
     Effect.h
     IntrospectProgram.h
+    LoadInterface.h
     Logging.h
     Material.h
     Mesh.h
@@ -16,13 +17,15 @@ set(${TARGET_NAME}_HEADERS
     StackRepository.h
     UniformParameters.h
 
+    3rdparty/nvpro/Profiler.hpp
+    3rdparty/nvpro/Profiler_gl.hpp
+
     gltf/GltfLoad.h
     gltf/LoadBuffer.h
 
-    text/Text.h
+    pipelines/ForwardShadows.h
 
-    3rdparty/nvpro/Profiler.hpp
-    3rdparty/nvpro/Profiler_gl.hpp
+    text/Text.h
 )
 
 set(${TARGET_NAME}_SOURCES
@@ -38,13 +41,15 @@ set(${TARGET_NAME}_SOURCES
     SetupDrawing.cpp
     ShaderResource.cpp
 
+    3rdparty/nvpro/Profiler.cpp
+    3rdparty/nvpro/Profiler_gl.cpp
+
     text/Text.cpp
 
     gltf/GltfLoad.cpp
     gltf/LoadBuffer.cpp
 
-    3rdparty/nvpro/Profiler.cpp
-    3rdparty/nvpro/Profiler_gl.cpp
+    pipelines/ForwardShadows.cpp
 )
 
 source_group(TREE ${CMAKE_CURRENT_LIST_DIR}
@@ -95,6 +100,7 @@ target_link_libraries(${TARGET_NAME}
     PRIVATE
         ad::arte
         ad::graphics
+        ad::imguiui 
         ad::renderer
         ad::resource
 

--- a/src/libs/snac-renderer/snac-renderer/Camera.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Camera.cpp
@@ -17,6 +17,7 @@ namespace ad {
 namespace snac {
 
 
+// TODO move to a generic library
 math::Matrix<4, 4, float> makePerspectiveProjection(math::Radian<float> aVerticalFov,
                                                     float aAspectRatio,
                                                     float aZNear,
@@ -50,11 +51,11 @@ void Camera::setPerspectiveProjection(float aAspectRatio, Parameters aParameters
                                   aAspectRatio,
                                   aParameters.zNear,
                                   aParameters.zFar);
+    mCurrentParameters = aParameters;
 }
 
 
-CameraBuffer::CameraBuffer(float aAspectRatio, Camera::Parameters aParameters) :
-    mCurrentParameters{aParameters}
+CameraBuffer::CameraBuffer(float aAspectRatio, Camera::Parameters aParameters)
 {
     const std::array<math::Matrix<4, 4, float>, 2> identities{
         math::Matrix<4, 4, float>::Identity(),
@@ -72,7 +73,6 @@ void CameraBuffer::resetProjection(float aAspectRatio, Camera::Parameters aParam
     graphics::ScopedBind bound{mViewing};
     glBufferSubData(GL_UNIFORM_BUFFER, sizeof(math::Matrix<4, 4, float>), sizeof(perspectiveProjection),
                     perspectiveProjection.data());
-    mCurrentParameters = aParameters;
 }
 
 

--- a/src/libs/snac-renderer/snac-renderer/Camera.h
+++ b/src/libs/snac-renderer/snac-renderer/Camera.h
@@ -15,6 +15,7 @@ math::Matrix<4, 4, float> makePerspectiveProjection(math::Radian<float> aVertica
                                                     float aZNear,
                                                     float aZFar);
 
+// TODO extend with orthographic projection
 struct Camera
 {
     // TODO rename perspectiveparameters
@@ -27,13 +28,16 @@ struct Camera
 
     Camera(float aAspectRatio, Parameters aParameters);
 
-    void setPose(math::AffineMatrix<4, GLfloat> aPose)
-    { mWorldToCamera = aPose; }
+    void setPose(math::AffineMatrix<4, GLfloat> aWorldToCamera)
+    { mWorldToCamera = aWorldToCamera; }
 
     void setPerspectiveProjection(float aAspectRatio, Parameters aParameters);
 
     math::Matrix<4, 4, GLfloat> assembleViewMatrix() const
     { return mWorldToCamera * mProjection; }
+
+    const Camera::Parameters getCurrentParameters() const
+    { return mCurrentParameters; }
 
     static constexpr Parameters gDefaults{
         .vFov = math::Degree<float>{45.f},
@@ -46,6 +50,8 @@ struct Camera
 private:
     math::AffineMatrix<4, GLfloat> mWorldToCamera = math::AffineMatrix<4, GLfloat>::Identity();
     math::Matrix<4, 4, GLfloat> mProjection;
+
+    Camera::Parameters mCurrentParameters;
 };
 
 // TODO redesign, potentially in term of a Camera member?
@@ -57,12 +63,6 @@ struct CameraBuffer
     void setWorldToCamera(const math::AffineMatrix<4, GLfloat> & aTransformation);
 
     graphics::UniformBufferObject mViewing;
-
-    const Camera::Parameters getCurrentParameters() const
-    { return mCurrentParameters; }
-
-private:
-    Camera::Parameters mCurrentParameters;
 };
 
 

--- a/src/libs/snac-renderer/snac-renderer/Cube.h
+++ b/src/libs/snac-renderer/snac-renderer/Cube.h
@@ -72,23 +72,23 @@ namespace cube {
     constexpr std::array<GLushort, 6*6> gIndices
     {
         // Left
-        0, 2, 1,
-        1, 2, 3,
+        0, 1, 2,
+        2, 1, 3,
         // Front
-        1, 3, 5,
-        5, 3, 7,
+        1, 5, 3,
+        3, 5, 7,
         // Right,
-        5, 7, 4,
-        4, 7, 6,
+        5, 4, 7,
+        7, 4, 6,
         // Back
-        4, 6, 0,
-        0, 6, 2,
+        4, 0, 6,
+        6, 0, 2,
         // Top
-        6, 7, 2,
-        2, 7, 3,
+        6, 2, 7,
+        7, 2, 3,
         // Bottom,
-        0, 1, 4,
-        4, 1, 5,
+        0, 4, 1,
+        1, 4, 5,
     };
 
     constexpr std::array<math::Vec<3, float>, 6> gNormals =

--- a/src/libs/snac-renderer/snac-renderer/LoadInterface.h
+++ b/src/libs/snac-renderer/snac-renderer/LoadInterface.h
@@ -1,0 +1,19 @@
+#pragma once
+
+
+#include <platform/Filesystem.h>
+
+
+namespace ad {
+namespace snac {
+
+
+template <class T_resource>
+struct Load
+{
+    virtual T_resource get(const filesystem::path & aResourcePath) = 0;
+};
+
+
+} // namespace graphics
+} // namespace ad

--- a/src/libs/snac-renderer/snac-renderer/Render.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Render.cpp
@@ -55,8 +55,6 @@ void Renderer::draw(
     const InstanceStream & aInstances,
     const IntrospectProgram & aProgram)
 {
-    auto depthTest = graphics::scopeFeature(GL_DEPTH_TEST, true);
-
     graphics::ScopedBind boundVAO{mVertexArrayRepo.get(aVertices, aInstances, aProgram)};
 
     graphics::ScopedBind usedProgram(aProgram);
@@ -112,8 +110,6 @@ void RendererDeprecated::render(const Mesh & aMesh,
                       TextureRepository & aTextures,
                       const std::vector<Technique::Annotation> & aTechniqueFilter)
 {
-    auto depthTest = graphics::scopeFeature(GL_DEPTH_TEST, true);
-
     if (const IntrospectProgram * program = findTechnique(*aMesh.mMaterial, aTechniqueFilter);
         program != nullptr)
     {

--- a/src/libs/snac-renderer/snac-renderer/Render.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Render.cpp
@@ -81,7 +81,7 @@ void Renderer::draw(
 void Pass::draw(std::span<const Visual> aVisuals, Renderer & aRenderer, ProgramSetup & aSetup) const
 {
     // The naive algorithm, should be refined by sorting similarities.
-    for (const auto & [instances, mesh] : aVisuals)
+    for (const auto & [mesh, instances] : aVisuals)
     {
         draw(*mesh, *instances, aRenderer, aSetup);
     }

--- a/src/libs/snac-renderer/snac-renderer/Render.cpp
+++ b/src/libs/snac-renderer/snac-renderer/Render.cpp
@@ -83,7 +83,7 @@ void Pass::draw(std::span<const Visual> aVisuals, Renderer & aRenderer, ProgramS
     // The naive algorithm, should be refined by sorting similarities.
     for (const auto & [instances, mesh] : aVisuals)
     {
-        draw(mesh, instances, aRenderer, aSetup);
+        draw(*mesh, *instances, aRenderer, aSetup);
     }
 }
 

--- a/src/libs/snac-renderer/snac-renderer/Render.h
+++ b/src/libs/snac-renderer/snac-renderer/Render.h
@@ -69,8 +69,8 @@ public:
     // TODO this is probably too specific an approach. But it avoids a lot of templating for the time being.
     struct Visual
     {
-        const InstanceStream * mInstances;
         const Mesh * mMesh;
+        const InstanceStream * mInstances;
     };
 
     Pass(std::string aName, std::vector<Technique::Annotation> aTechniqueFilter = {}) :

--- a/src/libs/snac-renderer/snac-renderer/Render.h
+++ b/src/libs/snac-renderer/snac-renderer/Render.h
@@ -57,6 +57,12 @@ public:
         const InstanceStream & aInstances,
         const IntrospectProgram & aProgram);
 
+    void resetRepositories()
+    {
+        mVertexArrayRepo= VertexArrayRepository{};
+        mWarningRepo = WarningRepository{};
+    }
+
 private:
     VertexArrayRepository mVertexArrayRepo;
     WarningRepository mWarningRepo;

--- a/src/libs/snac-renderer/snac-renderer/Render.h
+++ b/src/libs/snac-renderer/snac-renderer/Render.h
@@ -66,10 +66,11 @@ private:
 class Pass
 {
 public:
+    // TODO this is probably too specific an approach. But it avoids a lot of templating for the time being.
     struct Visual
     {
-        InstanceStream mInstances;
-        Mesh mMesh;
+        const InstanceStream * mInstances;
+        const Mesh * mMesh;
     };
 
     Pass(std::string aName, std::vector<Technique::Annotation> aTechniqueFilter = {}) :

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.cpp
@@ -119,7 +119,7 @@ std::shared_ptr<Effect> loadTrivialEffect(filesystem::path aProgram)
 
 
 std::shared_ptr<Effect> loadEffect(filesystem::path aEffectFile,
-                                   const resource::ResourceFinder & aFinder)
+                                   Load<Technique> & aTechniqueAccess)
 {
     auto result = std::make_shared<Effect>();
 
@@ -127,7 +127,7 @@ std::shared_ptr<Effect> loadEffect(filesystem::path aEffectFile,
     for (const auto & technique : effect.at("techniques"))
     {
         result->mTechniques.push_back(
-            loadTechnique(aFinder.pathFor(technique.at("programfile")))
+            aTechniqueAccess.get(technique.at("programfile"))
         );
         if(technique.contains("annotations"))
         {

--- a/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
+++ b/src/libs/snac-renderer/snac-renderer/ResourceLoad.h
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include "LoadInterface.h"
 #include "Mesh.h"
 
 #include <platform/Filesystem.h>
@@ -19,12 +20,31 @@ bool attemptRecompile(Technique & aTechnique);
 IntrospectProgram loadProgram(const filesystem::path & aProgram);
 Technique loadTechnique(filesystem::path aProgram);
 
+
+struct TechniqueLoader : public Load<Technique>
+{
+    /*implicit*/ TechniqueLoader(const resource::ResourceFinder & aFinder) :
+        mFinder{aFinder}
+    {}
+    
+    Technique get(const filesystem::path & aProgram) override
+    { return loadTechnique(mFinder.pathFor(aProgram)); }
+
+    const resource::ResourceFinder & mFinder;
+};
+
+
 /// \deprecated An effect should not be made from a single program file.
 std::shared_ptr<Effect> loadTrivialEffect(filesystem::path aProgram);
 
 /// \deprecated Should not take a finder directly, but a resource manager
 std::shared_ptr<Effect> loadEffect(filesystem::path aEffectFile,
-                                   const resource::ResourceFinder & aFinder);
+                                   Load<Technique> & aTechniqueAccess);
+
+inline
+std::shared_ptr<Effect> loadEffect(filesystem::path aEffectFile,
+                                   Load<Technique> && aTechniqueAccess)
+{ return loadEffect(aEffectFile, aTechniqueAccess); }
 
 Mesh loadCube(std::shared_ptr<Effect> aEffect);
 

--- a/src/libs/snac-renderer/snac-renderer/SetupDrawing.cpp
+++ b/src/libs/snac-renderer/snac-renderer/SetupDrawing.cpp
@@ -236,7 +236,8 @@ void setTextures(const TextureRepository & aTextures,
                 if(auto [iterator, didInsert] = aWarnedUniforms.insert(textureString);
                    didInsert)
                 {
-                SELOG(warn)(
+                // This is likely an error: the sampler being available means it is probably used.
+                SELOG(error)(
                     "{}: Could not find an a texture for semantic '{}' in program '{}'.", 
                     __func__,
                     textureString,

--- a/src/libs/snac-renderer/snac-renderer/effects/Text.sefx
+++ b/src/libs/snac-renderer/snac-renderer/effects/Text.sefx
@@ -1,0 +1,7 @@
+{
+    "techniques": [
+        {
+            "programfile": "shaders/Text.prog"
+        }
+    ]
+}

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
@@ -29,6 +29,14 @@ ForwardShadows::ForwardShadows(const graphics::AppInterface & aAppInterface,
     }
 {
     graphics::allocateStorage(depthMap, GL_DEPTH_COMPONENT24, gShadowMapSize);
+    {
+        auto boundDepthMap = graphics::ScopedBind{depthMap};
+        glTexParameteri(depthMap.mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+        glTexParameteri(depthMap.mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+        glTexParameterfv(depthMap.mTarget, 
+                         GL_TEXTURE_BORDER_COLOR,
+                         math::hdr::Rgba_f{1.f, 0.f, 0.f, 0.f}.data());
+    }
 
     graphics::attachImage(depthFBO, depthMap, GL_DEPTH_ATTACHMENT);
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
@@ -17,6 +17,14 @@ handy::StringId gDepthSid{"depth"};
 handy::StringId gForwardShadowSid{"forward_shadow"};
 
 
+void addCheckbox(const char * aLabel, MovableAtomic<bool> & aValue)
+{
+    bool value = aValue;
+    ImGui::Checkbox(aLabel, &value);
+    aValue = value;
+}
+
+
 ForwardShadows::ForwardShadows(const graphics::AppInterface & aAppInterface,
                                Load<Technique> & aTechniqueLoader) :
     mAppInterface{aAppInterface},
@@ -77,6 +85,8 @@ void ForwardShadows::Controls::drawGui()
         }
         ImGui::EndCombo();
     }
+
+    addCheckbox("Show depthmap", mShowDepthMap);
 
     ImGui::End();
 }
@@ -145,13 +155,14 @@ void ForwardShadows::execute(
         auto uniformPush = 
             aProgramSetup.mUniforms.push({
                 {Semantic::LightViewingMatrix, aLightViewpoint.assembleViewMatrix()},
-                {Semantic::ShadowBias, mControls.mShadowBias/*.load()*/},
+                {Semantic::ShadowBias, mControls.mShadowBias.load()},
             });
 
         forwardShadowPass.draw(aEntities, aRenderer, aProgramSetup);
     }
 
     // Show shadow map in a viewport
+    if(mControls.mShowDepthMap)
     {
         static const Pass showDepthmapPass{"debug-show-depthmap"};
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
@@ -1,9 +1,11 @@
-#include "DrawerShadows.h"
+#include "ForwardShadows.h"
+
+#include "../Cube.h"
+#include "../ResourceLoad.h"
 
 #include <math/Transformations.h>
 #include <math/VectorUtilities.h>
 
-#include <snac-renderer/ResourceLoad.h>
 
 
 namespace ad {
@@ -15,10 +17,9 @@ handy::StringId gDepthSid{"depth"};
 handy::StringId gForwardShadowSid{"forward_shadow"};
 
 
-DrawerShadows::DrawerShadows(graphics::ApplicationGlfw & aGlfwApp,
-                             const resource::ResourceFinder & aFinder) :
-    mAppInterface{*aGlfwApp.getAppInterface()},
-    mFinder{aFinder},
+ForwardShadows::ForwardShadows(const graphics::AppInterface & aAppInterface,
+                               Load<Technique> & aTechniqueLoader) :
+    mAppInterface{aAppInterface},
     screenQuad{
         .mStream = makeQuad(),
         .mMaterial = std::make_shared<Material>(Material{
@@ -32,11 +33,12 @@ DrawerShadows::DrawerShadows(graphics::ApplicationGlfw & aGlfwApp,
     graphics::attachImage(depthFBO, depthMap, GL_DEPTH_ATTACHMENT);
 
     screenQuad.mMaterial->mEffect->mTechniques.push_back(
-        loadTechnique(mFinder.pathFor("shaders/ShowDepth.prog")));
+        aTechniqueLoader.get("shaders/ShowDepth.prog"));
+        //loadTechnique(mFinder.pathFor("shaders/ShowDepth.prog")));
 }
 
 
-void DrawerShadows::drawGui()
+void ForwardShadows::drawGui()
 {
     ImGui::Begin("Shadow Controls");
 
@@ -70,12 +72,13 @@ void DrawerShadows::drawGui()
 }
 
 
-void DrawerShadows::draw(
+void ForwardShadows::draw(
     const std::vector<Pass::Visual> & aEntities,
     Renderer & aRenderer,
     ProgramSetup & aProgramSetup)
 {
-    drawGui();
+    // TODO restore
+    //drawGui();
 
     auto scopeDepth = graphics::scopeFeature(GL_DEPTH_TEST, true);
 
@@ -150,9 +153,9 @@ void DrawerShadows::draw(
 
         GLsizei viewportHeight = mAppInterface.getFramebufferSize().height() / 4;
         glViewport(0,
-                0, 
-                (GLsizei)(viewportHeight * getRatio<GLfloat>(gShadowMapSize)), 
-                viewportHeight);
+                   0, 
+                   (GLsizei)(viewportHeight * getRatio<GLfloat>(gShadowMapSize)), 
+                   viewportHeight);
 
         auto scopedTexture = aProgramSetup.mTextures.push(Semantic::BaseColorTexture, &depthMap);
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.cpp
@@ -162,10 +162,13 @@ void ForwardShadows::execute(
         }
 
         GLsizei viewportHeight = mAppInterface.getFramebufferSize().height() / 4;
-        glViewport(0,
-                   0, 
-                   (GLsizei)(viewportHeight * getRatio<GLfloat>(gShadowMapSize)), 
-                   viewportHeight);
+        Guard scopedViewport = graphics::scopeViewport({
+            {0, 0}, 
+            {
+                (GLsizei)(viewportHeight * getRatio<GLfloat>(gShadowMapSize)), 
+                   viewportHeight
+            }
+        });
 
         auto scopedTexture = aProgramSetup.mTextures.push(Semantic::BaseColorTexture, &depthMap);
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
@@ -22,6 +22,15 @@ namespace snac {
 
 class ForwardShadows
 {
+    struct Controls
+    {
+        void drawGui();
+
+        inline static const std::array<GLenum, 2> gAvailableFilters{GL_NEAREST, GL_LINEAR};
+        GLfloat mShadowBias = 0.00005f;
+        GLenum mDetphMapFilter = GL_LINEAR;
+    };
+
 public:
     ForwardShadows(const graphics::AppInterface & aAppInterface,
                    Load<Technique> & aTechniqueLoader);
@@ -37,9 +46,10 @@ public:
         Renderer & aRenderer,
         ProgramSetup & aProgramSetup);
 
-private:
-    void drawGui();
+    void drawGui()
+    { mControls.drawGui(); }
 
+private:
     static constexpr math::Size<2, int> gShadowMapSize{1024, 1024};
 
     const graphics::AppInterface & mAppInterface;
@@ -48,8 +58,7 @@ private:
     graphics::FrameBuffer depthFBO;
     Mesh screenQuad;
 
-    GLfloat mShadowBias = 0.00005f;
-    GLenum mDetphMapFilter = GL_NEAREST;
+    Controls mControls;
 };
 
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
@@ -15,6 +15,8 @@
 
 #include <imguiui/ImguiUi.h>
 
+#include <atomic>
+
 
 namespace ad {
 namespace snac {

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "Gui.h"
+
+#include "../LoadInterface.h"
+#include "../Render.h"
 
 #include <handy/StringId.h>
 
@@ -11,19 +13,23 @@
 
 #include <resource/ResourceFinder.h>
 
-#include <snac-renderer/Cube.h>
-#include <snac-renderer/Render.h>
+#include <imguiui/ImguiUi.h>
 
 
 namespace ad {
 namespace snac {
 
 
-class DrawerShadows
+class ForwardShadows
 {
 public:
-    DrawerShadows(graphics::ApplicationGlfw & aGlfwApp,
-                  const resource::ResourceFinder & aFinder);
+    ForwardShadows(const graphics::AppInterface & aAppInterface,
+                   Load<Technique> & aTechniqueLoader);
+
+    ForwardShadows(const graphics::AppInterface & aAppInterface,
+                   Load<Technique> && aTechniqueLoader) :
+        ForwardShadows{aAppInterface, aTechniqueLoader}
+    {}
 
     void draw(
         const std::vector<Pass::Visual> & aEntities,
@@ -36,7 +42,6 @@ private:
     static constexpr math::Size<2, int> gShadowMapSize{1024, 1024};
 
     const graphics::AppInterface & mAppInterface;
-    const resource::ResourceFinder & mFinder;
 
     graphics::Texture depthMap{GL_TEXTURE_2D};
     graphics::FrameBuffer depthFBO;

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
@@ -44,7 +44,12 @@ class ForwardShadows
 
         inline static const std::array<GLenum, 2> gAvailableFilters{GL_NEAREST, GL_LINEAR};
         MovableAtomic<GLenum> mDetphMapFilter = GL_LINEAR;
+
         MovableAtomic<GLfloat> mShadowBias = 0.0001f;
+
+        inline static const std::array<GLenum, 2> gCullFaceModes{GL_FRONT, GL_BACK};
+        MovableAtomic<GLenum> mCullFaceMode{GL_BACK};
+
         MovableAtomic<bool> mShowDepthMap{false};
     };
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
@@ -31,8 +31,9 @@ public:
         ForwardShadows{aAppInterface, aTechniqueLoader}
     {}
 
-    void draw(
+    void execute(
         const std::vector<Pass::Visual> & aEntities,
+        const Camera & aLightViewpoint,
         Renderer & aRenderer,
         ProgramSetup & aProgramSetup);
 

--- a/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
+++ b/src/libs/snac-renderer/snac-renderer/pipelines/ForwardShadows.h
@@ -45,7 +45,7 @@ class ForwardShadows
         inline static const std::array<GLenum, 2> gAvailableFilters{GL_NEAREST, GL_LINEAR};
         MovableAtomic<GLenum> mDetphMapFilter = GL_LINEAR;
 
-        MovableAtomic<GLfloat> mShadowBias = 0.0001f;
+        MovableAtomic<GLfloat> mShadowBias = 0.0005f;
 
         inline static const std::array<GLenum, 2> gCullFaceModes{GL_FRONT, GL_BACK};
         MovableAtomic<GLenum> mCullFaceMode{GL_BACK};

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLighting.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLighting.frag
@@ -32,12 +32,13 @@ uniform float u_ShadowBias = 0.;
 
 uniform sampler2DShadow u_ShadowMap;
 
-float getShadowAttenuation(vec4 fragPosition_lightClip)
+float getShadowAttenuation(vec4 fragPosition_lightClip, float bias)
 {
     // From light clip-space to light texture coordinates [0, 1]
     vec3 fragPosition_shadowTexture = 
         (fragPosition_lightClip.xyz/fragPosition_lightClip.w + 1) / 2;
-    fragPosition_shadowTexture.z -= u_ShadowBias;
+    
+    fragPosition_shadowTexture.z -= bias;
 
     return texture(u_ShadowMap, fragPosition_shadowTexture).r;
 }
@@ -93,14 +94,17 @@ void main(void)
     //
     vec3 ambient = 
         u_AmbientColor;
-    vec3 diffuse = 
+    vec3 diffuse =
         u_LightColor * max(0.f, dot(normal_c, light_c));
     vec3 specular = 
         u_LightColor * pow(max(0.f, dot(normal_c, h_c)), specularExponent);
-    vec3 phongColor = 
+
 #ifdef SHADOW
-        (ambient + (diffuse + specular) * getShadowAttenuation(ex_Position_lightClip)) * color.xyz;
+        float bias = max(8 * (1 - dot(normalize(ex_Normal_c), light_c)), 1) * u_ShadowBias;
+    vec3 phongColor = 
+        (ambient + (diffuse + specular) * getShadowAttenuation(ex_Position_lightClip, bias)) * color.xyz;
 #else
+    vec3 phongColor = 
         (ambient + diffuse + specular) * color.xyz;
 #endif
 

--- a/src/libs/snac-renderer/snac-renderer/shaders/PhongLighting.frag
+++ b/src/libs/snac-renderer/snac-renderer/shaders/PhongLighting.frag
@@ -70,7 +70,7 @@ void main(void)
     // The normal in tangent space
     vec3 normal_tbn = normalize(
         // Mapping from [0.0, 1.0] to [-1.0, 1.0]
-        (texture(u_NormalTexture, ex_TextureCoords[0]).xyz * 2.0 - vec3(1.0))
+        (texture(u_NormalTexture, ex_TextureCoords[u_NormalUVIndex]).xyz * 2.0 - vec3(1.0))
         * vec3(u_NormalMapScale, u_NormalMapScale, 1.0));
 
     // MikkT see: http://www.mikktspace.com/


### PR DESCRIPTION
closes #56
- Adapt snacman to the new Renderer/Pass API.
- Replace snacman mesh rendering with the ForwardShadow pipeline. This required several brutal changes.
- Add a default normal map to gltf models when not provided.
- Fix bug where PhongLighting shaders did not use correct normal index.
- Set shadow map wrap mode to border with depth of 1 (out of shadow).
- Accept light viewpoint as parameter in ForwardShadows pipeline.
- Sanitize the conversion from game grid to renderer world-coordinates.
- Enhance the shadow light viewpoint to cover the whole grid.
- Move the Renderer in RenderThread to a data member.
- Restore text rendering.
- Introduce generalized render controls.
- Use atomic in ForwardShadows control, add checkbox to show depthmap.
- Reverse order of members in Pass::Visual.
- Reverse cube face indices, to be counter-clockwise.
- Add control over the cull mode for depth-map rendering.
- Merge "illumination" light and "shadow" light to a static world pos.
- Implement dynamic bias and tune base value, overcoming most aliasing.
- Reset VAOs (and emitted warnings) upon shader recompilation.
