### PR TITLE
topic/snacman#111 profiler dynamic sections

### DIFF
--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -115,7 +115,7 @@ Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer
     // TODO Section identity is much more subtle than that
     // It should be robust to changing the structure of sections (loop variance, and logical structure)
     // and handle change in providers somehow.
-    // For the moment, make a few assertions that will trip the program as soon as it becomes more dynamic.
+    // For the moment, make a few assertions that will trip the program as soon as structure changes.
 
     // There must be a number of provider in [1, maxMetricsPerSection]
     assert(aProviders.size() > 0 && aProviders.size() <= gMaxMetricsPerSection);

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -111,6 +111,22 @@ void Profiler::endFrame()
     // Ensure we have enough entries in the circular buffer (frame count >= gFrameDelay)
     if((mFrameState.mFrameNumber + 1) < mLastResetFrame + gFrameDelay)
     {
+        // TODO Ad 2023/11/15: I do not like this explicit reset of all values at the end of the frame if a reset occurred:
+        // this is wasteful of resources, since all values for entities that changed have already been reset
+        // But this is currently imposed by the prettyPrint, which expects all Entities of a logical section to have the same count of samples...
+        if(mFrameState.mFrameNumber == mLastResetFrame)
+        {
+            // If this is the end of a frame during which a reset occurred, reset all values in all entries
+            for(EntryIndex entryIdx = 0; entryIdx != mFrameState.mNextEntry; ++entryIdx)
+            {
+                Entry & entry = mEntries[entryIdx];
+                for (std::size_t metricIdx = 0; metricIdx != entry.mActiveMetrics; ++metricIdx)
+                {
+                    entry.mMetrics[metricIdx].mValues = {};
+                }
+            }
+        }
+
         return;
     }
 

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -245,6 +245,10 @@ private:
 
         bool matchIdentity(const char * aName, const FrameState & aFrameState) const;
 
+        /// @brief Returns true if `this` currently has exactly the same providers as the iterators range, in the same order.
+        template <std::forward_iterator T_iterator>
+        bool matchProviders(T_iterator aFirstProviderIdx, T_iterator aLastProviderIdx) const;
+
         Identity mId;
         std::array<Metric<GLuint>, gMaxMetricsPerSection> mMetrics;
         std::size_t mActiveMetrics = 0;

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -233,7 +233,7 @@ private:
             bool operator==(const Identity & aRhs) const = default;
         };
 
-        bool matchIdentity(const char * aName, const FrameState & aFrameState);
+        bool matchIdentity(const char * aName, const FrameState & aFrameState) const;
 
         Identity mId;
         std::array<Metric<GLuint>, gMaxMetricsPerSection> mMetrics;
@@ -261,7 +261,7 @@ private:
             };
         };
 
-        bool areAllSectionsClosed()
+        bool areAllSectionsClosed() const
         {
             return 
                 (mCurrentLevel == 0)

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -210,6 +210,9 @@ private:
         Values<T_value, T_average> mValues;
     };
 
+    // Forward
+    struct FrameState;
+
     /// @brief A distinct Entry is used each time the flow of control reaches beginSection().
     /// (i.e. inside a given _frame_, each call to beginSection returns a distinct Entry.)
     /// @note Consolidation happens on the collection of Entries to group them by LogicalSection.
@@ -229,6 +232,8 @@ private:
 
             bool operator==(const Identity & aRhs) const = default;
         };
+
+        bool matchIdentity(const char * aName, const FrameState & aFrameState);
 
         Identity mId;
         std::array<Metric<GLuint>, gMaxMetricsPerSection> mMetrics;
@@ -273,6 +278,7 @@ private:
     std::vector<Entry> mEntries; // Initial size handled in constructor
     std::vector<std::unique_ptr<ProviderInterface>> mMetricProviders;
     FrameState mFrameState;
+    unsigned int mLastResetFrame{0};
 };
 
 

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
@@ -293,11 +293,6 @@ namespace {
                 const Material * material =
                     aMaterialOverride ? aMaterialOverride : &part.mMaterial;
 
-                if(aNode.mInstance.mMaterialOverride)
-                {
-                    SELOG(warn)("Material override for '%s'.", aNode.mInstance.mName);
-                }
-
                 aPartList.mParts.push_back(&part);
                 aPartList.mMaterials.push_back(material);
                 // pushed after

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
@@ -39,12 +39,12 @@ struct ProviderApi : public ProviderInterface
     }
 
     void resize(std::size_t aNewEntriesCount) override
