### PR TITLE
topic/snacman#113 profiler single shot

### DIFF
--- a/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
+++ b/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
@@ -46,8 +46,9 @@ set(${TARGET_NAME}_SOURCES
     SceneGui.cpp
     SetupDrawing.cpp
 
-    providers/ProviderGL.cpp
     providers/ProviderCpu.cpp
+    providers/ProviderGL.cpp
+    providers/ProviderRdtsc.cpp
 )
 
 

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -217,8 +217,8 @@ void Profiler::endFrame()
     // But this is currently imposed by the prettyPrint, which expects all Entities of a logical section to have the same count of samples...
     if(mFrameState.mFrameNumber == mLastResetFrame)
     {
-        // If a reset occured during this frame, reset all values in all entries
-        for(EntryIndex entryIdx = 0; entryIdx != mFrameState.mNextEntry; ++entryIdx)
+        // If a reset occured during this frame, reset all values in all recurring entries
+        for(EntryIndex entryIdx : mFrameState.mRecurrings)
         {
             Entry & entry = mEntries[entryIdx];
             entry.resetValues();

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -161,7 +161,7 @@ void Profiler::endFrame()
     }
 }
 
-Profiler::EntryIndex Profiler::beginSectionRecurring(const char * aName, std::initializer_list<ProviderIndex> aProviders)
+Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer_list<ProviderIndex> aProviders)
 {
     // TODO Section identity is much more subtle than that
     // It should be robust to changing the structure of sections (loop variance, and logical structure)
@@ -222,19 +222,19 @@ Profiler::EntryIndex Profiler::beginSectionRecurring(const char * aName, std::in
 
     for (std::size_t i = 0; i != entry.mActiveMetrics; ++i)
     {
-        getProvider(entry.mMetrics[i]).beginSectionRecurring(entryIndex, currentSubframe());
+        getProvider(entry.mMetrics[i]).beginSection(entryIndex, currentSubframe());
     }
 
     return entryIndex;
 }
 
 
-void Profiler::endSectionRecurring(EntryIndex aIndex)
+void Profiler::endSection(EntryIndex aIndex)
 {
     RecurringEntry & entry = mRecurringEntries.at(aIndex);
     for (std::size_t i = 0; i != entry.mActiveMetrics; ++i)
     {
-        getProvider(entry.mMetrics[i]).endSectionRecurring(aIndex, currentSubframe());
+        getProvider(entry.mMetrics[i]).endSection(aIndex, currentSubframe());
     }
     mFrameState.mCurrentParent = entry.mId.mParentIdx; // restore this Entry parent as the current parent
     --mFrameState.mCurrentLevel;
@@ -243,7 +243,7 @@ void Profiler::endSectionRecurring(EntryIndex aIndex)
 
 void Profiler::popCurrentSection()
 {
-    endSectionRecurring(mFrameState.mCurrentParent);
+    endSection(mFrameState.mCurrentParent);
 }
 
 

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -4,13 +4,12 @@
 
 
 #include "providers/ProviderApi.h"
-#include "providers/ProviderCpu.h"
 #include "providers/ProviderGL.h"
+#include "providers/ProviderRdtsc.h"
 
 
 #if defined(_WIN32)
-#include "providers/ProviderRdtsc.h"
-#include "providers/ProviderWindows.h"
+//#include "providers/ProviderWindows.h"
 #endif
 
 #include <cassert>
@@ -75,13 +74,11 @@ void Profiler::Entry::resetValues()
 
 Profiler::Profiler()
 {
-#if defined(_WIN32)
+//#if defined(_WIN32)
+//    mMetricProviders.push_back(std::make_unique<ProviderCpuPerformanceCounter>());
+//#else
     mMetricProviders.push_back(std::make_unique<ProviderCpuRdtsc>());
-    //mMetricProviders.push_back(std::make_unique<ProviderCpuPerformanceCounter>());
-#else
-    mMetricProviders.push_back(std::make_unique<ProviderCPUTime>());
-#endif
-
+    //mMetricProviders.push_back(std::make_unique<ProviderCPUTime>());
     mMetricProviders.push_back(std::make_unique<ProviderGLTime>());
     mMetricProviders.push_back(std::make_unique<ProviderGL>());
     mMetricProviders.push_back(std::make_unique<ProviderApi<&GlApi::Metrics::drawCount>>("draw", ""));

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -19,8 +19,7 @@
 namespace ad::renderer {
 
 
-template <class T_value>
-bool Profiler::Entry<T_value>::matchIdentity(const char * aName, const FrameState & aFrameState) const
+bool Profiler::Entry::matchIdentity(const char * aName, const FrameState & aFrameState) const
 {
     return 
         (mId.mName == aName)
@@ -30,13 +29,12 @@ bool Profiler::Entry<T_value>::matchIdentity(const char * aName, const FrameStat
 }
 
 
-template <class T_value>
 template <std::forward_iterator T_iterator>
-bool Profiler::Entry<T_value>::matchProviders(T_iterator aFirstProviderIdx, T_iterator aLastProviderIdx) const
+bool Profiler::Entry::matchProviders(T_iterator aFirstProviderIdx, T_iterator aLastProviderIdx) const
 {
     return std::equal(mMetrics.begin(), mMetrics.begin() + mActiveMetrics,
                       aFirstProviderIdx, aLastProviderIdx,
-                      [](const Profiler::Metric<T_value> & aMetric, Profiler::ProviderIndex aProviderIdx)
+                      [](const Profiler::Metric<GLuint> & aMetric, Profiler::ProviderIndex aProviderIdx)
                       {
                           return aMetric.mProviderIndex == aProviderIdx;
                       });
@@ -61,21 +59,21 @@ Profiler::Profiler()
 }
 
 
-Profiler::RecurringEntry & Profiler::fetchNextEntry()
+Profiler::Entry & Profiler::fetchNextEntry()
 {
-    if(mFrameState.mNextEntry == mRecurringEntries.size())
+    if(mFrameState.mNextEntry == mEntries.size())
     {
-        auto newSize = mRecurringEntries.size() * 2;
+        auto newSize = mEntries.size() * 2;
         SELOG(debug)("Resizing the profiler to {} entries.", newSize);
         resize(newSize);
     }
-    return mRecurringEntries[mFrameState.mNextEntry];
+    return mEntries[mFrameState.mNextEntry];
 }
 
 
 void Profiler::resize(std::size_t aNewEntriesCount)
 {
-    mRecurringEntries.resize(aNewEntriesCount);
+    mEntries.resize(aNewEntriesCount);
     for(const auto & provider : mMetricProviders)
     {
         provider->resize(aNewEntriesCount);
@@ -83,15 +81,13 @@ void Profiler::resize(std::size_t aNewEntriesCount)
 }
 
 
-template <class T_value>
-ProviderInterface & Profiler::getProvider(const Metric<T_value> & aMetric)
+ProviderInterface & Profiler::getProvider(const Metric<GLuint> & aMetric)
 {
     return *mMetricProviders.at(aMetric.mProviderIndex);
 }
 
 
-template <class T_value>
-const ProviderInterface & Profiler::getProvider(const Metric<T_value> & aMetric) const
+const ProviderInterface & Profiler::getProvider(const Metric<GLuint> & aMetric) const
 {
     return *mMetricProviders.at(aMetric.mProviderIndex);
 }
@@ -127,7 +123,7 @@ void Profiler::endFrame()
         // If a reset occured during this frame, reset all values in all entries
         for(EntryIndex entryIdx = 0; entryIdx != mFrameState.mNextEntry; ++entryIdx)
         {
-            RecurringEntry & entry = mRecurringEntries[entryIdx];
+            Entry & entry = mEntries[entryIdx];
             for (std::size_t metricIdx = 0; metricIdx != entry.mActiveMetrics; ++metricIdx)
             {
                 entry.mMetrics[metricIdx].mValues = {};
@@ -143,7 +139,7 @@ void Profiler::endFrame()
 
     for(EntryIndex entryIdx = 0; entryIdx != mFrameState.mNextEntry; ++entryIdx)
     {
-        RecurringEntry & entry = mRecurringEntries[entryIdx];
+        Entry & entry = mEntries[entryIdx];
         std::uint32_t queryFrame = queriedSubframe();
 
         GLuint result;
@@ -173,7 +169,7 @@ Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer
     
     auto setupNextEntry = [this](const char * aName, auto aProviders) -> std::pair<EntryIndex, bool>
     {
-        RecurringEntry & entry = fetchNextEntry();
+        Entry & entry = fetchNextEntry();
         bool alreadyPresent;
 
         if(alreadyPresent = entry.matchIdentity(aName, mFrameState);
@@ -198,7 +194,7 @@ Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer
                 assert(previousProvider == std::numeric_limits<ProviderIndex>::max() || previousProvider < providerIndex);
                 previousProvider = providerIndex;
 
-                entry.mMetrics.at(entry.mActiveMetrics++) = RecurringEntry::Metric_t{
+                entry.mMetrics.at(entry.mActiveMetrics++) = Metric<GLuint>{
                     // TODO we could optimize that without rewritting each individual sample to zero
                     .mProviderIndex = providerIndex,
                     .mValues = {}, // Note: No effect line, to make explicit that we reset values.
@@ -212,7 +208,7 @@ Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer
     };
 
     auto [entryIndex, alreadyPresent] = setupNextEntry(aName, aProviders);
-    RecurringEntry & entry = mRecurringEntries[entryIndex];
+    Entry & entry = mEntries[entryIndex];
 
     if (!alreadyPresent)
     {
@@ -231,7 +227,7 @@ Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer
 
 void Profiler::endSection(EntryIndex aIndex)
 {
-    RecurringEntry & entry = mRecurringEntries.at(aIndex);
+    Entry & entry = mEntries.at(aIndex);
     for (std::size_t i = 0; i != entry.mActiveMetrics; ++i)
     {
         getProvider(entry.mMetrics[i]).endSection(aIndex, currentSubframe());
@@ -249,14 +245,14 @@ void Profiler::popCurrentSection()
 
 struct LogicalSection
 {
-    LogicalSection(const Profiler::RecurringEntry & aEntry, Profiler::EntryIndex aEntryIndex) :
+    LogicalSection(const Profiler::Entry & aEntry, Profiler::EntryIndex aEntryIndex) :
         mId{aEntry.mId},
         mEntries{aEntryIndex},
         mValues{aEntry.mMetrics},
         mActiveMetrics{aEntry.mActiveMetrics}
     {}
 
-    void push(const Profiler::RecurringEntry & aEntry, Profiler::EntryIndex aEntryIndex)
+    void push(const Profiler::Entry & aEntry, Profiler::EntryIndex aEntryIndex)
     {
         assert(mActiveMetrics == aEntry.mActiveMetrics);
         for (std::size_t metricIdx = 0; metricIdx != mActiveMetrics; ++metricIdx)
@@ -294,7 +290,7 @@ struct LogicalSection
     }
 
     /// @brief Identity that determines the belonging of an Entry to this logical Section.
-    Profiler::RecurringEntry::Identity mId;
+    Profiler::Entry::Identity mId;
     // TODO should we use an array? 
     // Is it really useful to keep if we cumulate at push? (might be if we cache the sort result between frames)
     /// @brief Collection of entries beloging to this logical section. 
@@ -303,7 +299,7 @@ struct LogicalSection
     // TODO we actually only need to store Values here (not even sure we should keep the individual samples)
     // (note: we do not accumulate the samples at the moment)
     // If we go this route, we should split Metrics from AOS to SOA so we can copy Values from Entries with memcpy
-    std::array<Profiler::RecurringEntry::Metric_t, Profiler::gMaxMetricsPerSection> mValues;
+    std::array<Profiler::Metric<GLuint>, Profiler::gMaxMetricsPerSection> mValues;
     std::size_t mActiveMetrics = 0;
 
     /// @brief Keep track of the samples accounted for by sub-sections 
@@ -337,11 +333,11 @@ void Profiler::prettyPrint(std::ostream & aOut) const
     static constexpr LogicalSectionId gInvalidLogicalSection = std::numeric_limits<LogicalSectionId>::max();
     // This vector associate each entry index to a logical section index.
     // It allows to test whether distinct entry indices correspond to the same logical section, for parent consolidation.
-    std::vector<LogicalSectionId> entryIdToLogicalSectionId(mRecurringEntries.size(), gInvalidLogicalSection);
+    std::vector<LogicalSectionId> entryIdToLogicalSectionId(mEntries.size(), gInvalidLogicalSection);
 
     for(EntryIndex entryIdx = 0; entryIdx != mFrameState.mNextEntry; ++entryIdx)
     {
-        const RecurringEntry & entry = mRecurringEntries[entryIdx];
+        const Entry & entry = mEntries[entryIdx];
 
         // Important:
         // We cannot simply compare the Entry Identity the Identity of a section to test if the Entry belongs there:
@@ -352,18 +348,18 @@ void Profiler::prettyPrint(std::ostream & aOut) const
         if(auto found = std::find_if(sections.begin(), sections.end(),
                                      [&entry, &lookup = entryIdToLogicalSectionId](const auto & aCandidateSection)
                                      {
-                                        assert(entry.mId.mParentIdx == RecurringEntry::gNoParent 
+                                        assert(entry.mId.mParentIdx == Entry::gNoParent 
                                             || (lookup[entry.mId.mParentIdx] != gInvalidLogicalSection));
 
                                         return aCandidateSection.mId.mName == entry.mId.mName
                                                 // Check if the entry and the candidate section have the same logical parent:
                                                 // * either both have a parent, then we compare the LogicalSectionId of both parents
                                                 // * OR both have no parent
-                                            && (   (   entry.mId.mParentIdx != RecurringEntry::gNoParent 
-                                                    && aCandidateSection.mId.mParentIdx != RecurringEntry::gNoParent 
+                                            && (   (   entry.mId.mParentIdx != Entry::gNoParent 
+                                                    && aCandidateSection.mId.mParentIdx != Entry::gNoParent 
                                                     && lookup[entry.mId.mParentIdx] == lookup[aCandidateSection.mId.mParentIdx])
-                                                || (   entry.mId.mParentIdx == RecurringEntry::gNoParent
-                                                    && aCandidateSection.mId.mParentIdx == RecurringEntry::gNoParent))
+                                                || (   entry.mId.mParentIdx == Entry::gNoParent
+                                                    && aCandidateSection.mId.mParentIdx == Entry::gNoParent))
                                                 // Check if the entry and candidate have the same level
                                                 // Should alway be true then, so we assert
                                             && (assert(aCandidateSection.mId.mLevel == entry.mId.mLevel), true)
@@ -384,7 +380,7 @@ void Profiler::prettyPrint(std::ostream & aOut) const
     // Accumulate the values accounted for by child sections.
     for(LogicalSection & section : sections)
     {
-        if(section.mId.mParentIdx != RecurringEntry::gNoParent)
+        if(section.mId.mParentIdx != Entry::gNoParent)
         {
             LogicalSection & parentSection = sections[entryIdToLogicalSectionId[section.mId.mParentIdx]];
             parentSection.accountChildSection(section);

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -161,7 +161,7 @@ void Profiler::endFrame()
     }
 }
 
-Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer_list<ProviderIndex> aProviders)
+Profiler::EntryIndex Profiler::beginSectionRecurring(const char * aName, std::initializer_list<ProviderIndex> aProviders)
 {
     // TODO Section identity is much more subtle than that
     // It should be robust to changing the structure of sections (loop variance, and logical structure)
@@ -222,19 +222,19 @@ Profiler::EntryIndex Profiler::beginSection(const char * aName, std::initializer
 
     for (std::size_t i = 0; i != entry.mActiveMetrics; ++i)
     {
-        getProvider(entry.mMetrics[i]).beginSection(entryIndex, currentSubframe());
+        getProvider(entry.mMetrics[i]).beginSectionRecurring(entryIndex, currentSubframe());
     }
 
     return entryIndex;
 }
 
 
-void Profiler::endSection(EntryIndex aIndex)
+void Profiler::endSectionRecurring(EntryIndex aIndex)
 {
     RecurringEntry & entry = mRecurringEntries.at(aIndex);
     for (std::size_t i = 0; i != entry.mActiveMetrics; ++i)
     {
-        getProvider(entry.mMetrics[i]).endSection(aIndex, currentSubframe());
+        getProvider(entry.mMetrics[i]).endSectionRecurring(aIndex, currentSubframe());
     }
     mFrameState.mCurrentParent = entry.mId.mParentIdx; // restore this Entry parent as the current parent
     --mFrameState.mCurrentLevel;
@@ -243,7 +243,7 @@ void Profiler::endSection(EntryIndex aIndex)
 
 void Profiler::popCurrentSection()
 {
-    endSection(mFrameState.mCurrentParent);
+    endSectionRecurring(mFrameState.mCurrentParent);
 }
 
 

--- a/src/apps/refactor_proto/refactor_proto/Profiler.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.cpp
@@ -34,7 +34,7 @@ bool Profiler::Entry::matchProviders(T_iterator aFirstProviderIdx, T_iterator aL
 {
     return std::equal(mMetrics.begin(), mMetrics.begin() + mActiveMetrics,
                       aFirstProviderIdx, aLastProviderIdx,
-                      [](const Profiler::Metric<GLuint> & aMetric, Profiler::ProviderIndex aProviderIdx)
+                      [](const Profiler::Metric<Profiler::Sample_t> & aMetric, Profiler::ProviderIndex aProviderIdx)
                       {
                           return aMetric.mProviderIndex == aProviderIdx;
                       });
@@ -54,7 +54,7 @@ void Profiler::Entry::setProviders(T_iterator aFirstProviderIdx, T_iterator aLas
         assert(previousProvider == std::numeric_limits<ProviderIndex>::max() || previousProvider < providerIndex);
         previousProvider = providerIndex;
 
-        mMetrics.at(mActiveMetrics++) = Metric<GLuint>{
+        mMetrics.at(mActiveMetrics++) = Metric<Sample_t>{
             // TODO we could optimize that without rewritting each individual sample to zero
             // Note: this could be more tricky with the introduction of single shot
             .mProviderIndex = providerIndex,
@@ -132,7 +132,7 @@ Profiler::EntryIndex Profiler::fetchNextEntry(EntryNature aNature, const char * 
 // Note: Would be better as a member function of Entry, but we need the index, which is not stored in the Entry
 void Profiler::queryProviders(EntryIndex aEntryIdx, std::uint32_t aQueryFrame)
 {
-    GLuint result;
+    Sample_t result;
     Entry & entry = mEntries[aEntryIdx];
     for (std::size_t metricIdx = 0; metricIdx != entry.mActiveMetrics; ++metricIdx)
     {
@@ -158,13 +158,13 @@ void Profiler::resize(std::size_t aNewEntriesCount)
 }
 
 
-ProviderInterface & Profiler::getProvider(const Metric<GLuint> & aMetric)
+ProviderInterface & Profiler::getProvider(const Metric<Sample_t> & aMetric)
 {
     return *mMetricProviders.at(aMetric.mProviderIndex);
 }
 
 
-const ProviderInterface & Profiler::getProvider(const Metric<GLuint> & aMetric) const
+const ProviderInterface & Profiler::getProvider(const Metric<Sample_t> & aMetric) const
 {
     return *mMetricProviders.at(aMetric.mProviderIndex);
 }
@@ -403,12 +403,12 @@ struct LogicalSection
     // TODO we actually only need to store Values here (not even sure we should keep the individual samples)
     // (note: we do not accumulate the samples at the moment)
     // If we go this route, we should split Metrics from AOS to SOA so we can copy Values from Entries with memcpy
-    std::array<Profiler::Metric<GLuint>, Profiler::gMaxMetricsPerSection> mValues;
+    std::array<Profiler::Metric<Profiler::Sample_t>, Profiler::gMaxMetricsPerSection> mValues;
     std::size_t mActiveMetrics = 0;
 
     /// @brief Keep track of the samples accounted for by sub-sections 
     /// (thus allowing to know what has not been accounted for)
-    std::array<GLuint, Profiler::gMaxMetricsPerSection> mAccountedFor{0}; 
+    std::array<Profiler::Sample_t, Profiler::gMaxMetricsPerSection> mAccountedFor{0}; 
 };
 
 

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -98,8 +98,8 @@ public:
 
     virtual ~ProviderInterface() = default;
 
-    virtual void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
-    virtual void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
+    virtual void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
+    virtual void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
 
     // TODO make generic regarding provided type
     virtual bool provide(EntryIndex aEntryIndex, std::uint32_t aQueryFrame, GLuint & aSampleResult) = 0;
@@ -141,8 +141,8 @@ public:
     void beginFrame();
     void endFrame();
 
-    EntryIndex beginSectionRecurring(const char * aName, std::initializer_list<ProviderIndex> aProviders);
-    void endSectionRecurring(EntryIndex aIndex);
+    EntryIndex beginSection(const char * aName, std::initializer_list<ProviderIndex> aProviders);
+    void endSection(EntryIndex aIndex);
 
     // I am not sure this is a good idea, as it relies on a Profiler global state (mCurrentParent), which might not be a good idea.
     // The current assumption is that sections should always be strictly nested, and that they are created on a single thread
@@ -154,7 +154,7 @@ public:
     {
         ~SectionGuard()
         {
-            mProfiler->endSectionRecurring(mEntry);
+            mProfiler->endSection(mEntry);
         }
 
         Profiler * mProfiler;
@@ -165,7 +165,7 @@ public:
     { 
         return {
             .mProfiler = this,
-            .mEntry = beginSectionRecurring(aName, std::move(aProviders))
+            .mEntry = beginSection(aName, std::move(aProviders))
         };
     }
 
@@ -205,7 +205,7 @@ public:
     };
 
 private:
-    /// @brief The current subframe, which should be provided to profilers beginSectionRecurring() / endSectionRecurring().
+    /// @brief The current subframe, which should be provided to profilers beginSection() / endSection().
     std::uint32_t currentSubframe() const;
 
     /// @brief The subframe which is to be queried, taking into account the frame delay.

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -212,12 +212,12 @@ private:
     std::uint32_t queriedSubframe() const;
 
     /// @brief A reference to a metrics Provider, and a `Value` record of the samples taken by this provider.
-    template <class T_value>
+    template <class T_value, class T_average = T_value>
     struct Metric
     {
         //std::string mName;
         ProviderIndex mProviderIndex;
-        T_value mValues;
+        Values<T_value, T_average> mValues;
     };
 
     // Forward
@@ -228,14 +228,11 @@ private:
     /// @note Consolidation happens on the collection of Entries to group them by LogicalSection.
     ///
     /// Contains an array of `Metrics` measured for this entry.
-    template <class T_value>
     struct Entry
     {
         inline static constexpr unsigned int gInvalidLevel = -1;
         inline static constexpr EntryIndex gInvalidEntry = std::numeric_limits<EntryIndex>::max();
         inline static constexpr EntryIndex gNoParent = gInvalidEntry - 1;
-
-        using Metric_t = Metric<T_value>;
 
         struct Identity
         {
@@ -253,22 +250,18 @@ private:
         bool matchProviders(T_iterator aFirstProviderIdx, T_iterator aLastProviderIdx) const;
 
         Identity mId;
-        std::array<Metric_t, gMaxMetricsPerSection> mMetrics;
+        std::array<Metric<GLuint>, gMaxMetricsPerSection> mMetrics;
         std::size_t mActiveMetrics = 0;
     };
 
-    using RecurringEntry = Entry<Values<GLuint>>;
-
     /// @brief Returns the next entry, handling resizing of storage when needed.
     /// @warning Does not advance the next entry
-    RecurringEntry & fetchNextEntry();
+    Entry & fetchNextEntry();
 
     void resize(std::size_t aNewEntriesCount);
 
-    template <class T_value>
-    ProviderInterface & getProvider(const Metric<T_value> & aMetric);
-    template <class T_value>
-    const ProviderInterface & getProvider(const Metric<T_value> & aMetric) const;
+    ProviderInterface & getProvider(const Metric<GLuint> & aMetric);
+    const ProviderInterface & getProvider(const Metric<GLuint> & aMetric) const;
 
     /// @brief The intra-frame state (plus the corresponding frame number).
     struct FrameState
@@ -286,17 +279,17 @@ private:
         {
             return 
                 (mCurrentLevel == 0)
-                && (mCurrentParent == RecurringEntry::gNoParent)
+                && (mCurrentParent == Entry::gNoParent)
             ;
         }
 
         EntryIndex mNextEntry{0};
         unsigned int mCurrentLevel{0};
-        EntryIndex mCurrentParent{RecurringEntry::gNoParent};
+        EntryIndex mCurrentParent{Entry::gNoParent};
         unsigned int mFrameNumber{std::numeric_limits<unsigned int>::max()};
     };
 
-    std::vector<RecurringEntry> mRecurringEntries; // Initial size handled in constructor
+    std::vector<Entry> mEntries; // Initial size handled in constructor
     std::vector<std::unique_ptr<ProviderInterface>> mMetricProviders;
     FrameState mFrameState;
     unsigned int mLastResetFrame{0};

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -151,7 +151,7 @@ public:
     void beginFrame();
     void endFrame();
 
-    EntryIndex beginSection(const char * aName, std::initializer_list<ProviderIndex> aProviders);
+    EntryIndex beginSection(EntryNature aNature, const char * aName, std::initializer_list<ProviderIndex> aProviders);
     void endSection(EntryIndex aIndex);
 
     // I am not sure this is a good idea, as it relies on a Profiler global state (mCurrentParent), which might not be a good idea.
@@ -171,11 +171,11 @@ public:
         EntryIndex mEntry;
     };
     
-    SectionGuard scopeSection(const char * aName, std::initializer_list<ProviderIndex> aProviders)
+    SectionGuard scopeSection(EntryNature aNature, const char * aName, std::initializer_list<ProviderIndex> aProviders)
     { 
         return {
             .mProfiler = this,
-            .mEntry = beginSection(aName, std::move(aProviders))
+            .mEntry = beginSection(aNature, aName, std::move(aProviders))
         };
     }
 
@@ -222,6 +222,7 @@ private:
     std::uint32_t queriedSubframe() const;
 
     std::pair<EntryIndex, bool> setupNextEntryRecurring(const char * aName, auto aProviders);
+    EntryIndex setupNextEntrySingleShot(const char * aName, auto aProviders);
 
     /// @brief A reference to a metrics Provider, and a `Value` record of the samples taken by this provider.
     template <class T_value, class T_average = T_value>
@@ -273,9 +274,9 @@ private:
         std::size_t mActiveMetrics = 0;
     };
 
-    /// @brief Returns the next entry, handling resizing of storage when needed.
-    /// @warning Does not advance the next entry, nor set any value on it (not setting the name)
-    Entry & fetchNextEntry(EntryNature aNature, const char * aName);
+    /// @brief Returns the entry idx to use for the provided parameters, handling resizing of storage when needed.
+    /// @warning Does advance the next entry, but does not set any value on the entry instance itself (not setting the name).
+    EntryIndex fetchNextEntry(EntryNature aNature, const char * aName);
 
     void resize(std::size_t aNewEntriesCount);
 

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -82,8 +82,8 @@ struct Ratio
         den /= gcd;
     }
 
-    GLuint num;
-    GLuint den;
+    std::uint64_t num;
+    std::uint64_t den;
 };
 
 
@@ -98,6 +98,7 @@ enum class EntryNature
 class ProviderInterface
 {
 public:
+    using Sample_t = std::uint64_t;
     using EntryIndex = std::size_t;
 
     ProviderInterface(const char * aQuantityName, const char * aUnit, Ratio aScaleFactor = {.num = 1, .den = 1}) :
@@ -112,11 +113,11 @@ public:
     virtual void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
 
     // TODO make generic regarding provided type
-    virtual bool provide(EntryIndex aEntryIndex, std::uint32_t aQueryFrame, GLuint & aSampleResult) = 0;
+    virtual bool provide(EntryIndex aEntryIndex, std::uint32_t aQueryFrame, Sample_t & aSampleResult) = 0;
 
     virtual void resize(std::size_t aNewEntriesCount) = 0;
 
-    GLuint scale(GLuint aInput) const
+    Sample_t scale(Sample_t aInput) const
     { return aInput * mScaleFactor.num / mScaleFactor.den; }
 
     const char * mQuantityName = "quantity";
@@ -140,6 +141,7 @@ public:
     inline static constexpr std::size_t gMaxSamples{128};
     inline static constexpr std::size_t gMaxMetricsPerSection{16};
 
+    using Sample_t = ProviderInterface::Sample_t;
     using EntryIndex = ProviderInterface::EntryIndex;
     using ProviderIndex = std::size_t;
 
@@ -185,6 +187,7 @@ public:
     /// @brief Keep a record of up to `gMaxSample` samples, as well as special values over this record (TODO e.g. min, max, accumulation).
     /// @tparam T_value The type of value that are recorded when sampling.
     /// @tparam T_average The type of the average, notably usefull to request decimals when averaging integers.
+    // TODO rename T_value to T_sample
     template <class T_value, class T_average = T_value>
     struct Values
     {
@@ -281,7 +284,7 @@ private:
         void setProviders(T_iterator aFirstProviderIdx, T_iterator aLastProviderIdx);
 
         Identity mId;
-        std::array<Metric<GLuint>, gMaxMetricsPerSection> mMetrics;
+        std::array<Metric<Sample_t>, gMaxMetricsPerSection> mMetrics;
         std::size_t mActiveMetrics = 0;
     };
 
@@ -291,8 +294,8 @@ private:
 
     void resize(std::size_t aNewEntriesCount);
 
-    ProviderInterface & getProvider(const Metric<GLuint> & aMetric);
-    const ProviderInterface & getProvider(const Metric<GLuint> & aMetric) const;
+    ProviderInterface & getProvider(const Metric<Sample_t> & aMetric);
+    const ProviderInterface & getProvider(const Metric<Sample_t> & aMetric) const;
 
     /// @brief The intra-frame state (plus the corresponding frame number).
     struct FrameState

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -258,6 +258,7 @@ private:
     };
 
     using RecurringEntry = Entry<Values<GLuint>>;
+    using SingleShotEntry = Entry<GLuint>;
 
     /// @brief Returns the next entry, handling resizing of storage when needed.
     /// @warning Does not advance the next entry
@@ -297,6 +298,7 @@ private:
     };
 
     std::vector<RecurringEntry> mRecurringEntries; // Initial size handled in constructor
+    std::vector<SingleShotEntry> mSingleShotEntries;
     std::vector<std::unique_ptr<ProviderInterface>> mMetricProviders;
     FrameState mFrameState;
     unsigned int mLastResetFrame{0};

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -98,8 +98,8 @@ public:
 
     virtual ~ProviderInterface() = default;
 
-    virtual void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
-    virtual void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
+    virtual void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
+    virtual void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) = 0;
 
     // TODO make generic regarding provided type
     virtual bool provide(EntryIndex aEntryIndex, std::uint32_t aQueryFrame, GLuint & aSampleResult) = 0;
@@ -141,8 +141,8 @@ public:
     void beginFrame();
     void endFrame();
 
-    EntryIndex beginSection(const char * aName, std::initializer_list<ProviderIndex> aProviders);
-    void endSection(EntryIndex aIndex);
+    EntryIndex beginSectionRecurring(const char * aName, std::initializer_list<ProviderIndex> aProviders);
+    void endSectionRecurring(EntryIndex aIndex);
 
     // I am not sure this is a good idea, as it relies on a Profiler global state (mCurrentParent), which might not be a good idea.
     // The current assumption is that sections should always be strictly nested, and that they are created on a single thread
@@ -154,7 +154,7 @@ public:
     {
         ~SectionGuard()
         {
-            mProfiler->endSection(mEntry);
+            mProfiler->endSectionRecurring(mEntry);
         }
 
         Profiler * mProfiler;
@@ -165,7 +165,7 @@ public:
     { 
         return {
             .mProfiler = this,
-            .mEntry = beginSection(aName, std::move(aProviders))
+            .mEntry = beginSectionRecurring(aName, std::move(aProviders))
         };
     }
 
@@ -205,7 +205,7 @@ public:
     };
 
 private:
-    /// @brief The current subframe, which should be provided to profilers beginSection() / endSection().
+    /// @brief The current subframe, which should be provided to profilers beginSectionRecurring() / endSectionRecurring().
     std::uint32_t currentSubframe() const;
 
     /// @brief The subframe which is to be queried, taking into account the frame delay.

--- a/src/apps/refactor_proto/refactor_proto/Profiler.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiler.h
@@ -258,7 +258,6 @@ private:
     };
 
     using RecurringEntry = Entry<Values<GLuint>>;
-    using SingleShotEntry = Entry<GLuint>;
 
     /// @brief Returns the next entry, handling resizing of storage when needed.
     /// @warning Does not advance the next entry
@@ -298,7 +297,6 @@ private:
     };
 
     std::vector<RecurringEntry> mRecurringEntries; // Initial size handled in constructor
-    std::vector<SingleShotEntry> mSingleShotEntries;
     std::vector<std::unique_ptr<ProviderInterface>> mMetricProviders;
     FrameState mFrameState;
     unsigned int mLastResetFrame{0};

--- a/src/apps/refactor_proto/refactor_proto/Profiling.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiling.h
@@ -46,12 +46,12 @@ enum
 #define PROFILER_BEGIN_FRAME ::ad::renderer::getGlobalProfiler().beginFrame()
 #define PROFILER_END_FRAME ::ad::renderer::getGlobalProfiler().endFrame()
 
-#define PROFILER_PUSH_SECTION(name, ...) \
+#define PROFILER_PUSH_RECURRING_SECTION(name, ...) \
     ::ad::renderer::getGlobalProfiler().beginSection(::ad::renderer::EntryNature::Recurring, name, {__VA_ARGS__})
 
 #define PROFILER_POP_SECTION ::ad::renderer::getGlobalProfiler().popCurrentSection()
 
-#define PROFILER_SCOPE_SECTION(name, ...) \
+#define PROFILER_SCOPE_RECURRING_SECTION(name, ...) \
     auto profilerScopedSection = ::ad::renderer::getGlobalProfiler().scopeSection(::ad::renderer::EntryNature::Recurring, name, {__VA_ARGS__})
 
 #define PROFILER_PRINT_TO_STREAM(ostream) \
@@ -62,10 +62,10 @@ enum
 #define PROFILER_BEGIN_FRAME
 #define PROFILER_END_FRAME
 
-#define PROFILER_PUSH_SECTION(name, ...) 
+#define PROFILER_PUSH_RECURRING_SECTION(name, ...) 
 #define PROFILER_POP_SECTION
 
-#define PROFILER_SCOPE_SECTION(name, ...)
+#define PROFILER_SCOPE_RECURRING_SECTION(name, ...)
 
 #define PROFILER_PRINT_TO_STREAM(ostream)
 

--- a/src/apps/refactor_proto/refactor_proto/Profiling.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiling.h
@@ -47,7 +47,7 @@ enum
 #define PROFILER_END_FRAME ::ad::renderer::getGlobalProfiler().endFrame()
 
 #define PROFILER_PUSH_SECTION(name, ...) \
-    ::ad::renderer::getGlobalProfiler().beginSectionRecurring(name, {__VA_ARGS__})
+    ::ad::renderer::getGlobalProfiler().beginSection(name, {__VA_ARGS__})
 
 #define PROFILER_POP_SECTION ::ad::renderer::getGlobalProfiler().popCurrentSection()
 

--- a/src/apps/refactor_proto/refactor_proto/Profiling.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiling.h
@@ -47,12 +47,12 @@ enum
 #define PROFILER_END_FRAME ::ad::renderer::getGlobalProfiler().endFrame()
 
 #define PROFILER_PUSH_SECTION(name, ...) \
-    ::ad::renderer::getGlobalProfiler().beginSection(name, {__VA_ARGS__})
+    ::ad::renderer::getGlobalProfiler().beginSection(::ad::renderer::EntryNature::Recurring, name, {__VA_ARGS__})
 
 #define PROFILER_POP_SECTION ::ad::renderer::getGlobalProfiler().popCurrentSection()
 
 #define PROFILER_SCOPE_SECTION(name, ...) \
-    auto profilerScopedSection = ::ad::renderer::getGlobalProfiler().scopeSection(name, {__VA_ARGS__})
+    auto profilerScopedSection = ::ad::renderer::getGlobalProfiler().scopeSection(::ad::renderer::EntryNature::Recurring, name, {__VA_ARGS__})
 
 #define PROFILER_PRINT_TO_STREAM(ostream) \
     ::ad::renderer::getGlobalProfiler().prettyPrint(ostream);

--- a/src/apps/refactor_proto/refactor_proto/Profiling.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiling.h
@@ -49,10 +49,18 @@ enum
 #define PROFILER_PUSH_RECURRING_SECTION(name, ...) \
     ::ad::renderer::getGlobalProfiler().beginSection(::ad::renderer::EntryNature::Recurring, name, {__VA_ARGS__})
 
-#define PROFILER_POP_SECTION ::ad::renderer::getGlobalProfiler().popCurrentSection()
+#define PROFILER_PUSH_SINGLESHOT_SECTION(name, ...) \
+    ::ad::renderer::getGlobalProfiler().beginSection(::ad::renderer::EntryNature::SingleShot, name, {__VA_ARGS__})
+
+#define PROFILER_POP_RECURRING_SECTION ::ad::renderer::getGlobalProfiler().popCurrentSection()
+
+#define PROFILER_POP_SECTION(entryIdx) ::ad::renderer::getGlobalProfiler().endSection(entryIdx)
 
 #define PROFILER_SCOPE_RECURRING_SECTION(name, ...) \
     auto profilerScopedSection = ::ad::renderer::getGlobalProfiler().scopeSection(::ad::renderer::EntryNature::Recurring, name, {__VA_ARGS__})
+
+#define PROFILER_SCOPE_SINGLESHOT_SECTION(name, ...) \
+    auto profilerScopedSection = ::ad::renderer::getGlobalProfiler().scopeSection(::ad::renderer::EntryNature::SingleShot, name, {__VA_ARGS__})
 
 #define PROFILER_PRINT_TO_STREAM(ostream) \
     ::ad::renderer::getGlobalProfiler().prettyPrint(ostream);
@@ -63,9 +71,12 @@ enum
 #define PROFILER_END_FRAME
 
 #define PROFILER_PUSH_RECURRING_SECTION(name, ...) 
-#define PROFILER_POP_SECTION
+#define PROFILER_PUSH_SINGLESHOT_SECTION(name, ...)
+#define PROFILER_POP_RECURRING_SECTION
 
 #define PROFILER_SCOPE_RECURRING_SECTION(name, ...)
+
+#define PROFILER_SCOPE_SINGLESHOT_SECTION(name, ...)
 
 #define PROFILER_PRINT_TO_STREAM(ostream)
 

--- a/src/apps/refactor_proto/refactor_proto/Profiling.h
+++ b/src/apps/refactor_proto/refactor_proto/Profiling.h
@@ -47,7 +47,7 @@ enum
 #define PROFILER_END_FRAME ::ad::renderer::getGlobalProfiler().endFrame()
 
 #define PROFILER_PUSH_SECTION(name, ...) \
-    ::ad::renderer::getGlobalProfiler().beginSection(name, {__VA_ARGS__})
+    ::ad::renderer::getGlobalProfiler().beginSectionRecurring(name, {__VA_ARGS__})
 
 #define PROFILER_POP_SECTION ::ad::renderer::getGlobalProfiler().popCurrentSection()
 

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
@@ -219,7 +219,7 @@ namespace {
             PROFILER_PUSH_RECURRING_SECTION("discard_2", CpuTime);
             const IntrospectProgram & selectedProgram = *aCall.mProgram;
             const graphics::VertexArrayObject & vao = *aCall.mVao;
-            PROFILER_POP_SECTION;
+            PROFILER_POP_RECURRING_SECTION;
 
             // TODO Ad 2023/10/05: #perf #azdo 
             // Only change what is necessary, instead of rebiding everything each time.
@@ -227,7 +227,7 @@ namespace {
             {
                 PROFILER_PUSH_RECURRING_SECTION("bind_VAO", CpuTime);
                 graphics::ScopedBind vaoScope{vao};
-                PROFILER_POP_SECTION;
+                PROFILER_POP_RECURRING_SECTION;
                 
                 {
                     PROFILER_SCOPE_RECURRING_SECTION("set_buffer_backed_blocks", CpuTime);
@@ -255,7 +255,7 @@ namespace {
 
                 PROFILER_PUSH_RECURRING_SECTION("bind_program", CpuTime);
                 graphics::ScopedBind programScope{selectedProgram};
-                PROFILER_POP_SECTION;
+                PROFILER_POP_RECURRING_SECTION;
 
                 {
                     // TODO Ad 2023/08/23: Measuring GPU time here has a x2 impact on cpu performance

--- a/src/apps/refactor_proto/refactor_proto/main.cpp
+++ b/src/apps/refactor_proto/refactor_proto/main.cpp
@@ -112,11 +112,13 @@ void runApplication(int argc, char * argv[])
 
     auto scopeProfiler = renderer::scopeGlobalProfiler();
 
+    auto loadingSection = PROFILER_PUSH_SINGLESHOT_SECTION("rendergraph_loading", renderer::CpuTime);
     renderer::RenderGraph renderGraph{
         glfwApp.getAppInterface(),
         handleArguments(argc, argv),
         imguiUi,
     };
+    PROFILER_POP_SECTION(loadingSection);
 
     renderer::Profiler::Values<std::uint64_t> frameDuration;
     Clock::time_point previousFrame = Clock::now();
@@ -164,7 +166,7 @@ void runApplication(int argc, char * argv[])
 
         glfwApp.swapBuffers();
 
-        PROFILER_POP_SECTION; // frame
+        PROFILER_POP_RECURRING_SECTION; // frame
         PROFILER_END_FRAME;
 
         // Note: the printing of the profiler content happens out of the frame, so its time is excluded from profiler's frame time

--- a/src/apps/refactor_proto/refactor_proto/main.cpp
+++ b/src/apps/refactor_proto/refactor_proto/main.cpp
@@ -45,7 +45,7 @@ void showGui(imguiui::ImguiUi & imguiUi,
              renderer::RenderGraph & renderGraph,
              const std::string & aProfilerOutput)
 {
-    PROFILER_SCOPE_SECTION("imgui ui", renderer::CpuTime, renderer::GpuTime);
+    PROFILER_SCOPE_RECURRING_SECTION("imgui ui", renderer::CpuTime, renderer::GpuTime);
 
     imguiUi.newFrame();
 
@@ -129,10 +129,10 @@ void runApplication(int argc, char * argv[])
     while (glfwApp.handleEvents())
     {
         PROFILER_BEGIN_FRAME;
-        PROFILER_PUSH_SECTION("frame", renderer::CpuTime, renderer::GpuTime);
+        PROFILER_PUSH_RECURRING_SECTION("frame", renderer::CpuTime, renderer::GpuTime);
 
         {
-            PROFILER_SCOPE_SECTION("fps_counter", renderer::CpuTime);
+            PROFILER_SCOPE_RECURRING_SECTION("fps_counter", renderer::CpuTime);
             {
                 // TODO this could be integrated into the Profiler::beginFrame()
                 // Currently measure the real frame time (not just the time between beginFrame()/endFrame())

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
@@ -21,12 +21,12 @@ struct ProviderApi : public ProviderInterface
         ProviderInterface{aQuantityName, aUnit}
     {}
 
-    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
+    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
     {
         getRecord(aEntryIndex, aCurrentFrame) = (gl.get().*F_getter)();
     }
 
-    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
+    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
     {
         auto & count = getRecord(aEntryIndex, aCurrentFrame);
         count = (gl.get().*F_getter)() - count;

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
@@ -32,9 +32,9 @@ struct ProviderApi : public ProviderInterface
         count = (gl.get().*F_getter)() - count;
     }
 
-    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override
+    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult) override
     {
-        aSampleResult = (GLuint)getRecord(aEntryIndex, aQueryFrame);
+        aSampleResult = (Sample_t)getRecord(aEntryIndex, aQueryFrame);
         return true;
     }
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderApi.h
@@ -21,12 +21,12 @@ struct ProviderApi : public ProviderInterface
         ProviderInterface{aQuantityName, aUnit}
     {}
 
-    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
+    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
     {
         getRecord(aEntryIndex, aCurrentFrame) = (gl.get().*F_getter)();
     }
 
-    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
+    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override
     {
         auto & count = getRecord(aEntryIndex, aCurrentFrame);
         count = (gl.get().*F_getter)() - count;

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
@@ -22,11 +22,11 @@ void ProviderCPUTime::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentF
 }
 
 
-bool ProviderCPUTime::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult)
+bool ProviderCPUTime::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult)
 {
     const auto & interval = getInterval(aEntryIndex, aQueryFrame);
     // TODO address this case (potentially with Values of the correct type)
-    aSampleResult = (GLuint)(interval.mEnd - interval.mBegin).count();
+    aSampleResult = (Sample_t)(interval.mEnd - interval.mBegin).count();
     //if(aSampleResult == 0)
     //{
     //    SELOG(warn)("Read a null sample, resolution of the timer might not be enough for some sections.");

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
@@ -10,13 +10,13 @@ ProviderCPUTime::TimeInterval & ProviderCPUTime::getInterval(EntryIndex aEntryIn
 }
 
 
-void ProviderCPUTime::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCPUTime::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame).mBegin = Clock::now();
 }
 
 
-void ProviderCPUTime::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCPUTime::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame).mEnd = Clock::now();
 }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.cpp
@@ -10,13 +10,13 @@ ProviderCPUTime::TimeInterval & ProviderCPUTime::getInterval(EntryIndex aEntryIn
 }
 
 
-void ProviderCPUTime::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCPUTime::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame).mBegin = Clock::now();
 }
 
 
-void ProviderCPUTime::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCPUTime::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame).mEnd = Clock::now();
 }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
@@ -18,8 +18,8 @@ struct ProviderCPUTime : public ProviderInterface {
                            Ratio::MakeConversion<Clock::period, std::micro>()}
     {}
 
-    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
@@ -21,7 +21,7 @@ struct ProviderCPUTime : public ProviderInterface {
     void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
     void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
-    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
+    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
     { mTimePoints.resize(aNewEntriesCount * Profiler::CountSubframes() ); }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderCpu.h
@@ -18,8 +18,8 @@ struct ProviderCPUTime : public ProviderInterface {
                            Ratio::MakeConversion<Clock::period, std::micro>()}
     {}
 
-    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
@@ -13,7 +13,7 @@ graphics::Query & ProviderGL::getQuery(EntryIndex aEntryIndex, std::uint32_t aCu
 }
 
 
-void ProviderGL::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGL::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     assert(!mActive);
     mActive = true;
@@ -21,7 +21,7 @@ void ProviderGL::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFram
 }
 
 
-void ProviderGL::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGL::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     glEndQueryIndexed(GL_PRIMITIVES_GENERATED, 0);
     mActive = false;
@@ -62,13 +62,13 @@ graphics::Query & ProviderGLTime::getQuery(EntryIndex aEntryIndex, std::uint32_t
                         + (aEvent == Event::Begin ? 0 : 1)];
 }
 
-void ProviderGLTime::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGLTime::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     glQueryCounter(getQuery(aEntryIndex, aCurrentFrame, Event::Begin), GL_TIMESTAMP);
 }
 
 
-void ProviderGLTime::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGLTime::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     glQueryCounter(getQuery(aEntryIndex, aCurrentFrame, Event::End), GL_TIMESTAMP);
 }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
@@ -50,7 +50,7 @@ bool getGLQueryResult(const graphics::Query & aQuery, T_result & aResult)
 }
 
 
-bool ProviderGL::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult)
+bool ProviderGL::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult)
 {
     return getGLQueryResult(getQuery(aEntryIndex, aQueryFrame), aSampleResult);
 }
@@ -74,13 +74,13 @@ void ProviderGLTime::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFr
 }
 
 
-bool ProviderGLTime::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult)
+bool ProviderGLTime::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult)
 {
     GLuint64 beginTime, endTime; 
     bool available = getGLQueryResult(getQuery(aEntryIndex, aQueryFrame, Event::Begin), beginTime);
     available &= getGLQueryResult(getQuery(aEntryIndex, aQueryFrame, Event::End), endTime);
 
-    aSampleResult = static_cast<GLuint>((endTime - beginTime) / 1000);
+    aSampleResult = static_cast<Sample_t>((endTime - beginTime) / 1000);
     return available;
 }
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.cpp
@@ -13,7 +13,7 @@ graphics::Query & ProviderGL::getQuery(EntryIndex aEntryIndex, std::uint32_t aCu
 }
 
 
-void ProviderGL::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGL::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     assert(!mActive);
     mActive = true;
@@ -21,7 +21,7 @@ void ProviderGL::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCu
 }
 
 
-void ProviderGL::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGL::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     glEndQueryIndexed(GL_PRIMITIVES_GENERATED, 0);
     mActive = false;
@@ -62,13 +62,13 @@ graphics::Query & ProviderGLTime::getQuery(EntryIndex aEntryIndex, std::uint32_t
                         + (aEvent == Event::Begin ? 0 : 1)];
 }
 
-void ProviderGLTime::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGLTime::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     glQueryCounter(getQuery(aEntryIndex, aCurrentFrame, Event::Begin), GL_TIMESTAMP);
 }
 
 
-void ProviderGLTime::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderGLTime::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     glQueryCounter(getQuery(aEntryIndex, aCurrentFrame, Event::End), GL_TIMESTAMP);
 }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
@@ -15,8 +15,8 @@ struct ProviderGL : public ProviderInterface
         ProviderInterface{"GPU generated", "primitive(s)"}
     {}
 
-    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
@@ -44,8 +44,8 @@ struct ProviderGLTime : public ProviderInterface
         ProviderInterface{"GPU time", "us"}
     {}
 
-    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
@@ -15,8 +15,8 @@ struct ProviderGL : public ProviderInterface
         ProviderInterface{"GPU generated", "primitive(s)"}
     {}
 
-    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
@@ -44,8 +44,8 @@ struct ProviderGLTime : public ProviderInterface
         ProviderInterface{"GPU time", "us"}
     {}
 
-    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderGL.h
@@ -18,7 +18,7 @@ struct ProviderGL : public ProviderInterface
     void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
     void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
-    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
+    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
     { mQueriesPool.resize(aNewEntriesCount * Profiler::CountSubframes() ); }
@@ -47,7 +47,7 @@ struct ProviderGLTime : public ProviderInterface
     void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
     void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
-    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
+    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult) override;
 
     // This is currently very conservative, having enough queries to recorded begin/end time for each section
     // in each "frame delay slot".

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.cpp
@@ -1,0 +1,34 @@
+#include "ProviderRdtsc.h"
+
+#include "../Logging.h"
+
+
+namespace ad::renderer {
+
+
+Ratio evluateRtscTickPeriodMicroSeconds()
+{
+    auto clockStart = Clock::now();
+    auto tickCount = readTsc();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+    auto clockDuration = Clock::now() - clockStart;
+    tickCount = readTsc() - tickCount;
+
+    std::uint64_t ticksPerMicrosecond =
+        tickCount / getTicks<std::chrono::microseconds>(clockDuration);
+    SELOG(info)("TSC frequency evaluated to: {} MHz", ticksPerMicrosecond);
+
+    // Check it does not overflow
+    //assert(ticksPerMicrosecond < std::numeric_limits<Sample_t>::max());
+    static_assert(std::is_same_v<ProviderInterface::Sample_t, std::uint64_t>);
+
+    return Ratio{
+        .num = 1,
+        .den = ticksPerMicrosecond,
+    };
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
@@ -15,8 +15,8 @@ struct ProviderCpuRdtsc : public ProviderInterface
 
     ProviderCpuRdtsc();
 
-    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
@@ -73,13 +73,13 @@ inline ProviderCpuRdtsc::TickCount_t & ProviderCpuRdtsc::getInterval(EntryIndex 
 }
 
 
-inline void ProviderCpuRdtsc::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+inline void ProviderCpuRdtsc::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame) = readTsc();
 }
 
 
-inline void ProviderCpuRdtsc::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+inline void ProviderCpuRdtsc::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     auto & interval = getInterval(aEntryIndex, aCurrentFrame);
     interval = readTsc() - interval ;

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
@@ -37,7 +37,7 @@ inline std::uint64_t readTsc()
 }
 
 
-Ratio evluateRtscTickPeriod()
+Ratio evluateRtscTickPeriodMicroSeconds()
 {
     auto clockStart = Clock::now();
     auto tickCount = readTsc();
@@ -64,7 +64,7 @@ Ratio evluateRtscTickPeriod()
 //
 
 inline ProviderCpuRdtsc::ProviderCpuRdtsc():
-        ProviderInterface{"CPU (tsc)", "us", evluateRtscTickPeriod()}
+        ProviderInterface{"CPU (tsc)", "us", evluateRtscTickPeriodMicroSeconds()}
     {}
 
 inline ProviderCpuRdtsc::TickCount_t & ProviderCpuRdtsc::getInterval(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
@@ -89,7 +89,9 @@ inline void ProviderCpuRdtsc::endSection(EntryIndex aEntryIndex, std::uint32_t a
 bool ProviderCpuRdtsc::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult)
 {
     const auto & interval = getInterval(aEntryIndex, aQueryFrame);
-    aSampleResult = (GLuint)(interval);
+    // TODO this assert should disappear when we have a better solution.
+    assert(interval <= std::numeric_limits<GLuint>::max());
+    aSampleResult = (GLuint)(interval / 1000);
     return true;
 }
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
@@ -15,8 +15,8 @@ struct ProviderCpuRdtsc : public ProviderInterface
 
     ProviderCpuRdtsc();
 
-    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 
@@ -73,13 +73,13 @@ inline ProviderCpuRdtsc::TickCount_t & ProviderCpuRdtsc::getInterval(EntryIndex 
 }
 
 
-inline void ProviderCpuRdtsc::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+inline void ProviderCpuRdtsc::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame) = readTsc();
 }
 
 
-inline void ProviderCpuRdtsc::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+inline void ProviderCpuRdtsc::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     auto & interval = getInterval(aEntryIndex, aCurrentFrame);
     interval = readTsc() - interval ;

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
@@ -4,8 +4,22 @@
 #include "../Profiler.h"
 #include "../Time.h"
 
+#ifdef _WIN32
+#include <intrin.h>
+#endif
+
 
 namespace ad::renderer {
+
+
+inline std::uint64_t readTsc()
+{
+    unsigned int ui;
+    return __rdtscp(&ui);
+}
+
+
+Ratio evluateRtscTickPeriodMicroSeconds();
 
 
 struct ProviderCpuRdtsc : public ProviderInterface
@@ -29,37 +43,6 @@ struct ProviderCpuRdtsc : public ProviderInterface
     std::vector<TickCount_t> mIntervals;
 };
 
-
-inline std::uint64_t readTsc()
-{
-    unsigned int ui;
-    return __rdtscp(&ui);
-}
-
-
-Ratio evluateRtscTickPeriodMicroSeconds()
-{
-    auto clockStart = Clock::now();
-    auto tickCount = readTsc();
-
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
-
-    auto clockDuration = Clock::now() - clockStart;
-    tickCount = readTsc() - tickCount;
-
-    std::uint64_t ticksPerMicrosecond =
-        tickCount / getTicks<std::chrono::microseconds>(clockDuration);
-    SELOG(info)("TSC frequency evaluated to: {} MHz", ticksPerMicrosecond);
-
-    // Check it does not overflow
-    //assert(ticksPerMicrosecond < std::numeric_limits<Sample_t>::max());
-    static_assert(std::is_same_v<ProviderInterface::Sample_t, std::uint64_t>);
-
-    return Ratio{
-        .num = 1,
-        .den = ticksPerMicrosecond,
-    };
-}
 
 //
 // Implementations
@@ -88,7 +71,7 @@ inline void ProviderCpuRdtsc::endSection(EntryIndex aEntryIndex, std::uint32_t a
 }
 
 
-bool ProviderCpuRdtsc::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult)
+inline bool ProviderCpuRdtsc::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult)
 {
     const auto & interval = getInterval(aEntryIndex, aQueryFrame);
     aSampleResult = interval;

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderRdtsc.h
@@ -6,6 +6,8 @@
 
 #ifdef _WIN32
 #include <intrin.h>
+#else
+#include <x86intrin.h>
 #endif
 
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
@@ -6,6 +6,8 @@
 #define NOMINMAX
 #include <Windows.h>
 
+#include <cassert>
+
 
 namespace{
 
@@ -18,11 +20,12 @@ namespace{
     }
 
 
-    inline std::int64_t getTickFrequency()
+    inline std::uint64_t getTickFrequency()
     {
         LARGE_INTEGER tmp;
         QueryPerformanceFrequency(&tmp);
-        return tmp.QuadPart;
+        assert(tmp.QuadPart >= 0);
+        return (std::uint64_t)tmp.QuadPart;
     }
 
 
@@ -36,7 +39,7 @@ ProviderCpuPerformanceCounter::ProviderCpuPerformanceCounter() :
     ProviderInterface{
         "CPU (perfc)",
         "us",
-        Ratio::MakeConversion(Ratio{1, (GLuint)getTickFrequency()}, Ratio::MakeRatio<std::micro>())}
+        Ratio::MakeConversion(Ratio{1, getTickFrequency()}, Ratio::MakeRatio<std::micro>())}
 {}
 
 
@@ -58,11 +61,9 @@ void ProviderCpuPerformanceCounter::endSection(EntryIndex aEntryIndex, std::uint
 }
 
 
-bool ProviderCpuPerformanceCounter::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult)
+bool ProviderCpuPerformanceCounter::provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult)
 {
-    const auto & interval = getInterval(aEntryIndex, aQueryFrame);
-    // TODO address this case (potentially with Values of the correct type)
-    aSampleResult = (GLuint)(interval);
+    aSampleResult = getInterval(aEntryIndex, aQueryFrame);
     return true;
 }
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
@@ -46,13 +46,13 @@ ProviderCpuPerformanceCounter::TimeInterval & ProviderCpuPerformanceCounter::get
 }
 
 
-void ProviderCpuPerformanceCounter::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCpuPerformanceCounter::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame) = -::getTicks();
 }
 
 
