### PR TITLE
topic/snacman#95 keep billpad interround

### DIFF
--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -325,8 +325,7 @@ createPlayerSpawnEntity(GameContext & aContext,
 
 ent::Handle<ent::Entity>
 createHudBillpad(GameContext & aContext,
-                 const component::PlayerSlot & aPlayerSlot,
-                 const component::PlayerLifeCycle & aPlayerLifeCycle)
+                 const component::PlayerSlot & aPlayerSlot)
 {
     EntHandle hudHandle = aContext.mWorld.addEntity();
     {
@@ -356,7 +355,7 @@ createHudBillpad(GameContext & aContext,
         {
             ent::Entity scoreText = *scoreHandle.get(createScore);
             scoreText.add(component::Text{
-                .mString = std::to_string(aPlayerLifeCycle.mScore),
+                .mString = "0",
                 .mFont = aContext.mResources.getFont(fontname, 100),
                 //.mColor = playerSlot.mColor,
                 .mColor = math::hdr::gBlack<float>,
@@ -369,7 +368,7 @@ createHudBillpad(GameContext & aContext,
         {
             ent::Entity roundText = *roundHandle.get(createScore);
             roundText.add(component::Text{
-                .mString = std::to_string(aPlayerLifeCycle.mRoundsWon),
+                .mString = "0",
                 .mFont = aContext.mResources.getFont(fontname, 100),
                 //.mColor = playerSlot.mColor,
                 .mColor = math::hdr::gBlack<float>,
@@ -486,10 +485,12 @@ ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
             .mTimeToRespawn = component::gBaseTimeToRespawn,
         };
 
-        lifeCycle.mHud = createHudBillpad(aContext, playerSlot, lifeCycle);
-
         player.add(component::PlayerModel{.mModel = playerModel})
-            .add(lifeCycle)
+            .add(component::PlayerLifeCycle{
+                    .mIsAlive = false,
+                    .mTimeToRespawn = component::gBaseTimeToRespawn,
+                    .mHud = createHudBillpad(aContext, playerSlot),
+            })
             .add(component::PlayerMoveState{})
             .add(component::AllowedMovement{})
             .add(component::Controller{.mType = aControllerType,

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -413,10 +413,9 @@ createHudBillpad(GameContext & aContext,
         insertEntityInScene(billpadHandle, hudHandle);
 
         assert(aContext.mLevel);
-        // Insert the billpad into the root (hardcoded to level parent...)
+        // Insert the billpad into the root, not the level,
         // because the level scale changes depending on the tile dimensions.
-        insertEntityInScene(hudHandle,
-            *snac::getComponent<component::SceneNode>(*aContext.mLevel).mParent);
+        insertEntityInScene(hudHandle, *aContext.mRoot);
 
         hudHandle.get(completeSceneGraph)
             ->add(component::PlayerHud{

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -480,11 +480,6 @@ ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
             player.get<component::PlayerSlot>();
         playerSlot.mFilled = true;
 
-        component::PlayerLifeCycle lifeCycle{
-            .mIsAlive = false,
-            .mTimeToRespawn = component::gBaseTimeToRespawn,
-        };
-
         player.add(component::PlayerModel{.mModel = playerModel})
             .add(component::PlayerLifeCycle{
                     .mIsAlive = false,

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.h
@@ -107,8 +107,7 @@ createPlayerSpawnEntity(GameContext & aContext,
 
 ent::Handle<ent::Entity>
 createHudBillpad(GameContext & aContext,
-                 const component::PlayerSlot & aPlayerSlot,
-                 const component::PlayerLifeCycle & aPlayerLifeCycle);
+                 const component::PlayerSlot & aPlayerSlot);
 
 ent::Handle<ent::Entity> fillSlotWithPlayer(GameContext & aContext,
                                             ControllerType aControllerType,

--- a/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
@@ -23,6 +23,7 @@ struct GameContext
     snac::RenderThread<Renderer> & mRenderThread;
     SimulationControl mSimulationControl;
     std::optional<ent::Handle<ent::Entity>> mLevel;
+    std::optional<ent::Handle<ent::Entity>> mRoot; // only because it cannot be assigned on construction, it should not change
 };
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/EatPill.cpp
@@ -52,20 +52,23 @@ void EatPill::update()
                 aHandle.get(eatPillUpdate)->erase();
                 aLifeCycle.mScore += gPointPerPill;
 
-                // Update the text showing the score in the hud.
-                // TODO code smell, this is defensive programming because sometimes we get there without the HUD
-                // (when the round monitor removed the hud but the spawner did not populate it yet)
-                // This is a great way to increase cyclomatic complexity
-                if(aLifeCycle.mHud && aLifeCycle.mHud->isValid())
-                {
-                    auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
-                    snac::getComponent<component::Text>(playerHud.mScoreText)
-                            .mString = std::to_string(aLifeCycle.mScore);
-                    snac::getComponent<component::Text>(playerHud.mRoundText)
-                            .mString = std::to_string(aLifeCycle.mRoundsWon);
-                }
             }
         });
+
+        // TODO Should only happen on pill eating (collision),
+        // but it would show the previous round score until 1st pill of next round is eaten (stunfest Q&D)
+        // Update the text showing the score in the hud.
+        // TODO code smell, this is defensive programming because sometimes we get there without the HUD
+        // (when the round monitor removed the hud but the spawner did not populate it yet)
+        // This is a great way to increase cyclomatic complexity
+        if(aLifeCycle.mHud && aLifeCycle.mHud->isValid())
+        {
+            auto & playerHud = snac::getComponent<component::PlayerHud>(*aLifeCycle.mHud);
+            snac::getComponent<component::Text>(playerHud.mScoreText)
+                    .mString = std::to_string(aLifeCycle.mScore);
+            snac::getComponent<component::Text>(playerHud.mRoundText)
+                    .mString = std::to_string(aLifeCycle.mRoundsWon);
+        }
     });
 
     mPills.each([](const component::GlobalPose & aPillPose, const component::Collision & aPillCol) {

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
@@ -21,7 +21,6 @@ void PlayerSpawner::update(float aDelta)
     mSpawnable.each([this, &aDelta](EntHandle aPlayerHandle,
                                     component::PlayerLifeCycle & aPlayer,
                                     component::PlayerMoveState & aMoveState,
-                                    component::PlayerSlot & aSlot,
                                     component::Geometry & aPlayerGeometry) 
     {
         if (!aPlayer.mIsAlive) {
@@ -30,7 +29,7 @@ void PlayerSpawner::update(float aDelta)
             } else {
                 // TODO: Needs an alg to choose the right spawner if there are
                 // many spawner
-                mSpawner.each([this, aPlayerHandle, &aPlayer, &aMoveState, &aSlot, &aPlayerGeometry]
+                mSpawner.each([this, aPlayerHandle, &aPlayer, &aMoveState, &aPlayerGeometry]
                               (component::Spawner & aSpawner) 
                 {
                     if (!aPlayer.mIsAlive && !aSpawner.mSpawnedPlayer) 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/PlayerSpawner.cpp
@@ -38,7 +38,6 @@ void PlayerSpawner::update(float aDelta)
                         aPlayer.mIsAlive = true;
                         aPlayer.mTimeToRespawn = component::gBaseTimeToRespawn;
                         aPlayer.mInvulFrameCounter = component::gBaseInvulFrameDuration;
-                        aPlayer.mHud = createHudBillpad(*mGameContext, aSlot, aPlayer);
                         aPlayerGeometry.mPosition = aSpawner.mSpawnPosition;
                         aSpawner.mSpawnedPlayer = true;
                         aMoveState.mMoveState = gPlayerMoveFlagNone;

--- a/src/apps/snacman/snacman/simulations/snacgame/system/SceneStateMachine.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/SceneStateMachine.cpp
@@ -37,6 +37,7 @@ SceneStateMachine::SceneStateMachine(ent::EntityManager & aWorld,
         sceneRoot.get(createRoot)->add(component::Geometry{});
         sceneRoot.get(createRoot)->add(component::GlobalPose{});
     }
+    aGameContext.mRoot = sceneRoot;
 
     for (auto sceneDesc : data)
     {


### PR DESCRIPTION
closes #95
- Add the scene graph root node in the game context.
- Add the billpad when the player slot is filled, and remove with player.
- Refactor createHudBillpad, not taking the player lifecycle anymore.
- Fix a problem with score of previous round showing on next before eat.