-    { mCounts.resize(aNewEntriesCount * Profiler::gFrameDelay); }
+    { mCounts.resize(aNewEntriesCount * Profiler::CountSubframes() ); }
 
     /////
     Value_t & getRecord(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
     {
-        return mCounts[aEntryIndex * Profiler::gFrameDelay + aCurrentFrame];
+        return mCounts[aEntryIndex * Profiler::CountSubframes()  + aCurrentFrame];
     }
 
     std::vector<Value_t> mCounts;

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
@@ -6,7 +6,7 @@ namespace ad::renderer {
 
 ProviderCPUTime::TimeInterval & ProviderCPUTime::getInterval(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
-    return mTimePoints[aEntryIndex * Profiler::gFrameDelay + aCurrentFrame];
+    return mTimePoints[aEntryIndex * Profiler::CountSubframes()  + aCurrentFrame];
 }
 
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
@@ -24,7 +24,7 @@ struct ProviderCPUTime : public ProviderInterface {
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
-    { mTimePoints.resize(aNewEntriesCount * Profiler::gFrameDelay); }
+    { mTimePoints.resize(aNewEntriesCount * Profiler::CountSubframes() ); }
 
     //////
     struct TimeInterval

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
@@ -9,7 +9,7 @@ namespace ad::renderer {
 
 graphics::Query & ProviderGL::getQuery(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
-    return mQueriesPool[aEntryIndex * Profiler::gFrameDelay + aCurrentFrame];
+    return mQueriesPool[aEntryIndex * Profiler::CountSubframes()  + aCurrentFrame];
 }
 
 
@@ -58,7 +58,7 @@ bool ProviderGL::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & 
 
 graphics::Query & ProviderGLTime::getQuery(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame, Event aEvent)
 {
-    return mQueriesPool[2 * (aEntryIndex * Profiler::gFrameDelay + aCurrentFrame) 
+    return mQueriesPool[2 * (aEntryIndex * Profiler::CountSubframes()  + aCurrentFrame) 
                         + (aEvent == Event::Begin ? 0 : 1)];
 }
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
@@ -21,7 +21,7 @@ struct ProviderGL : public ProviderInterface
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
-    { mQueriesPool.resize(aNewEntriesCount * Profiler::gFrameDelay); }
+    { mQueriesPool.resize(aNewEntriesCount * Profiler::CountSubframes() ); }
 
     //////
 
@@ -52,7 +52,7 @@ struct ProviderGLTime : public ProviderInterface
     // This is currently very conservative, having enough queries to recorded begin/end time for each section
     // in each "frame delay slot".
     void resize(std::size_t aNewEntriesCount) override
-    { mQueriesPool.resize(2 * aNewEntriesCount * Profiler::gFrameDelay); }
+    { mQueriesPool.resize(2 * aNewEntriesCount * Profiler::CountSubframes() ); }
 
     //////
     graphics::Query & getQuery(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame, Event aEvent);

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
@@ -21,7 +21,7 @@ struct ProviderCpuRdtsc : public ProviderInterface
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
-    { mIntervals.resize(aNewEntriesCount * Profiler::gFrameDelay); }
+    { mIntervals.resize(aNewEntriesCount * Profiler::CountSubframes() ); }
 
     ////// Logically private
     TickCount_t & getInterval(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame);
@@ -69,7 +69,7 @@ inline ProviderCpuRdtsc::ProviderCpuRdtsc():
 
 inline ProviderCpuRdtsc::TickCount_t & ProviderCpuRdtsc::getInterval(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
-    return mIntervals[aEntryIndex * Profiler::gFrameDelay + aCurrentFrame];
+    return mIntervals[aEntryIndex * Profiler::CountSubframes()  + aCurrentFrame];
 }
 
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
@@ -42,7 +42,7 @@ ProviderCpuPerformanceCounter::ProviderCpuPerformanceCounter() :
 
 ProviderCpuPerformanceCounter::TimeInterval & ProviderCpuPerformanceCounter::getInterval(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
-    return mTimePoints[aEntryIndex * Profiler::gFrameDelay + aCurrentFrame];
+    return mTimePoints[aEntryIndex * Profiler::CountSubframes()  + aCurrentFrame];
 }
 
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
@@ -20,7 +20,7 @@ struct ProviderCpuPerformanceCounter : public ProviderInterface
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
-    { mTimePoints.resize(aNewEntriesCount * Profiler::gFrameDelay); }
+    { mTimePoints.resize(aNewEntriesCount * Profiler::CountSubframes() ); }
 
     //////
     using TimeInterval = TickCount_t;


### PR DESCRIPTION
closes #111
- Update profiler comments, in particular introductory notes.
- Structure Profiler data, with a FrameData nested structure.
- Remove a leftover "debug" log.
- Allow dynamic profiler sections hierarchies.
- Reset all values in all entries when a reset frame ends.
- Move Profiler::prettyPrint() out of the profiler's frame.
- Sort a bug with frame delay, it is now the actual delay, 0 works.