-void ProviderCpuPerformanceCounter::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCpuPerformanceCounter::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame) += ::getTicks();
 }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.cpp
@@ -46,13 +46,13 @@ ProviderCpuPerformanceCounter::TimeInterval & ProviderCpuPerformanceCounter::get
 }
 
 
-void ProviderCpuPerformanceCounter::beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCpuPerformanceCounter::beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame) = -::getTicks();
 }
 
 
-void ProviderCpuPerformanceCounter::endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
+void ProviderCpuPerformanceCounter::endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame)
 {
     getInterval(aEntryIndex, aCurrentFrame) += ::getTicks();
 }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
@@ -17,7 +17,7 @@ struct ProviderCpuPerformanceCounter : public ProviderInterface
     void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
     void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
-    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
+    bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, Sample_t & aSampleResult) override;
 
     void resize(std::size_t aNewEntriesCount) override
     { mTimePoints.resize(aNewEntriesCount * Profiler::CountSubframes() ); }

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
@@ -14,8 +14,8 @@ struct ProviderCpuPerformanceCounter : public ProviderInterface
 
     ProviderCpuPerformanceCounter();
 
-    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 

--- a/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
+++ b/src/apps/refactor_proto/refactor_proto/providers/ProviderWindows.h
@@ -14,8 +14,8 @@ struct ProviderCpuPerformanceCounter : public ProviderInterface
 
     ProviderCpuPerformanceCounter();
 
