### PR TITLE
topic/snacman#82 paper bill score

### DIFF
--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -25,6 +25,7 @@ set(${TARGET_NAME}_HEADERS
     simulations/snacgame/GameContext.h
     simulations/snacgame/GameParameters.h
     simulations/snacgame/GraphicState.h
+    simulations/snacgame/ImguiSceneEditor.h
     simulations/snacgame/InputConstants.h
     simulations/snacgame/InputCommandConverter.h
     simulations/snacgame/LevelHelper.h
@@ -93,6 +94,7 @@ set(${TARGET_NAME}_SOURCES
     Resources.cpp
 
     simulations/snacgame/Entities.cpp
+    simulations/snacgame/ImguiSceneEditor.cpp
     simulations/snacgame/Renderer.cpp
     simulations/snacgame/SnacGame.cpp
     simulations/snacgame/SimulationControl.cpp

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -7,6 +7,7 @@ configure_file(build_info.h.in build_info.h @ONLY)
 
 set(${TARGET_NAME}_HEADERS
     DebugDrawing.h
+    EntityUtilities.h
     GraphicState.h
     ImguiUtilities.h
     Input.h

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -100,6 +100,7 @@ set(${TARGET_NAME}_SOURCES
 
     simulations/snacgame/component/Context.cpp
     simulations/snacgame/component/DebugUi.cpp
+    simulations/snacgame/component/PlayerHud.cpp
 
     simulations/snacgame/scene/GameScene.cpp
     simulations/snacgame/scene/GameScene-setup.cpp

--- a/src/apps/snacman/snacman/EntityUtilities.h
+++ b/src/apps/snacman/snacman/EntityUtilities.h
@@ -1,0 +1,23 @@
+// This file is an illustration of why Entity interface is too cumbersome
+#pragma once
+
+
+#include <entity/Entity.h>
+
+
+namespace ad {
+namespace snac {
+
+
+template <class T_component>
+T_component & getComponent(ent::Handle<ent::Entity> aHandle)
+{
+    auto view = aHandle.get();
+    assert(view.has_value());
+    assert(view->has<T_component>());
+    return view->get<T_component>();
+}
+
+
+} // namespace snac
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -348,7 +348,6 @@ createHudPaperScore(GameContext & aContext,
             ent::Entity powerupText = *powerupHandle.get(createScore);
             powerupText 
                 .add(component::Text{
-                    .mString = "Pup",
                     .mFont = aContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120),
                     //.mColor = playerSlot.mColor,
                     .mColor = math::hdr::gBlack<float>,
@@ -388,7 +387,6 @@ createHudPaperScore(GameContext & aContext,
             ->add(component::PlayerHud{
                 .mScoreText = scoreHandle,
                 .mPowerupText = powerupHandle,
-                .mPlayer = aPlayer,
             })
             .add(component::LevelEntity{})
             ;
@@ -442,7 +440,9 @@ ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
         player.add(component::PlayerModel{.mModel = playerModel})
             .add(component::PlayerLifeCycle{
                 .mIsAlive = false,
-                .mTimeToRespawn = component::gBaseTimeToRespawn})
+                .mTimeToRespawn = component::gBaseTimeToRespawn,
+                .mHud = createHudPaperScore(aContext, aSlot),
+            })
             .add(component::PlayerMoveState{})
             .add(component::AllowedMovement{})
             .add(component::Controller{.mType = aControllerType,
@@ -450,8 +450,6 @@ ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
             .add(component::Collision{component::gPlayerHitbox})
             .add(component::PlayerPortalData{})
         ;
-
-        createHudPaperScore(aContext, aSlot);
     }
     return aSlot;
 }

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -315,7 +315,12 @@ createHudPaperScore(GameContext & aContext,
 
         ent::Entity hud = *hudHandle.get(createHud);
         // Create the Hud common ancestor in the scene graph
-        addGeoNode(aContext, hud, component::gHudPositionsWorld[playerSlot.mIndex]);
+        addGeoNode(aContext,
+                   hud,
+                   component::gHudPositionsWorld[playerSlot.mIndex],
+                   1.f,
+                   {1.f, 1.f , 1.f},
+                   component::gHudOrientationsWorld[playerSlot.mIndex]);
     }
 
     // The score text line
@@ -336,7 +341,7 @@ createHudPaperScore(GameContext & aContext,
                 //.add(component::LevelEntity{}) crashes because it also tries to add as a child of the scene
                 ;
 
-            addGeoNode(aContext, scoreText, {0.f, 0.f, 0.f}, 1.25f);
+            addGeoNode(aContext, scoreText, {-1.7f, 0.6f, 0.f}, 1.25f);
         }
 
         {
@@ -349,7 +354,7 @@ createHudPaperScore(GameContext & aContext,
                     .mColor = math::hdr::gBlack<float>,
                 })
                 ;
-            addGeoNode(aContext, powerupText, {0.f, -.25f, 0.f}, 0.7f);
+            addGeoNode(aContext, powerupText, {-1.9f, -.25f, 0.f}, 0.7f);
         }
 
         {

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -231,6 +231,7 @@ EntHandle createPlayerPowerUp(GameContext & aContext,
     return handle;
 }
 
+
 EntHandle createPathEntity(GameContext & aContext,
                            Phase & aPhase,
                            const math::Position<2, float> & aGridPos)
@@ -240,6 +241,7 @@ EntHandle createPathEntity(GameContext & aContext,
                        math::hdr::gWhite<float>);
     return handle;
 }
+
 
 ent::Handle<ent::Entity>
 createPortalEntity(GameContext & aContext,
@@ -254,6 +256,7 @@ createPortalEntity(GameContext & aContext,
     portal.add(component::Portal{aPortalIndex});
     return handle;
 }
+
 
 void addPortalInfo(component::Portal & aPortal,
                    const component::Geometry & aGeo,
@@ -270,6 +273,7 @@ void addPortalInfo(component::Portal & aPortal,
     aPortal.mMirrorSpawnPosition = aGeo.mPosition + aDirection;
 }
 
+
 ent::Handle<ent::Entity>
 createCopPenEntity(GameContext & aContext,
                    Phase & aPhase,
@@ -280,6 +284,7 @@ createCopPenEntity(GameContext & aContext,
                        math::hdr::gYellow<float>);
     return handle;
 }
+
 
 ent::Handle<ent::Entity>
 createPlayerSpawnEntity(GameContext & aContext,
@@ -307,11 +312,18 @@ createHudPaperScore(GameContext & aContext,
 
     Phase createHud;
     EntHandle hudHandle = aContext.mWorld.addEntity();
-    hudHandle.get(createHud)
-        ->add(component::PlayerHud{
+    ent::Entity hud = *hudHandle.get(createHud);
+    // Create the Hud common ancestor in the scene graph
+    addGeoNode(createHud, aContext, hud, component::gHudPositionsWorld[playerSlot.mIndex]);
+    hud.add(component::PlayerHud{
             .mPlayer = aPlayer,
         })
-    ;
+        .add(component::Text{
+            .mFont = aContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120),
+            .mColor = playerSlot.mColor,
+        })
+        .add(component::LevelEntity{});
+        ;
 
     return hudHandle;
 }

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -326,29 +326,31 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
     {
         Phase createScore;
 
+        const std::string fontname = "fonts/notes/Bitcheese.ttf";
+
         {
             ent::Entity scoreText = *scoreHandle.get(createScore);
             scoreText
                 .add(component::Text{
-                    .mFont = aContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120),
+                    .mFont = aContext.mResources.getFont(fontname, 100),
                     //.mColor = playerSlot.mColor,
                     .mColor = math::hdr::gBlack<float>,
                 })
                 ;
 
-            addGeoNode(aContext, scoreText, {-1.7f, 0.6f, 0.f}, 1.25f);
+            addGeoNode(aContext, scoreText, {-1.7f, 0.6f, 0.f}, 1.f);
         }
 
         {
             ent::Entity powerupText = *powerupHandle.get(createScore);
             powerupText 
                 .add(component::Text{
-                    .mFont = aContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120),
+                    .mFont = aContext.mResources.getFont(fontname, 100),
                     //.mColor = playerSlot.mColor,
                     .mColor = math::hdr::gBlack<float>,
                 })
                 ;
-            addGeoNode(aContext, powerupText, {-1.9f, -.25f, 0.f}, 0.7f);
+            addGeoNode(aContext, powerupText, {-1.9f, -.5f, 0.f}, 0.6f);
         }
 
         {

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -321,6 +321,7 @@ createHudPaperScore(GameContext & aContext,
     // The score text line
     EntHandle scoreHandle =   aContext.mWorld.addEntity();
     EntHandle powerupHandle = aContext.mWorld.addEntity();
+    EntHandle billpadHandle = aContext.mWorld.addEntity();
     {
         Phase createScore;
 
@@ -329,7 +330,8 @@ createHudPaperScore(GameContext & aContext,
             scoreText
                 .add(component::Text{
                     .mFont = aContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120),
-                    .mColor = playerSlot.mColor,
+                    //.mColor = playerSlot.mColor,
+                    .mColor = math::hdr::gBlack<float>,
                 })
                 //.add(component::LevelEntity{}) crashes because it also tries to add as a child of the scene
                 ;
@@ -343,10 +345,30 @@ createHudPaperScore(GameContext & aContext,
                 .add(component::Text{
                     .mString = "Pup",
                     .mFont = aContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120),
-                    .mColor = playerSlot.mColor,
+                    //.mColor = playerSlot.mColor,
+                    .mColor = math::hdr::gBlack<float>,
                 })
                 ;
             addGeoNode(aContext, powerupText, {0.f, -.25f, 0.f}, 0.7f);
+        }
+
+        {
+            ent::Entity billpad = *billpadHandle.get(createScore);
+            addMeshGeoNode(
+                aContext,
+                billpad,
+                "models/billpad/billpad.gltf", "effects/MeshTextures.sefx",
+                {0.f, 0.f, -gPlayerHeight / 2.f},
+                8.f,
+                {1.f, 1.f, 1.f},
+                Quat_f{
+                    math::UnitVec<3, float>{{1.f, 0.f, 0.f}},
+                    math::Turn<float>{-0.25f}}
+                    * Quat_f{
+                        math::UnitVec<3, float>{{0.f, 1.f, 0.f}},
+                        math::Turn<float>{0.25f}}
+                    ,
+                playerSlot.mColor);
         }
     }
 
@@ -355,6 +377,8 @@ createHudPaperScore(GameContext & aContext,
 
         insertEntityInScene(scoreHandle, hudHandle);
         insertEntityInScene(powerupHandle, hudHandle);
+        insertEntityInScene(billpadHandle, hudHandle);
+
         hudHandle.get(completeSceneGraph)
             ->add(component::PlayerHud{
                 .mScoreText = scoreHandle,

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -354,7 +354,7 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
                 })
                 ;
 
-            addGeoNode(aContext, roundText, {1.5f, 0.3f, 0.f}, 1.1f);
+            addGeoNode(aContext, roundText, {0.5f, 0.3f, 0.f}, 1.1f);
         }
 
         // Power-up
@@ -591,7 +591,9 @@ void removeRoundTransientPlayerComponent(Phase & aPhase, EntHandle aHandle)
 
     // Remove the whole hud subtree (billpad, texts, ...)
     assert(playerEntity.has<component::PlayerLifeCycle>());
-    eraseEntityRecursive(*playerEntity.get<component::PlayerLifeCycle>().mHud, aPhase);
+    auto & lifeCycle = playerEntity.get<component::PlayerLifeCycle>();
+    eraseEntityRecursive(*lifeCycle.mHud, aPhase);
+    lifeCycle.mHud = std::nullopt;
 }
 
 EntHandle removePlayerFromGame(Phase & aPhase, EntHandle aHandle)

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -568,6 +568,10 @@ void removeRoundTransientPlayerComponent(Phase & aPhase, EntHandle aHandle)
             ->erase();
         aHandle.get(aPhase)->remove<component::PlayerPortalData>();
     }
+
+    // Remove the whole hud subtree (billpad, texts, ...)
+    assert(playerEntity.has<component::PlayerLifeCycle>());
+    eraseEntityRecursive(*playerEntity.get<component::PlayerLifeCycle>().mHud, aPhase);
 }
 
 EntHandle removePlayerFromGame(Phase & aPhase, EntHandle aHandle)
@@ -577,9 +581,6 @@ EntHandle removePlayerFromGame(Phase & aPhase, EntHandle aHandle)
     slot.mFilled = false;
 
     Entity playerEntity = *aHandle.get(aPhase);
-
-    // Remove the whole hud subtree (billpad, texts, ...)
-    eraseEntityRecursive(*playerEntity.get<component::PlayerLifeCycle>().mHud, aPhase);
 
     playerEntity.remove<component::Controller>();
     playerEntity.remove<component::Geometry>();

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -50,8 +50,8 @@ namespace snacgame {
 
 constexpr Size3 lLevelElementScaling = {1.f, 1.f, 1.f};
 
-void addGeoNode(Phase & aPhase,
-                GameContext & aContext,
+// TODO phase is not used...
+void addGeoNode(GameContext & aContext,
                 Entity & aEnt,
                 Pos3 aPos,
                 float aScale,
@@ -68,8 +68,7 @@ void addGeoNode(Phase & aPhase,
         .add(component::GlobalPose{});
 }
 
-std::shared_ptr<snac::Model> addMeshGeoNode(Phase & aPhase,
-                                            GameContext & aContext,
+std::shared_ptr<snac::Model> addMeshGeoNode(GameContext & aContext,
                                             Entity & aEnt,
                                             const char * aModelPath,
                                             const char * aEffectPath,
@@ -101,7 +100,7 @@ void createLevelElement(Phase & aPhase,
 {
     Entity path = *aHandle.get(aPhase);
     addMeshGeoNode(
-        aPhase, aContext, path, "models/square_biscuit/square_biscuit.gltf",
+        aContext, path, "models/square_biscuit/square_biscuit.gltf",
         "effects/MeshTextures.sefx",
         {static_cast<float>(aGridPos.x()), static_cast<float>(aGridPos.y()),
          gLevelHeight},
@@ -144,7 +143,7 @@ createAnimatedTest(GameContext & aContext,
     auto handle = aContext.mWorld.addEntity();
     Entity entity = *handle.get(aPhase);
     std::shared_ptr<snac::Model> model = addMeshGeoNode(
-        aPhase, aContext, entity, "models/anim/anim.gltf",
+        aContext, entity, "models/anim/anim.gltf",
         "effects/MeshRigging.sefx",
         {static_cast<float>(aGridPos.x()), static_cast<float>(aGridPos.y()),
          gLevelHeight},
@@ -169,7 +168,7 @@ ent::Handle<ent::Entity> createPill(GameContext & aContext,
 {
     auto handle = aContext.mWorld.addEntity();
     Entity pill = *handle.get(aPhase);
-    addMeshGeoNode(aPhase, aContext, pill, "models/burger/burger.gltf",
+    addMeshGeoNode(aContext, pill, "models/burger/burger.gltf",
                    "effects/MeshTextures.sefx",
                    {static_cast<float>(aGridPos.x()),
                     static_cast<float>(aGridPos.y()), gPillHeight},
@@ -198,7 +197,7 @@ createPowerUp(GameContext & aContext,
     component::PowerUpType baseType = component::PowerUpType::Dog;
     component::PowerUpBaseInfo info =
         component::gPowerupPathByType.at(static_cast<unsigned int>(baseType));
-    addMeshGeoNode(aPhase, aContext, powerUp, info.mPath,
+    addMeshGeoNode(aContext, powerUp, info.mPath,
                    "effects/MeshTextures.sefx",
                    {static_cast<float>(aGridPos.x()),
                     static_cast<float>(aGridPos.y()), gPillHeight},
@@ -224,7 +223,7 @@ EntHandle createPlayerPowerUp(GameContext & aContext,
     Entity powerUp = *handle.get(init);
     component::PowerUpBaseInfo info =
         component::gPowerupPathByType.at(static_cast<unsigned int>(aType));
-    addMeshGeoNode(init, aContext, powerUp, info.mPath,
+    addMeshGeoNode(aContext, powerUp, info.mPath,
                    "effects/MeshTextures.sefx", {1.f, 1.f, 0.f},
                    info.mPlayerScaling, info.mPlayerInstanceScale,
                    info.mPlayerOrientation);
@@ -316,7 +315,7 @@ createHudPaperScore(GameContext & aContext,
 
         ent::Entity hud = *hudHandle.get(createHud);
         // Create the Hud common ancestor in the scene graph
-        addGeoNode(createHud, aContext, hud, component::gHudPositionsWorld[playerSlot.mIndex]);
+        addGeoNode(aContext, hud, component::gHudPositionsWorld[playerSlot.mIndex]);
     }
 
     // The score text line
@@ -335,7 +334,7 @@ createHudPaperScore(GameContext & aContext,
                 //.add(component::LevelEntity{}) crashes because it also tries to add as a child of the scene
                 ;
 
-            addGeoNode(createScore, aContext, scoreText, {0.f, 0.f, 0.f}, 1.25f);
+            addGeoNode(aContext, scoreText, {0.f, 0.f, 0.f}, 1.25f);
         }
 
         {
@@ -347,7 +346,7 @@ createHudPaperScore(GameContext & aContext,
                     .mColor = playerSlot.mColor,
                 })
                 ;
-            addGeoNode(createScore, aContext, powerupText, {0.f, -.25f, 0.f}, 0.7f);
+            addGeoNode(aContext, powerupText, {0.f, -.25f, 0.f}, 0.7f);
         }
     }
 
@@ -389,8 +388,8 @@ ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
 
         Entity model = *playerModel.get(sceneInit);
 
-        addGeoNode(sceneInit, aContext, player, {0.f, 0.f, gPlayerHeight});
-        addMeshGeoNode(sceneInit, aContext, model,
+        addGeoNode(aContext, player, {0.f, 0.f, gPlayerHeight});
+        addMeshGeoNode(aContext, model,
                        "models/donut/donut.gltf", "effects/MeshTextures.sefx",
                        {0.f, 0.f, 0.f}, 1.f,
                        {0.2f, 0.2f, 0.2f},
@@ -575,7 +574,7 @@ EntHandle createStageDecor(GameContext & aContext)
         Phase createStage;
         Entity stageEntity = *result.get(createStage);
 
-        addMeshGeoNode(createStage, aContext, stageEntity,
+        addMeshGeoNode(aContext, stageEntity,
                        "models/stage/stage.gltf", "effects/MeshTextures.sefx",
                        {7.f, 7.f, -0.4f}, 1.f, {1.f, 1.f, 1.f},
                        Quat_f{math::UnitVec<3, float>{{0.f, 0.f, 1.f}},
@@ -594,7 +593,7 @@ EntHandle createTargetArrow(GameContext & aContext, const HdrColor_f & aColor)
         Phase createTargetArrow;
         Entity stageEntity = *result.get(createTargetArrow);
 
-        addMeshGeoNode(createTargetArrow, aContext, stageEntity,
+        addMeshGeoNode(aContext, stageEntity,
                        "models/arrow/arrow.gltf", "effects/MeshTextures.sefx", {0.f, 0.f, 2.f}, 0.4f,
                        {1.f, 1.f, 1.f},
                        Quat_f{math::UnitVec<3, float>{{1.f, 0.f, 0.f}},

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -350,7 +350,7 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
                     .mColor = math::hdr::gBlack<float>,
                 })
                 ;
-            addGeoNode(aContext, powerupText, {-1.9f, -.5f, 0.f}, 0.6f);
+            addGeoNode(aContext, powerupText, {-1.9f, -.5f, 0.f}, 0.5f);
         }
 
         {

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -321,6 +321,7 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
 
     // The score text line
     EntHandle scoreHandle =   aContext.mWorld.addEntity();
+    EntHandle roundHandle =   aContext.mWorld.addEntity();
     EntHandle powerupHandle = aContext.mWorld.addEntity();
     EntHandle billpadHandle = aContext.mWorld.addEntity();
     {
@@ -328,6 +329,7 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
 
         const std::string fontname = "fonts/notes/Bitcheese.ttf";
 
+        // Score
         {
             ent::Entity scoreText = *scoreHandle.get(createScore);
             scoreText
@@ -341,6 +343,21 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
             addGeoNode(aContext, scoreText, {-1.7f, 0.6f, 0.f}, 1.f);
         }
 
+        // Rounds
+        {
+            ent::Entity roundText = *roundHandle.get(createScore);
+            roundText
+                .add(component::Text{
+                    .mFont = aContext.mResources.getFont(fontname, 100),
+                    //.mColor = playerSlot.mColor,
+                    .mColor = math::hdr::gBlack<float>,
+                })
+                ;
+
+            addGeoNode(aContext, roundText, {1.5f, 0.3f, 0.f}, 1.1f);
+        }
+
+        // Power-up
         {
             ent::Entity powerupText = *powerupHandle.get(createScore);
             powerupText 
@@ -350,9 +367,10 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
                     .mColor = math::hdr::gBlack<float>,
                 })
                 ;
-            addGeoNode(aContext, powerupText, {-1.9f, -.5f, 0.f}, 0.5f);
+            addGeoNode(aContext, powerupText, {-1.9f, -.7f, 0.f}, 0.5f);
         }
 
+        // Billpad model
         {
             ent::Entity billpad = *billpadHandle.get(createScore);
             addMeshGeoNode(
@@ -377,6 +395,7 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
         Phase completeSceneGraph;
 
         insertEntityInScene(scoreHandle, hudHandle);
+        insertEntityInScene(roundHandle, hudHandle);
         insertEntityInScene(powerupHandle, hudHandle);
         insertEntityInScene(billpadHandle, hudHandle);
 
@@ -386,6 +405,7 @@ createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot)
         hudHandle.get(completeSceneGraph)
             ->add(component::PlayerHud{
                 .mScoreText = scoreHandle,
+                .mRoundText = roundHandle,
                 .mPowerupText = powerupHandle,
             })
             ;

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.h
@@ -39,10 +39,6 @@ struct Transition;
 
 struct GameContext;
 
-constexpr float gPillHeight = 6 * gCellSize * 0.1f;
-constexpr float gPlayerHeight = 0 * gCellSize * 0.1f;
-constexpr float gLevelHeight = 0 * gCellSize * 0.1f;
-
 void addGeoNode(
     ent::Phase & aPhase,
     GameContext & aContext,

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.h
@@ -40,7 +40,6 @@ struct Transition;
 struct GameContext;
 
 void addGeoNode(
-    ent::Phase & aPhase,
     GameContext & aContext,
     ent::Entity & aEnt,
     math::Position<3, float> aPos = math::Position<3, float>::Zero(),
@@ -50,7 +49,6 @@ void addGeoNode(
     math::hdr::Rgba_f aColor = math::hdr::gWhite<float>);
 
 std::shared_ptr<snac::Model> addMeshGeoNode(
-    ent::Phase & aPhase,
     GameContext & aContext,
     ent::Entity & aEnt,
     const char * aModelPath,

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.h
@@ -99,6 +99,9 @@ createPlayerSpawnEntity(GameContext & aContext,
                         ent::Phase & aPhase,
                         const math::Position<2, float> & aPos);
 
+ent::Handle<ent::Entity>
+createHudBillpad(GameContext & aContext, component::PlayerSlot aPlayerSlot);
+
 ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
                                             ControllerType aControllerType,
                                             ent::Handle<ent::Entity> aSlot,

--- a/src/apps/snacman/snacman/simulations/snacgame/GameParameters.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameParameters.h
@@ -14,6 +14,9 @@ constexpr float gOtherTurningZoneHalfWidth = 0.05f;
 constexpr int gPointPerPill = 10;
 constexpr int gMaxPlayerSlots = 4;
 
+constexpr float gPillHeight = 6 * gCellSize * 0.1f;
+constexpr float gPlayerHeight = 0 * gCellSize * 0.1f;
+constexpr float gLevelHeight = 0 * gCellSize * 0.1f;
 
 static const math::Quaternion<float> gWorldCoordTo3dCoordQuat = math::Quaternion<float>{
     math::UnitVec<3, float>::MakeFromUnitLength({-1.f, 0.f, 0.f}),

--- a/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.cpp
@@ -3,6 +3,8 @@
 #include "component/Geometry.h"
 #include "component/SceneNode.h"
 
+#include <snacman/EntityUtilities.h>
+
 #include <imgui.h>
 
 #include <string>
@@ -18,10 +20,7 @@ namespace {
 
     const component::SceneNode & getNode(ent::Handle<ent::Entity> aEntityHandle)
     {
-        assert(aEntityHandle.isValid());
-        auto entity = *aEntityHandle.get();
-        assert(entity.has<SceneNode>());
-        return entity.get<SceneNode>();
+        return snac::getComponent<component::SceneNode>(aEntityHandle);
     }
 
     component::Geometry & getGeometry(ent::Handle<ent::Entity> aEntityHandle)

--- a/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.cpp
@@ -1,0 +1,178 @@
+#include "ImguiSceneEditor.h"
+
+#include "component/Geometry.h"
+#include "component/SceneNode.h"
+
+#include <imgui.h>
+
+#include <string>
+
+
+namespace ad {
+namespace snacgame {
+
+using component::Geometry;
+using component::SceneNode;
+
+namespace {
+
+    const component::SceneNode & getNode(ent::Handle<ent::Entity> aEntityHandle)
+    {
+        assert(aEntityHandle.isValid());
+        auto entity = *aEntityHandle.get();
+        assert(entity.has<SceneNode>());
+        return entity.get<SceneNode>();
+    }
+
+    component::Geometry & getGeometry(ent::Handle<ent::Entity> aEntityHandle)
+    {
+        assert(aEntityHandle.isValid());
+        auto entity = *aEntityHandle.get();
+        assert(entity.has<Geometry>());
+        return entity.get<Geometry>();
+    }
+
+    
+    template <template <class> class TT_angle>
+    struct EulerAngles
+    {
+        TT_angle<float> roll, pitch, yaw;
+
+        template <template <class> class TT_angle>
+        EulerAngles<TT_angle> as() const
+        {
+            return {
+                roll.as<TT_angle>(),
+                pitch.as<TT_angle>(),
+                yaw.as<TT_angle>(),
+            };
+        }
+    };
+
+    // For conversion procedures see:
+    // https://en.wikipedia.org/wiki/Conversion_between_quaternions_and_Euler_angles
+    EulerAngles<math::Radian> toEulerAngles(math::Quaternion<float> q) 
+    {
+        using Rad = math::Radian<float>;
+        EulerAngles<math::Radian> angles;
+
+        // roll (x-axis rotation)
+        float sinr_cosp = 2 * (q.w() * q.x() + q.y() * q.z());
+        float cosr_cosp = 1 - 2 * (q.x() * q.x() + q.y() * q.y());
+        angles.roll = Rad{std::atan2(sinr_cosp, cosr_cosp)};
+
+        // pitch (y-.x()is rotation)
+        float sinp = std::sqrt(1 + 2 * (q.w() * q.y() - q.x() * q.z()));
+        float cosp = std::sqrt(1 - 2 * (q.w() * q.y() - q.x() * q.z()));
+        angles.pitch = Rad{2 * std::atan2(sinp, cosp) - math::pi<float> / 2};
+
+        // yaw (z-.x()is rotation)
+        float siny_cosp = 2 * (q.w() * q.z() + q.x() * q.y());
+        float cosy_cosp = 1 - 2 * (q.y() * q.y() + q.z() * q.z());
+        angles.yaw = Rad{std::atan2(siny_cosp, cosy_cosp)};
+
+        return angles;
+    }
+
+    math::Quaternion<float> toQuaternion(EulerAngles<math::Radian> aAngles) // roll (x), pitch (Y), yaw (z)
+    {
+        // Abbreviations for the various angular functions
+
+        float cr = cos(aAngles.roll * 1.5f);
+        float sr = sin(aAngles.roll * 0.5f);
+        float cp = cos(aAngles.pitch * 0.5f);
+        float sp = sin(aAngles.pitch * 0.5f);
+        float cy = cos(aAngles.yaw * 0.5f);
+        float sy = sin(aAngles.yaw * 0.5f);
+
+        math::Vec<4, float> v{
+            sr * cp * cy - cr * sp * sy,
+            cr * sp * cy + sr * cp * sy,
+            cr * cp * sy - sr * sp * cy,
+            cr * cp * cy + sr * sp * sy,
+        };
+        v.normalize();
+
+        return math::Quaternion<float>{
+            v.x(),
+            v.y(),
+            v.z(),
+            v.w(),
+        };
+    }
+
+    void presentPoseEditor(ent::Handle<ent::Entity> aEntityHandle)
+    {
+        ImGui::Begin("Pose");
+
+        Geometry & geometry = getGeometry(aEntityHandle);
+        ImGui::InputFloat3("Position", geometry.mPosition.data());
+        ImGui::InputFloat("Scaling", &geometry.mScaling);
+        ImGui::InputFloat3("Instance scaling", geometry.mInstanceScaling.data());
+
+        EulerAngles<math::Radian> angles = toEulerAngles(geometry.mOrientation);
+        EulerAngles<math::Degree> degrees = angles.as<math::Degree>();
+        if(ImGui::InputFloat3("Orientation", (float*)&degrees))
+        {
+            angles = degrees.as<math::Radian>();
+            geometry.mOrientation = toQuaternion(angles);
+        }
+
+        ImGui::End();
+    }
+
+    
+} // unnamed namespace
+
+
+void SceneEditor::showEditor(ent::Handle<ent::Entity> aSceneRoot)
+{
+    ImGui::Begin("Scene tree");
+    
+    presentNode(aSceneRoot);
+
+    // Note: when changing scene, selected node might become invalid.
+    // Address it naively by testing.
+    if(mSelected && mSelected->isValid())
+    {
+        presentPoseEditor(*mSelected);
+    }
+
+    ImGui::End();
+}
+
+
+void SceneEditor::presentNode(ent::Handle<ent::Entity> aEntityHandle)
+{
+    const component::SceneNode & sceneNode = getNode(aEntityHandle);
+
+    int flags = sceneNode.hasChild() ? 0 : ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_Bullet;
+    const std::string  name = 
+        sceneNode.hasName() ? sceneNode.mName : "Node_" + std::to_string(aEntityHandle.id());
+
+    bool opened = ImGui::TreeNodeEx((void*)aEntityHandle.id(), flags, "%s", name.c_str());
+
+    ImGui::PushID((void*)aEntityHandle.id());
+
+    if(ImGui::IsItemClicked(0))
+    {
+        mSelected = aEntityHandle;
+    }
+
+    if(opened)
+    {
+        for(std::optional<ent::Handle<ent::Entity>> child = sceneNode.mFirstChild;
+            child.has_value();
+            child = getNode(*child).mNextChild)
+        {
+            presentNode(*child);
+        }
+        ImGui::TreePop();
+    }
+
+    ImGui::PopID();
+}
+
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.cpp
@@ -37,13 +37,13 @@ namespace {
     {
         TT_angle<float> roll, pitch, yaw;
 
-        template <template <class> class TT_angle>
-        EulerAngles<TT_angle> as() const
+        template <template <class> class TT_targetAngle>
+        EulerAngles<TT_targetAngle> as() const
         {
             return {
-                roll.as<TT_angle>(),
-                pitch.as<TT_angle>(),
-                yaw.as<TT_angle>(),
+                roll.template as<TT_targetAngle>(),
+                pitch.template as<TT_targetAngle>(),
+                yaw.template as<TT_targetAngle>(),
             };
         }
     };

--- a/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/ImguiSceneEditor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+
+#include <entity/Entity.h>
+
+
+namespace ad {
+namespace snacgame {
+
+
+class SceneEditor
+{
+public:
+    void showEditor(ent::Handle<ent::Entity> aSceneRoot);
+
+private:
+    void presentNode(ent::Handle<ent::Entity> aEntityHandle);
+
+    std::optional<ent::Handle<ent::Entity>> mSelected;
+};
+
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/SceneGraph.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SceneGraph.cpp
@@ -134,11 +134,13 @@ EntHandle insertTransformNode(ent::EntityManager & aWorld,
     return nodeEnt;
 }
 
+
 void insertEntityInScene(ent::Handle<ent::Entity> aHandle,
                          ent::Handle<ent::Entity> aParent)
 {
     ent::Phase graphPhase;
     Entity parentEntity = *aParent.get(graphPhase);
+    // TODO Ad: Dayum, we need typed handles...
     assert(parentEntity.has<component::SceneNode>()
            && "Can't add a child to a parent if it does not have scene node");
     assert(parentEntity.has<component::Geometry>()

--- a/src/apps/snacman/snacman/simulations/snacgame/SceneGraph.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SceneGraph.cpp
@@ -5,6 +5,8 @@
 #include "component/SceneNode.h"
 #include "typedef.h"
 
+#include <snacman/EntityUtilities.h>
+
 #include <entity/EntityManager.h>
 #include <math/Transformations.h>
 
@@ -247,6 +249,20 @@ void transferEntity(EntHandle aHandle, EntHandle aNewParent)
     computeNewLocalTransform(childGeo, childPose, parentPose);
 
     insertEntityInScene(aHandle, aNewParent);
+}
+
+void eraseEntityRecursive(ent::Handle<ent::Entity> aHandle, ent::Phase & aPhase)
+{
+    const component::SceneNode & sceneNode = snac::getComponent<component::SceneNode>(aHandle);
+
+    for(std::optional<ent::Handle<ent::Entity>> child = sceneNode.mFirstChild;
+        child.has_value();
+        child = snac::getComponent<component::SceneNode>(*child).mNextChild)
+    {
+        eraseEntityRecursive(*child, aPhase);
+    }
+    
+    aHandle.get(aPhase)->erase();
 }
 
 } // namespace snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/SceneGraph.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SceneGraph.h
@@ -21,6 +21,9 @@ math::Position<3, float> getTranslation(const math::AffineMatrix<4, float> & aMa
 float getUniformScale(const math::AffineMatrix<4, float> & aMatrix);
 math::Quaternion<float> getRotation(const math::AffineMatrix<4, float> & aMatrix, float aScale);
 
+/// @brief Erase the entity, and all its children, from the EntityManager.
+void eraseEntityRecursive(ent::Handle<ent::Entity> aHandle, ent::Phase & aPhase);
+
 template<class T_pose>
     concept Decomposition = requires(T_pose a)
     {

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -467,8 +467,8 @@ std::unique_ptr<visu::GraphicState> SnacGame::makeGraphicState()
     //
     mQueryTextScreen.get(nomutation)
         .each([&state, this](ent::Handle<ent::Entity> aHandle,
-                       component::Text & aText,
-                       component::PoseScreenSpace & aPose) 
+                             component::Text & aText,
+                             component::PoseScreenSpace & aPose) 
         {
 
             math::Position<3, float> position_screenPix{
@@ -498,44 +498,46 @@ std::unique_ptr<visu::GraphicState> SnacGame::makeGraphicState()
         mGameContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120);
 
     mQueryHuds.get(nomutation)
-        .each([&font, &state, this](ent::Handle<ent::Entity> aHandle,
-                    const component::PlayerHud & aHud, const component::PlayerSlot & aSlot)
-    {
-        math::Position<3, float> position_screenPix{component::gHudPositions.at(aSlot.mIndex).cwMul(
-                    static_cast<math::Position<2, GLfloat>>(this->mAppInterface->getFramebufferSize())/2.f),
-        0.f};
-        math::Position<3, float> powerupOffset{math::Position<2, float>{0.f, -0.1f}.cwMul(
-                    static_cast<math::Position<2, GLfloat>>(this->mAppInterface->getFramebufferSize())/2.f),
-        0.f};
+        .each([&font, &state, this]
+              (ent::Handle<ent::Entity> aHandle,
+               const component::PlayerHud & aHud)
+        {
+            const component::PlayerSlot & slot = aHud.getSlot();
+            math::Position<3, float> position_screenPix{component::gHudPositions.at(slot.mIndex).cwMul(
+                        static_cast<math::Position<2, GLfloat>>(this->mAppInterface->getFramebufferSize())/2.f),
+            0.f};
+            math::Position<3, float> powerupOffset{math::Position<2, float>{0.f, -0.1f}.cwMul(
+                        static_cast<math::Position<2, GLfloat>>(this->mAppInterface->getFramebufferSize())/2.f),
+            0.f};
 
 
-        std::ostringstream playerText;
-        playerText << "P" << aSlot.mIndex + 1 << " "
-                   << aHud.mScore;
+            std::ostringstream playerText;
+            playerText << "P" << slot.mIndex + 1 << " "
+                    << aHud.getScore();
 
-        state->mTextScreenEntities.insert(
-            aHandle.id(),
-            visu::Text{
-                .mPosition_world = position_screenPix,
-                .mScaling = math::Size<3, float>{1.f, 1.f, 1.f}, 
-                .mOrientation = Quat_f::Identity(),
-                .mString = playerText.str(),
-                .mFont = font,
-                .mColor = aSlot.mColor,
-            });
+            state->mTextScreenEntities.insert(
+                aHandle.id(),
+                visu::Text{
+                    .mPosition_world = position_screenPix,
+                    .mScaling = math::Size<3, float>{1.f, 1.f, 1.f}, 
+                    .mOrientation = Quat_f::Identity(),
+                    .mString = playerText.str(),
+                    .mFont = font,
+                    .mColor = slot.mColor,
+                });
 
-        state->mTextScreenEntities.insert(
-            aHandle.id() + 100,
-            visu::Text{
-                .mPosition_world = position_screenPix + powerupOffset.as<math::Vec>(),
-                .mScaling = math::Size<3, float>{0.3f, 0.3f, 0.3f}, 
-                .mOrientation = Quat_f::Identity(),
-                .mString = aHud.mPowerUpName,
-                .mFont = font,
-                .mColor = aSlot.mColor,
-            });
+            state->mTextScreenEntities.insert(
+                aHandle.id() + 100,
+                visu::Text{
+                    .mPosition_world = position_screenPix + powerupOffset.as<math::Vec>(),
+                    .mScaling = math::Size<3, float>{0.3f, 0.3f, 0.3f}, 
+                    .mOrientation = Quat_f::Identity(),
+                    .mString = aHud.getPowerUpName(),
+                    .mFont = font,
+                    .mColor = slot.mColor,
+                });
 
-    });
+        });
 
     state->mCamera = mSystemOrbitalCamera->getCamera();
 

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -320,9 +320,11 @@ void SnacGame::drawDebugUi(snac::ConfigurableSettings & aSettings,
                 {
                     Phase pathfinding;
                     Entity pEntity = *pathfinder.get(pathfinding);
-                    addMeshGeoNode(pathfinding, mGameContext, pEntity, 
+                    addMeshGeoNode(mGameContext,
+                                   pEntity, 
                                    "CUBE", "effects/Mesh.sefx",
-                                   {7.f, 7.f, gPillHeight}, 1.f,
+                                   {7.f, 7.f, gPillHeight},
+                                   1.f,
                                    {0.5f, 0.5f, 0.5f});
                     pEntity.add(component::AllowedMovement{
                         .mWindow = gOtherTurningZoneHalfWidth});

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -128,6 +128,10 @@ void SnacGame::drawDebugUi(snac::ConfigurableSettings & aSettings,
 
         mImguiDisplays.display();
 
+        if (mImguiDisplays.mShowSceneEditor)
+        {
+            mSceneEditor.showEditor(mStateMachine->getCurrentScene()->mSceneRoot);
+        }
         if (mImguiDisplays.mShowPlayerInfo)
         {
             ent::Phase update;

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -497,48 +497,6 @@ std::unique_ptr<visu::GraphicState> SnacGame::makeGraphicState()
     auto font =
         mGameContext.mResources.getFont("fonts/FredokaOne-Regular.ttf", 120);
 
-    mQueryHuds.get(nomutation)
-        .each([&font, &state, this]
-              (ent::Handle<ent::Entity> aHandle,
-               const component::PlayerHud & aHud)
-        {
-            const component::PlayerSlot & slot = aHud.getSlot();
-            math::Position<3, float> position_screenPix{component::gHudPositions.at(slot.mIndex).cwMul(
-                        static_cast<math::Position<2, GLfloat>>(this->mAppInterface->getFramebufferSize())/2.f),
-            0.f};
-            math::Position<3, float> powerupOffset{math::Position<2, float>{0.f, -0.1f}.cwMul(
-                        static_cast<math::Position<2, GLfloat>>(this->mAppInterface->getFramebufferSize())/2.f),
-            0.f};
-
-
-            std::ostringstream playerText;
-            playerText << "P" << slot.mIndex + 1 << " "
-                    << aHud.getScore();
-
-            state->mTextScreenEntities.insert(
-                aHandle.id(),
-                visu::Text{
-                    .mPosition_world = position_screenPix,
-                    .mScaling = math::Size<3, float>{1.f, 1.f, 1.f}, 
-                    .mOrientation = Quat_f::Identity(),
-                    .mString = playerText.str(),
-                    .mFont = font,
-                    .mColor = slot.mColor,
-                });
-
-            state->mTextScreenEntities.insert(
-                aHandle.id() + 100,
-                visu::Text{
-                    .mPosition_world = position_screenPix + powerupOffset.as<math::Vec>(),
-                    .mScaling = math::Size<3, float>{0.3f, 0.3f, 0.3f}, 
-                    .mOrientation = Quat_f::Identity(),
-                    .mString = aHud.getPowerUpName(),
-                    .mFont = font,
-                    .mColor = slot.mColor,
-                });
-
-        });
-
     state->mCamera = mSystemOrbitalCamera->getCamera();
 
     state->mDebugDrawList = snac::DebugDrawer::EndFrame();

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
@@ -3,6 +3,7 @@
 #include "EntityWrap.h"
 #include "GameContext.h"
 #include "Renderer.h"
+#include "ImguiSceneEditor.h"
 #include "snacman/simulations/snacgame/component/PlayerHud.h"
 #include "snacman/simulations/snacgame/component/PlayerSlot.h"
 
@@ -45,6 +46,7 @@ namespace visu { struct GraphicState; }
 
 struct ImguiDisplays
 {
+    bool mShowSceneEditor = false;
     bool mShowMappings = false;
     bool mShowSimulationDelta = false;
     bool mShowImguiDemo = false;
@@ -61,6 +63,7 @@ struct ImguiDisplays
     void display()
     {
         ImGui::Begin("Debug windows");
+        ImGui::Checkbox("Scene editor",  &mShowSceneEditor);
         ImGui::Checkbox("Speed control", &mSpeedControl);
         ImGui::Checkbox("Mappings", &mShowMappings);
         ImGui::Checkbox("Simulation delta", &mShowSimulationDelta);
@@ -140,6 +143,7 @@ private:
 
     imguiui::ImguiUi & mImguiUi;
     ImguiDisplays mImguiDisplays;
+    SceneEditor mSceneEditor;
 
     snac::Time mSimulationTime;
 };

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
@@ -136,7 +136,7 @@ private:
     EntityWrap<ent::Query<component::GlobalPose, component::VisualModel>> mQueryRenderable;
     EntityWrap<ent::Query<component::Text, component::GlobalPose>> mQueryTextWorld;
     EntityWrap<ent::Query<component::Text, component::PoseScreenSpace>> mQueryTextScreen;
-    EntityWrap<ent::Query<component::PlayerHud, component::PlayerSlot>> mQueryHuds;
+    EntityWrap<ent::Query<component::PlayerHud>> mQueryHuds;
 
     imguiui::ImguiUi & mImguiUi;
     ImguiDisplays mImguiDisplays;

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.cpp
@@ -1,9 +1,6 @@
 #include "PlayerHud.h"
 
-
-#include "PlayerLifeCycle.h"
 #include "PlayerPowerUp.h"
-#include "PlayerSlot.h"
 
 
 namespace ad {
@@ -11,25 +8,9 @@ namespace snacgame {
 namespace component {
 
 
-int PlayerHud::getScore() const
+const char * getPowerUpName(ent::Handle<ent::Entity> aPlayer)
 {
-    auto playerView = mPlayer.get();
-    assert(playerView && playerView->has<PlayerLifeCycle>());
-    return playerView->get<PlayerLifeCycle>().mScore;
-}
-
-
-const PlayerSlot & PlayerHud::getSlot() const
-{
-    auto playerView = mPlayer.get();
-    assert(playerView && playerView->has<PlayerSlot>());
-    return playerView->get<PlayerSlot>();
-}
-
-
-const char * PlayerHud::getPowerUpName() const
-{
-    auto playerView = mPlayer.get();
+    auto playerView = aPlayer.get();
     assert(playerView);
     
     // In the current design, the PlayerPowerUp component is only present while a power up is picked up

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.cpp
@@ -1,0 +1,50 @@
+#include "PlayerHud.h"
+
+
+#include "PlayerLifeCycle.h"
+#include "PlayerPowerUp.h"
+#include "PlayerSlot.h"
+
+
+namespace ad {
+namespace snacgame {
+namespace component {
+
+
+int PlayerHud::getScore() const
+{
+    auto playerView = mPlayer.get();
+    assert(playerView && playerView->has<PlayerLifeCycle>());
+    return playerView->get<PlayerLifeCycle>().mScore;
+}
+
+
+const PlayerSlot & PlayerHud::getSlot() const
+{
+    auto playerView = mPlayer.get();
+    assert(playerView && playerView->has<PlayerSlot>());
+    return playerView->get<PlayerSlot>();
+}
+
+
+const char * PlayerHud::getPowerUpName() const
+{
+    auto playerView = mPlayer.get();
+    assert(playerView);
+    
+    // In the current design, the PlayerPowerUp component is only present while a power up is picked up
+    if(playerView->has<PlayerPowerUp>())
+    {
+        return component::gPowerUpName.at(
+            static_cast<std::size_t>(playerView->get<PlayerPowerUp>().mType));
+    }
+    else
+    {
+        return "";
+    }
+}
+
+
+} // namespace component
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -43,9 +43,9 @@ const std::array<math::Quaternion<float>, 4> gHudOrientationsWorld{
 };
 
 const std::array<const char *, static_cast<unsigned int>(PowerUpType::_End)> gPowerUpName{
-    "Donut Seeking dog",
+    "Seeking dog",
     "Donut swapper",
-    "Donut controlled missile"
+    "Controlled missile"
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -53,6 +53,7 @@ const char * getPowerUpName(ent::Handle<ent::Entity> aPlayer);
 struct PlayerHud
 {
     ent::Handle<ent::Entity> mScoreText;
+    ent::Handle<ent::Entity> mRoundText;
     ent::Handle<ent::Entity> mPowerupText;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../GameParameters.h"
 #include "snacman/simulations/snacgame/component/PowerUp.h"
 
 #include <entity/Entity.h>
@@ -15,11 +16,19 @@ namespace component {
 
 struct PlayerSlot;
 
-const std::array<math::Position<2, float>, 4> gHudPositions{
+// Note: Unused since we moved to bills
+const std::array<math::Position<2, float>, 4> gHudPositionsScreenspace{
     math::Position<2, float>{-0.95f, 0.5f},
     math::Position<2, float>{-0.95f, -0.5f},
     math::Position<2, float>{0.7f, 0.5f},
     math::Position<2, float>{0.7f, -0.5f},
+};
+
+const std::array<math::Position<3, float>, 4> gHudPositionsWorld{
+    math::Position<3, float>{-6.f, 11.f, gPlayerHeight},
+    math::Position<3, float>{-6.f,  2.f, gPlayerHeight},
+    math::Position<3, float>{18.f, 11.f, gPlayerHeight},
+    math::Position<3, float>{18.f,  2.f, gPlayerHeight},
 };
 
 const std::array<const char *, static_cast<unsigned int>(PowerUpType::_End)> gPowerUpName{

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -25,10 +25,21 @@ const std::array<math::Position<2, float>, 4> gHudPositionsScreenspace{
 };
 
 const std::array<math::Position<3, float>, 4> gHudPositionsWorld{
-    math::Position<3, float>{-7.f, 11.f, gPlayerHeight},
-    math::Position<3, float>{-7.f,  2.f, gPlayerHeight},
-    math::Position<3, float>{19.f, 11.f, gPlayerHeight},
-    math::Position<3, float>{19.f,  2.f, gPlayerHeight},
+    math::Position<3, float>{-6.5f, 10.f, gPlayerHeight},
+    math::Position<3, float>{-4.0f,  1.f, gPlayerHeight},
+    math::Position<3, float>{20.5f, 10.f, gPlayerHeight},
+    math::Position<3, float>{18.5f,  1.f, gPlayerHeight},
+};
+
+namespace {
+    const auto axis = math::UnitVec<3, float>::MakeFromUnitLength({0.f, 0.f, 1.f});
+}
+
+const std::array<math::Quaternion<float>, 4> gHudOrientationsWorld{
+    math::Quaternion<float>{axis, math::Degree<float>{ -5.f}},
+    math::Quaternion<float>{axis, math::Degree<float>{ 20.f}},
+    math::Quaternion<float>{axis, math::Degree<float>{  5.f}},
+    math::Quaternion<float>{axis, math::Degree<float>{-20.f}},
 };
 
 const std::array<const char *, static_cast<unsigned int>(PowerUpType::_End)> gPowerUpName{

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -1,12 +1,20 @@
 #pragma once
 
-#include "math/Vector.h"
 #include "snacman/simulations/snacgame/component/PowerUp.h"
 
+#include <entity/Entity.h>
+
+#include <math/Vector.h>
+
 #include <array>
+
+
 namespace ad {
 namespace snacgame {
 namespace component {
+
+struct PlayerSlot;
+
 const std::array<math::Position<2, float>, 4> gHudPositions{
     math::Position<2, float>{-0.95f, 0.5f},
     math::Position<2, float>{-0.95f, -0.5f},
@@ -20,11 +28,20 @@ const std::array<const char *, static_cast<unsigned int>(PowerUpType::_End)> gPo
     "Donut controlled missile"
 };
 
+
 struct PlayerHud
 {
-    unsigned int mScore;
-    const char * mPowerUpName = "";
+    int getScore() const;
+    const PlayerSlot & getSlot() const;
+    const char * getPowerUpName() const;
+
+    ent::Handle<ent::Entity> mPlayer;
+    // Note: It is not convenient to populate this at the moment the powerup is picked up
+    // since the PlayerHud is not part of the Player anymore.
+    //const char * mPowerUpName = "";
 };
+
+
 } // namespace component
 } // namespace snacgame
 } // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -27,8 +27,8 @@ const std::array<math::Position<2, float>, 4> gHudPositionsScreenspace{
 const std::array<math::Position<3, float>, 4> gHudPositionsWorld{
     math::Position<3, float>{-7.f, 11.f, gPlayerHeight},
     math::Position<3, float>{-7.f,  2.f, gPlayerHeight},
-    math::Position<3, float>{18.f, 11.f, gPlayerHeight},
-    math::Position<3, float>{18.f,  2.f, gPlayerHeight},
+    math::Position<3, float>{19.f, 11.f, gPlayerHeight},
+    math::Position<3, float>{19.f,  2.f, gPlayerHeight},
 };
 
 const std::array<const char *, static_cast<unsigned int>(PowerUpType::_End)> gPowerUpName{

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -25,8 +25,8 @@ const std::array<math::Position<2, float>, 4> gHudPositionsScreenspace{
 };
 
 const std::array<math::Position<3, float>, 4> gHudPositionsWorld{
-    math::Position<3, float>{-6.f, 11.f, gPlayerHeight},
-    math::Position<3, float>{-6.f,  2.f, gPlayerHeight},
+    math::Position<3, float>{-7.f, 11.f, gPlayerHeight},
+    math::Position<3, float>{-7.f,  2.f, gPlayerHeight},
     math::Position<3, float>{18.f, 11.f, gPlayerHeight},
     math::Position<3, float>{18.f,  2.f, gPlayerHeight},
 };
@@ -43,6 +43,9 @@ struct PlayerHud
     int getScore() const;
     const PlayerSlot & getSlot() const;
     const char * getPowerUpName() const;
+
+    ent::Handle<ent::Entity> mScoreText;
+    ent::Handle<ent::Entity> mPowerupText;
 
     ent::Handle<ent::Entity> mPlayer;
     // Note: It is not convenient to populate this at the moment the powerup is picked up

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerHud.h
@@ -14,7 +14,6 @@ namespace ad {
 namespace snacgame {
 namespace component {
 
-struct PlayerSlot;
 
 // Note: Unused since we moved to bills
 const std::array<math::Position<2, float>, 4> gHudPositionsScreenspace{
@@ -31,6 +30,7 @@ const std::array<math::Position<3, float>, 4> gHudPositionsWorld{
     math::Position<3, float>{18.5f,  1.f, gPlayerHeight},
 };
 
+// TODO Why is the rotation in the plane of the table around Z and not Y?
 namespace {
     const auto axis = math::UnitVec<3, float>::MakeFromUnitLength({0.f, 0.f, 1.f});
 }
@@ -48,20 +48,12 @@ const std::array<const char *, static_cast<unsigned int>(PowerUpType::_End)> gPo
     "Controlled missile"
 };
 
+const char * getPowerUpName(ent::Handle<ent::Entity> aPlayer);
 
 struct PlayerHud
 {
-    int getScore() const;
-    const PlayerSlot & getSlot() const;
-    const char * getPowerUpName() const;
-
     ent::Handle<ent::Entity> mScoreText;
     ent::Handle<ent::Entity> mPowerupText;
-
-    ent::Handle<ent::Entity> mPlayer;
-    // Note: It is not convenient to populate this at the moment the powerup is picked up
-    // since the PlayerHud is not part of the Player anymore.
-    //const char * mPowerUpName = "";
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
@@ -15,6 +15,14 @@ constexpr float gBaseHitStunDuration = 2.f;
 
 struct PlayerLifeCycle
 {
+    void reset()
+    {
+        // Do not lose the hud reference though
+        auto hudCopy = std::move(mHud);
+        *this = PlayerLifeCycle{};
+        mHud = std::move(hudCopy);
+    }
+
     int mScore = 0;
     bool mIsAlive = false;
     float mTimeToRespawn = 0;

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
@@ -15,21 +15,25 @@ constexpr float gBaseHitStunDuration = 2.f;
 
 struct PlayerLifeCycle
 {
-    void reset()
+    void resetBetweenRound()
     {
-        // Do not lose the hud reference though
-        auto hudCopy = std::move(mHud);
-        *this = PlayerLifeCycle{};
-        mHud = std::move(hudCopy);
+        // Do not lose the hud reference nor the count of rounds won
+        mScore = 0;
+        mIsAlive = false;
+        mTimeToRespawn = 0;
+        mInvulFrameCounter = 0;
+        mHitStun = 0;
     }
 
     int mScore = 0;
     bool mIsAlive = false;
     float mTimeToRespawn = 0;
     float mInvulFrameCounter = 0;
-
     // Hit stun
     float mHitStun = 0;
+
+    // Kept alive between rounds
+    int mRoundsWon = 0;
 
     // The HUD showing player informations (score, power-up)
     std::optional<ent::Handle<ent::Entity>> mHud;

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
@@ -24,7 +24,7 @@ struct PlayerLifeCycle
     float mHitStun = 0;
 
     // The HUD showing player informations (score, power-up)
-    ent::Handle<ent::Entity> mHud;
+    std::optional<ent::Handle<ent::Entity>> mHud;
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
@@ -1,6 +1,9 @@
 #pragma once
 
 
+#include <entity/Entity.h>
+
+
 namespace ad {
 namespace snacgame {
 namespace component {
@@ -18,7 +21,10 @@ struct PlayerLifeCycle
     float mInvulFrameCounter = 0;
 
     // Hit stun
-    float mHitStun = 0; 
+    float mHitStun = 0;
+
+    // The HUD showing player informations (score, power-up)
+    ent::Handle<ent::Entity> mHud;
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/PlayerLifeCycle.h
@@ -12,7 +12,7 @@ constexpr float gBaseHitStunDuration = 2.f;
 
 struct PlayerLifeCycle
 {
-    int mPoints = 0;
+    int mScore = 0;
     bool mIsAlive = false;
     float mTimeToRespawn = 0;
     float mInvulFrameCounter = 0;

--- a/src/apps/snacman/snacman/simulations/snacgame/component/SceneNode.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/SceneNode.h
@@ -7,11 +7,20 @@ namespace component {
 
 struct SceneNode
 {
+    bool hasChild() const
+    { return mFirstChild.has_value(); }
+
+    bool hasName() const
+    { return !mName.empty(); }
+
     std::optional<ent::Handle<ent::Entity>> mFirstChild;
     std::optional<ent::Handle<ent::Entity>> mNextChild;
     std::optional<ent::Handle<ent::Entity>> mPrevChild;
     std::optional<ent::Handle<ent::Entity>> mParent;
+    // TODO There should not be a name here directly, but this makes debugging easier
+    std::string mName;
 };
+
 
 }
 } // namespace snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
@@ -222,12 +222,12 @@ std::optional<Transition> GameScene::update(const snac::Time & aTime, RawInput &
 
     mSystems.get(update)->get<system::SceneGraphResolver>().update();
 
-    mSystems.get(update)->get<system::RoundMonitor>().update();
-    mSystems.get(update)->get<system::PlayerSpawner>().update((float)aTime.mDeltaSeconds);
-
     mSystems.get(update)->get<system::PortalManagement>().postGraphUpdate();
     mSystems.get(update)->get<system::PowerUpUsage>().update((float)aTime.mDeltaSeconds);
     mSystems.get(update)->get<system::EatPill>().update();
+
+    mSystems.get(update)->get<system::RoundMonitor>().update();
+    mSystems.get(update)->get<system::PlayerSpawner>().update((float)aTime.mDeltaSeconds);
 
     mSystems.get(update)->get<system::Debug_BoundingBoxes>().update();
 

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
@@ -222,12 +222,12 @@ std::optional<Transition> GameScene::update(const snac::Time & aTime, RawInput &
 
     mSystems.get(update)->get<system::SceneGraphResolver>().update();
 
+    mSystems.get(update)->get<system::RoundMonitor>().update();
+    mSystems.get(update)->get<system::PlayerSpawner>().update((float)aTime.mDeltaSeconds);
+
     mSystems.get(update)->get<system::PortalManagement>().postGraphUpdate();
     mSystems.get(update)->get<system::PowerUpUsage>().update((float)aTime.mDeltaSeconds);
     mSystems.get(update)->get<system::EatPill>().update();
-
-    mSystems.get(update)->get<system::RoundMonitor>().update();
-    mSystems.get(update)->get<system::PlayerSpawner>().update((float)aTime.mDeltaSeconds);
 
     mSystems.get(update)->get<system::Debug_BoundingBoxes>().update();
 

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
@@ -99,6 +99,7 @@ GameScene::GameScene(const std::string & aName,
     mTiles{mGameContext.mWorld},
     mSlots{mGameContext.mWorld},
     mPlayers{mGameContext.mWorld},
+    mHuds{mGameContext.mWorld},
     mPathfinders{mGameContext.mWorld}
 {
     createLevel(mGameContext,
@@ -125,6 +126,11 @@ void GameScene::teardown(RawInput & aInput)
                                  component::PlayerSlot & aSlot,
                                  component::Controller & aController) {
             removePlayerFromGame(destroy, aHandle);
+        });
+
+        mHuds.each([&destroy](EntHandle aHandle)
+        {
+            aHandle.get(destroy)->erase();
         });
     }
     {

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
@@ -99,7 +99,6 @@ GameScene::GameScene(const std::string & aName,
     mTiles{mGameContext.mWorld},
     mSlots{mGameContext.mWorld},
     mPlayers{mGameContext.mWorld},
-    mHuds{mGameContext.mWorld},
     mPathfinders{mGameContext.mWorld}
 {
     createLevel(mGameContext,
@@ -126,11 +125,6 @@ void GameScene::teardown(RawInput & aInput)
                                  component::PlayerSlot & aSlot,
                                  component::Controller & aController) {
             removePlayerFromGame(destroy, aHandle);
-        });
-
-        mHuds.each([&destroy](EntHandle aHandle)
-        {
-            aHandle.get(destroy)->erase();
         });
     }
     {

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.h
@@ -5,6 +5,7 @@
 #include "../component/Controller.h"
 #include "../component/LevelTags.h"
 #include "../component/PathToOnGrid.h"
+#include "../component/PlayerHud.h"
 #include "../component/PlayerSlot.h"
 
 #include <entity/EntityManager.h>
@@ -47,6 +48,7 @@ private:
     ent::Query<component::LevelEntity> mTiles;
     ent::Query<component::PlayerSlot> mSlots;
     ent::Query<component::PlayerSlot, component::Controller> mPlayers;
+    ent::Query<component::PlayerHud> mHuds;
     ent::Query<component::PathToOnGrid> mPathfinders;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.h
@@ -48,7 +48,6 @@ private:
     ent::Query<component::LevelEntity> mTiles;
     ent::Query<component::PlayerSlot> mSlots;
     ent::Query<component::PlayerSlot, component::Controller> mPlayers;
-    ent::Query<component::PlayerHud> mHuds;
     ent::Query<component::PathToOnGrid> mPathfinders;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -53,11 +53,17 @@ void EatPill::update()
                 aLifeCycle.mScore += gPointPerPill;
 
                 // Update the text showing the score in the hud.
-                auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
-                snac::getComponent<component::Text>(playerHud.mScoreText)
-                        .mString = std::to_string(aLifeCycle.mScore);
-                snac::getComponent<component::Text>(playerHud.mRoundText)
-                        .mString = std::to_string(aLifeCycle.mRoundsWon);
+                // TODO code smell, this is defensive programming because sometimes we get there without the HUD
+                // (when the round monitor removed the hud but the spawner did not populate it yet)
+                // This is a great way to increase cyclomatic complexity
+                if(aLifeCycle.mHud && aLifeCycle.mHud->isValid())
+                {
+                    auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
+                    snac::getComponent<component::Text>(playerHud.mScoreText)
+                            .mString = std::to_string(aLifeCycle.mScore);
+                    snac::getComponent<component::Text>(playerHud.mRoundText)
+                            .mString = std::to_string(aLifeCycle.mRoundsWon);
+                }
             }
         });
     });

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -52,10 +52,18 @@ void EatPill::update()
         });
     });
 
-    mHuds.each([](const component::PlayerHud & aPlayerHud, component::Text & aText)
+    mHuds.each([](const component::PlayerHud & aPlayerHud)
     {
-        aText.mString = "P" + std::to_string(aPlayerHud.getSlot().mIndex + 1) 
+        auto scoreView = aPlayerHud.mScoreText.get();
+        assert(scoreView && scoreView->has<component::Text>());
+        auto & text = scoreView->get<component::Text>();
+
+        text.mString = "P" + std::to_string(aPlayerHud.getSlot().mIndex + 1) 
                         + " " + std::to_string(aPlayerHud.getScore());
+        
+        auto powerupView = aPlayerHud.mPowerupText.get();
+        assert(powerupView && powerupView->has<component::Text>());
+        powerupView->get<component::Text>().mString = aPlayerHud.getPowerUpName();
     });
 
     mPills.each([](const component::GlobalPose & aPillPose, const component::Collision & aPillCol) {

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -15,12 +15,15 @@
 namespace ad {
 namespace snacgame {
 namespace system {
+
+
 void EatPill::update()
 {
     TIME_RECURRING_CLASSFUNC(Main);
     mPlayers.each([this](const component::GlobalPose & aPlayerGeo,
                          component::Collision aPlayerCol,
-                         component::PlayerHud & aHud) {
+                         component::PlayerLifeCycle & aPlayerLifeCycle)
+    {
         ent::Phase eatPillUpdate;
         Box_f playerHitbox = component::transformHitbox(aPlayerGeo.mPosition,
                                                         aPlayerCol.mHitbox);
@@ -33,17 +36,18 @@ void EatPill::update()
             playerHitbox
         );
 
-        mPills.each([&eatPillUpdate, &playerHitbox,
-                     &aHud](ent::Handle<ent::Entity> aHandle,
-                             const component::GlobalPose & aPillGeo,
-                             const component::Collision & aPillCol) {
+        mPills.each([&eatPillUpdate, &playerHitbox, &aPlayerLifeCycle]
+                    (ent::Handle<ent::Entity> aHandle,
+                     const component::GlobalPose & aPillGeo,
+                     const component::Collision & aPillCol) 
+        {
             Box_f pillHitbox = component::transformHitbox(aPillGeo.mPosition,
                                                           aPillCol.mHitbox);
 
             if (component::collideWithSat(pillHitbox, playerHitbox))
             {
                 aHandle.get(eatPillUpdate)->erase();
-                aHud.mScore = gPointPerPill;
+                aPlayerLifeCycle.mScore += gPointPerPill;
             }
         });
     });
@@ -60,6 +64,8 @@ void EatPill::update()
                 pillHitbox);
     });
 }
+
+
 } // namespace system
 } // namespace snacgame
 } // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -52,6 +52,12 @@ void EatPill::update()
         });
     });
 
+    mHuds.each([](const component::PlayerHud & aPlayerHud, component::Text & aText)
+    {
+        aText.mString = "P" + std::to_string(aPlayerHud.getSlot().mIndex + 1) 
+                        + " " + std::to_string(aPlayerHud.getScore());
+    });
+
     mPills.each([](const component::GlobalPose & aPillPose, const component::Collision & aPillCol) {
         Box_f pillHitbox = component::transformHitbox(aPillPose.mPosition,
                                                       aPillCol.mHitbox);

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -56,6 +56,8 @@ void EatPill::update()
                 auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
                 snac::getComponent<component::Text>(playerHud.mScoreText)
                         .mString = std::to_string(aLifeCycle.mScore);
+                snac::getComponent<component::Text>(playerHud.mRoundText)
+                        .mString = std::to_string(aLifeCycle.mRoundsWon);
             }
         });
     });

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -53,7 +53,7 @@ void EatPill::update()
                 aLifeCycle.mScore += gPointPerPill;
 
                 // Update the text showing the score in the hud.
-                auto & playerHud = snac::getComponent<component::PlayerHud>(aLifeCycle.mHud);
+                auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
                 snac::getComponent<component::Text>(playerHud.mScoreText)
                         .mString = std::to_string(aLifeCycle.mScore);
             }

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.h
@@ -22,7 +22,9 @@ class EatPill
 {
 public:
     EatPill(GameContext & aGameContext) :
-        mPlayers{aGameContext.mWorld}, mPills{aGameContext.mWorld}
+        mPlayers{aGameContext.mWorld},
+        mPills{aGameContext.mWorld},
+        mHuds{aGameContext.mWorld}
     {}
 
     void update();
@@ -34,6 +36,8 @@ private:
         mPlayers;
     ent::Query<component::GlobalPose, component::Collision, component::Pill>
         mPills;
+    ent::Query<component::PlayerHud, component::Text>
+        mHuds;
 };
 
 } // namespace system

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.h
@@ -36,7 +36,7 @@ private:
         mPlayers;
     ent::Query<component::GlobalPose, component::Collision, component::Pill>
         mPills;
-    ent::Query<component::PlayerHud, component::Text>
+    ent::Query<component::PlayerHud>
         mHuds;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.h
@@ -30,7 +30,7 @@ public:
 private:
     ent::Query<component::GlobalPose,
                component::Collision,
-               component::PlayerHud>
+               component::PlayerLifeCycle>
         mPlayers;
     ent::Query<component::GlobalPose, component::Collision, component::Pill>
         mPills;

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
@@ -20,6 +20,7 @@ void PlayerSpawner::update(float aDelta)
 
     mSpawnable.each([this, &aDelta](EntHandle aPlayerHandle,
                                     component::PlayerLifeCycle & aPlayer,
+                                    component::PlayerMoveState & aMoveState,
                                     component::PlayerSlot & aSlot,
                                     component::Geometry & aPlayerGeometry) 
     {
@@ -29,7 +30,7 @@ void PlayerSpawner::update(float aDelta)
             } else {
                 // TODO: Needs an alg to choose the right spawner if there are
                 // many spawner
-                mSpawner.each([this, aPlayerHandle, &aPlayer, &aSlot, &aPlayerGeometry]
+                mSpawner.each([this, aPlayerHandle, &aPlayer, &aMoveState, &aSlot, &aPlayerGeometry]
                               (component::Spawner & aSpawner) 
                 {
                     if (!aPlayer.mIsAlive && !aSpawner.mSpawnedPlayer) 
@@ -40,6 +41,7 @@ void PlayerSpawner::update(float aDelta)
                         aPlayer.mHud = createHudBillpad(*mGameContext, aSlot);
                         aPlayerGeometry.mPosition = aSpawner.mSpawnPosition;
                         aSpawner.mSpawnedPlayer = true;
+                        aMoveState.mMoveState = gPlayerMoveFlagNone;
                         insertEntityInScene(aPlayerHandle, *mGameContext->mLevel);
                     }
                 });

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
@@ -1,5 +1,6 @@
 #include "PlayerSpawner.h"
 
+#include "../Entities.h"
 #include "../SceneGraph.h"
 #include "../typedef.h"
 
@@ -17,19 +18,26 @@ void PlayerSpawner::update(float aDelta)
 {
     TIME_RECURRING_CLASSFUNC(Main);
 
-    mSpawnable.each([this, &aDelta](EntHandle aPlayerHandle, component::PlayerLifeCycle & aPlayer,
-                                   component::Geometry & aPlayerGeometry) {
+    mSpawnable.each([this, &aDelta](EntHandle aPlayerHandle,
+                                    component::PlayerLifeCycle & aPlayer,
+                                    component::PlayerSlot & aSlot,
+                                    component::Geometry & aPlayerGeometry) 
+    {
         if (!aPlayer.mIsAlive) {
             if (aPlayer.mTimeToRespawn < 0) {
                 aPlayer.mTimeToRespawn -= aDelta;
             } else {
                 // TODO: Needs an alg to choose the right spawner if there are
                 // many spawner
-                mSpawner.each([this, aPlayerHandle, &aPlayer, &aPlayerGeometry](component::Spawner & aSpawner) {
-                    if (!aPlayer.mIsAlive && !aSpawner.mSpawnedPlayer) {
+                mSpawner.each([this, aPlayerHandle, &aPlayer, &aSlot, &aPlayerGeometry]
+                              (component::Spawner & aSpawner) 
+                {
+                    if (!aPlayer.mIsAlive && !aSpawner.mSpawnedPlayer) 
+                    {
                         aPlayer.mIsAlive = true;
                         aPlayer.mTimeToRespawn = component::gBaseTimeToRespawn;
                         aPlayer.mInvulFrameCounter = component::gBaseInvulFrameDuration;
+                        aPlayer.mHud = createHudBillpad(*mGameContext, aSlot);
                         aPlayerGeometry.mPosition = aSpawner.mSpawnPosition;
                         aSpawner.mSpawnedPlayer = true;
                         insertEntityInScene(aPlayerHandle, *mGameContext->mLevel);

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.h
@@ -2,6 +2,7 @@
 
 #include "../GameContext.h"
 #include "../component/PlayerLifeCycle.h"
+#include "../component/PlayerMoveState.h"
 #include "../component/PlayerSlot.h"
 #include "../component/Spawner.h"
 #include "../component/Geometry.h"
@@ -27,7 +28,10 @@ public:
 
 private:
     GameContext * mGameContext;
-    ent::Query<component::PlayerLifeCycle, component::PlayerSlot, component::Geometry> mSpawnable;
+    ent::Query<component::PlayerLifeCycle,
+               component::PlayerSlot,
+               component::Geometry,
+               component::PlayerMoveState> mSpawnable;
     ent::Query<component::Spawner> mSpawner;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.h
@@ -2,6 +2,7 @@
 
 #include "../GameContext.h"
 #include "../component/PlayerLifeCycle.h"
+#include "../component/PlayerSlot.h"
 #include "../component/Spawner.h"
 #include "../component/Geometry.h"
 
@@ -23,9 +24,10 @@ public:
     {}
 
     void update(float aDelta);
+
 private:
     GameContext * mGameContext;
-    ent::Query<component::PlayerLifeCycle, component::Geometry> mSpawnable;
+    ent::Query<component::PlayerLifeCycle, component::PlayerSlot, component::Geometry> mSpawnable;
     ent::Query<component::Spawner> mSpawner;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PortalManagement.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PortalManagement.cpp
@@ -38,7 +38,7 @@ void PortalManagement::preGraphUpdate()
                         Entity portal = *newPortalImage.get(addPortalImage);
                         Vec2 relativePos = aPortal.mMirrorSpawnPosition.xy()
                                            - aPortalData.mCurrentPortalPos;
-                        addMeshGeoNode(addPortalImage, *mGameContext, portal,
+                        addMeshGeoNode(*mGameContext, portal,
                                        "models/donut/donut.gltf",
                                        "effects/MeshTextures.sefx",
                                        {relativePos.x(), relativePos.y(), 0.f},

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
@@ -4,6 +4,7 @@
 #include "snacman/simulations/snacgame/component/SceneNode.h"
 #include "snacman/simulations/snacgame/component/Speed.h"
 #include "snacman/simulations/snacgame/GameParameters.h"
+#include <snacman/EntityUtilities.h>
 
 #include "../component/AllowedMovement.h"
 #include "../component/LevelData.h"
@@ -11,6 +12,8 @@
 #include "../component/PlayerLifeCycle.h"
 #include "../component/PlayerPowerUp.h"
 #include "../component/PowerUp.h"
+#include "../component/Text.h"
+
 #include "../Entities.h"
 #include "../InputConstants.h"
 #include "../SceneGraph.h"
@@ -28,6 +31,8 @@
 namespace ad {
 namespace snacgame {
 namespace system {
+
+
 void PowerUpUsage::update(float aDelta)
 {
     TIME_RECURRING_CLASSFUNC(Main);
@@ -92,6 +97,7 @@ void PowerUpUsage::update(float aDelta)
                         createPlayerPowerUp(*mGameContext, aPowerup.mType);
                     component::PlayerPowerUp newPowerup = {
                         .mPowerUp = playerPowerup, .mType = aPowerup.mType};
+                    
                     insertEntityInScene(playerPowerup,
                                         aPlayer.get(powerup)
                                             ->get<component::PlayerModel>()
@@ -372,6 +378,15 @@ void PowerUpUsage::update(float aDelta)
             math::Vec<3, float> mForward =
                 aGeo.mOrientation.rotate(math::Vec<3, float>{0.f, 1.f, 0.f});
             aSpeed.mSpeed = mForward * 2.f;
+    });
+
+                    
+    // Update power-up name in HUD
+    mPlayers.each([](ent::Handle<ent::Entity> aPlayer, component::PlayerLifeCycle & aLifeCycle)
+    {
+        auto & playerHud = snac::getComponent<component::PlayerHud>(aLifeCycle.mHud);
+        snac::getComponent<component::Text>(playerHud.mPowerupText)
+                .mString = component::getPowerUpName(aPlayer);
     });
 }
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
@@ -63,7 +63,6 @@ void PowerUpUsage::update(float aDelta)
     // Powerup pickup phase
     mPlayers.each([&](EntHandle aPlayer,
                       const component::GlobalPose & aPlayerPose,
-                      component::PlayerHud & aHud,
                       const component::PlayerSlot & aSlot,
                       component::Collision aPlayerCol) {
         const Box_f playerHitbox = component::transformHitbox(
@@ -93,8 +92,6 @@ void PowerUpUsage::update(float aDelta)
                         createPlayerPowerUp(*mGameContext, aPowerup.mType);
                     component::PlayerPowerUp newPowerup = {
                         .mPowerUp = playerPowerup, .mType = aPowerup.mType};
-                    aHud.mPowerUpName = component::gPowerUpName.at(
-                        static_cast<std::size_t>(aPowerup.mType));
                     insertEntityInScene(playerPowerup,
                                         aPlayer.get(powerup)
                                             ->get<component::PlayerModel>()

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
@@ -384,7 +384,7 @@ void PowerUpUsage::update(float aDelta)
     // Update power-up name in HUD
     mPlayers.each([](ent::Handle<ent::Entity> aPlayer, component::PlayerLifeCycle & aLifeCycle)
     {
-        auto & playerHud = snac::getComponent<component::PlayerHud>(aLifeCycle.mHud);
+        auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
         snac::getComponent<component::Text>(playerHud.mPowerupText)
                 .mString = component::getPowerUpName(aPlayer);
     });

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
@@ -384,9 +384,15 @@ void PowerUpUsage::update(float aDelta)
     // Update power-up name in HUD
     mPlayers.each([](ent::Handle<ent::Entity> aPlayer, component::PlayerLifeCycle & aLifeCycle)
     {
-        auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
-        snac::getComponent<component::Text>(playerHud.mPowerupText)
-                .mString = component::getPowerUpName(aPlayer);
+        // TODO code smell, this is defensive programming because sometimes we get there
+        // when the round monitor already removed the hud from the entitymanager
+        // (I suppose the correct logic would be not to execute this system on players between rounds)
+        if(aLifeCycle.mHud->isValid())
+        {
+            auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
+            snac::getComponent<component::Text>(playerHud.mPowerupText)
+                    .mString = component::getPowerUpName(aPlayer);
+        }
     });
 }
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.cpp
@@ -387,7 +387,7 @@ void PowerUpUsage::update(float aDelta)
         // TODO code smell, this is defensive programming because sometimes we get there
         // when the round monitor already removed the hud from the entitymanager
         // (I suppose the correct logic would be not to execute this system on players between rounds)
-        if(aLifeCycle.mHud->isValid())
+        if(aLifeCycle.mHud && aLifeCycle.mHud->isValid())
         {
             auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
             snac::getComponent<component::Text>(playerHud.mPowerupText)

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PowerUpUsage.h
@@ -50,7 +50,6 @@ private:
     ent::Query<component::GlobalPose,
                component::Geometry,
                component::PlayerSlot,
-               component::PlayerHud,
                component::Collision,
                component::PlayerLifeCycle>
         mPlayers;

--- a/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.cpp
@@ -37,16 +37,18 @@ void RoundMonitor::update()
         level.get(destroyLevel)->add(component::LevelToCreate{});
 
         // Removing players
-        mPlayers.each([&destroyLevel](EntHandle aHandle,
-                                      component::PlayerLifeCycle & lifeCycle,
-                                      component::PlayerPowerUp & aPowerup) {
-            // Reset alive status so that player can be spawned
-            lifeCycle.mIsAlive = false;
-            lifeCycle.mTimeToRespawn = component::gBaseTimeToRespawn;
-
-            removeRoundTransientPlayerComponent(destroyLevel, aHandle);
-            removeEntityFromScene(aHandle);
-        });
+        mPlayers.each(
+            [&destroyLevel]
+            (EntHandle aHandle,
+             component::PlayerLifeCycle & lifeCycle,
+             component::PlayerMoveState & aMoveState) 
+            {
+                removeRoundTransientPlayerComponent(destroyLevel, aHandle);
+                removeEntityFromScene(aHandle);
+                // Notably reset alive status so that player can be spawned
+                lifeCycle.reset();
+                aMoveState.mMoveState = gPlayerMoveFlagNone;
+            });
     };
 }
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.cpp
@@ -47,7 +47,6 @@ void RoundMonitor::update()
                 removeEntityFromScene(aHandle);
                 // Notably reset alive status so that player can be spawned
                 lifeCycle.reset();
-                aMoveState.mMoveState = gPlayerMoveFlagNone;
             });
     };
 }

--- a/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.h
@@ -3,7 +3,7 @@
 #include "../GameContext.h"
 #include "../component/LevelData.h"
 #include "../component/PlayerLifeCycle.h"
-#include "../component/PlayerPowerUp.h"
+#include "../component/PlayerMoveState.h"
 
 #include <entity/EntityManager.h>
 
@@ -24,7 +24,7 @@ public:
     void update();
 private:
     GameContext * mGameContext;
-    ent::Query<component::PlayerLifeCycle, component::PlayerPowerUp> mPlayers;
+    ent::Query<component::PlayerLifeCycle, component::PlayerMoveState> mPlayers;
     ent::Query<component::Pill>
         mPills;
     ent::Query<component::LevelEntity> mLevelEntities;

--- a/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/RoundMonitor.h
@@ -3,7 +3,6 @@
 #include "../GameContext.h"
 #include "../component/LevelData.h"
 #include "../component/PlayerLifeCycle.h"
-#include "../component/PlayerMoveState.h"
 
 #include <entity/EntityManager.h>
 
@@ -24,7 +23,7 @@ public:
     void update();
 private:
     GameContext * mGameContext;
-    ent::Query<component::PlayerLifeCycle, component::PlayerMoveState> mPlayers;
+    ent::Query<component::PlayerLifeCycle> mPlayers;
     ent::Query<component::Pill>
         mPills;
     ent::Query<component::LevelEntity> mLevelEntities;


### PR DESCRIPTION
closes #82.
- Make each player hud a distinct Entity.
- Move the score to world space.
- Add the powerup text line.
- Remove unused parameter from add*GeoNode().
- Add billpad model under score and powerup texts.
- Implement a (hackish) scene editor.
- Refine positionning of the paperbill hud thanks to scene editor.
- Shorten power-up names.
- Reverse order: player entity is pointing to the hud entity.
- Refactor the billpad to be manually added to the scene graph. Allow to corretly remove the hud with the player.
- Change HUD font.
- Fix removal of paperbill and reset of player state between rounds.
- Scale down powerup text.
- Fix snacman#83: player moves along direction pressed in previous round.
- Count won rounds, and display them in billpad.
- Fix snacman#84: Reorder round monitor after eatpill.