-    void beginSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
-    void endSectionRecurring(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void beginSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
+    void endSection(EntryIndex aEntryIndex, std::uint32_t aCurrentFrame) override;
 
     bool provide(EntryIndex aEntryIndex, uint32_t aQueryFrame, GLuint & aSampleResult) override;
 


### PR DESCRIPTION
closes #113
- Templatize "Profiler::Entry", make an alias for the recurring Entry.
- Introduce SingleShotEntry type alias.
- Rename begin/endSection() to begin/endSectionRecurring().
- Revert "Rename begin/endSection() to begin/endSectionRecurring()."
- Revert "Introduce SingleShotEntry type alias."
- Revert "Templatize "Profiler::Entry", make an alias for the recurring Entry."
- Factorize the entry setup, preparing for SingleShot entries.
- Add EntryNature parameter to sections, to allow for single shots.
- Rename profiling macros to make the recurring nature explicit.
- Complete the implementation of single shots, up to presenting results.
- Assert on rdtsc value conversion, causing issues with sections > 1s.
- Change Value sample type from GLuint to std::uint64_t.
- Fix issues with headers not included from ProviderRdtsc.
- Rewrite fetchNextEntry(), to factorize code paths and optimize op count.
- Implement more robust logic, to query singleshots after delay frames.
- Fix bug, only resetting values of recurring entries.
