### PR TITLE
topic/snacman#115 multipass transparency

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -22,17 +22,17 @@ class SnacmanConan(ConanFile):
     }
 
     requires = (
-        ("entity/e3b28a133b@adnn/develop"),
-        ("graphics/e66adcad71@adnn/develop"),
-        ("handy/ef8f663bb0@adnn/develop"),
+        ("entity/401d8462ac@adnn/develop"),
+        ("graphics/b26cc7e19b@adnn/develop"),
+        ("handy/3658039b72@adnn/develop"),
         ("math/4c3fcbd2f5@adnn/develop"),
-        ("MarkovJunior.cpp/fd8e207bee@adnn/develop"),
+        ("MarkovJunior.cpp/443432fad3@adnn/develop"),
 
         # Waiting for my PR on conan-center for assimp to get merged in
         # see: https://github.com/conan-io/conan-center-index/pull/20185
         # I manually exported the recipe and uploaded it.
         ("assimp/5.3.1@adnn/develop"),
-        ("spdlog/1.11.0@#1e0f4eb6338d05e4bd6fcc6bf4734172"),
+        ("spdlog/1.13.0"),
         ("nlohmann_json/3.11.2"),
 
         # The overrides (who will think about reviewing them?)

--- a/conan/workspaces/complete.yml
+++ b/conan/workspaces/complete.yml
@@ -1,11 +1,11 @@
 editables:
-    MarkovJunior.cpp/fd8e207bee@adnn/develop:
+    MarkovJunior.cpp/443432fad3@adnn/develop:
         path: ../../../MarkovJunior.cpp/conan
-    entity/e3b28a133b@adnn/develop:
+    entity/401d8462ac@adnn/develop:
         path: ../../../entity/conan
-    graphics/e66adcad71@adnn/develop:
+    graphics/b26cc7e19b@adnn/develop:
         path: ../../../graphics/conan
-    handy/ef8f663bb0@adnn/develop:
+    handy/3658039b72@adnn/develop:
         path: ../../../handy/conan
     math/4c3fcbd2f5@adnn/develop:
         path: ../../../math/conan

--- a/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
+++ b/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
@@ -39,6 +39,7 @@ set(${TARGET_NAME}_SOURCES
     main.cpp
 
     Camera.cpp
+    DrawQuad.cpp
     IntrospectProgram.cpp
     Loader.cpp
     Logging.cpp

--- a/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
+++ b/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
@@ -9,6 +9,7 @@ set(${TARGET_NAME}_HEADERS
     Camera.h
     Commons.h
     Cube.h
+    DrawQuad.h
     GlApi.h
     IntrospectProgram.h
     Json.h

--- a/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
+++ b/src/apps/refactor_proto/refactor_proto/CMakeLists.txt
@@ -17,6 +17,7 @@ set(${TARGET_NAME}_HEADERS
     Logging.h
     Material.h
     Model.h
+    Pass.h
     Profiler.h
     Profiling.h
     RenderGraph.h
@@ -25,6 +26,7 @@ set(${TARGET_NAME}_HEADERS
     Scene.h
     SceneGui.h
     SetupDrawing.h
+    TheGraph.h
     Time.h
 
     providers/ProviderApi.h
@@ -40,12 +42,14 @@ set(${TARGET_NAME}_SOURCES
     IntrospectProgram.cpp
     Loader.cpp
     Logging.cpp
+    Pass.cpp
     Profiler.cpp
     Profiling.cpp
     RenderGraph.cpp
     Scene.cpp
     SceneGui.cpp
     SetupDrawing.cpp
+    TheGraph.cpp
 
     providers/ProviderCpu.cpp
     providers/ProviderGL.cpp

--- a/src/apps/refactor_proto/refactor_proto/Camera.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Camera.cpp
@@ -86,6 +86,17 @@ void changeOrthographicViewportHeight(Camera & aCamera, float aNewHeight)
 }
 
 
+std::pair<float/*near*/, float/*far*/> getNearFarPlanes(const Camera & aCamera)
+{
+    return std::visit(
+        [](auto aParams) -> std::pair<float, float>
+        {
+            return {aParams.mNearZ, aParams.mFarZ};
+        },
+        aCamera.getProjectionParameters());
+}
+
+
 ////////
 // Orbital
 ////////

--- a/src/apps/refactor_proto/refactor_proto/Camera.h
+++ b/src/apps/refactor_proto/refactor_proto/Camera.h
@@ -79,6 +79,9 @@ private:
 void changeOrthographicViewportHeight(Camera & aCamera, float aNewHeight);
 
 
+std::pair<float/*near*/, float/*far*/> getNearFarPlanes(const Camera & aCamera);
+
+
 // TODO factorize, this is more general than purely camera movements.
 
 /// @brief `Orbital` represent a position on a spherical orbit around an origin.

--- a/src/apps/refactor_proto/refactor_proto/DrawQuad.cpp
+++ b/src/apps/refactor_proto/refactor_proto/DrawQuad.cpp
@@ -1,0 +1,148 @@
+#include "DrawQuad.h"
+
+#include <renderer/ScopeGuards.h>
+#include <renderer/Shading.h>
+#include <renderer/Uniforms.h>
+#include <renderer/VertexSpecification.h>
+
+
+namespace ad::renderer {
+
+
+namespace {
+
+    const char * gVertexShaderTex = R"#(
+        #version 420
+
+        const vec2 pos_data[4] = vec2[] (
+            vec2(-1.0, -1.0),
+            vec2( 1.0, -1.0),
+            vec2(-1.0,  1.0),
+            vec2( 1.0,  1.0)
+        );
+
+        const vec2 tex_data[4] = vec2[] (
+            vec2(0.0, 0.0),
+            vec2(1.0, 0.0),
+            vec2(0.0, 1.0),
+            vec2(1.0, 1.0)
+        );
+
+        out vec2 ex_Uv;
+
+        void main() 
+        {
+            ex_Uv = tex_data[gl_VertexID];
+            gl_Position = vec4(pos_data[gl_VertexID], 0.0, 1.0);
+        }
+    )#";
+
+
+    const char * gFragmentShaderTex = R"#(
+        #version 420
+
+        in vec2 ex_Uv;
+
+        layout(binding=0) uniform sampler2D u_Texture;
+
+        uniform int u_SourceChannel;
+
+        uniform unsigned int u_Linearization;
+        uniform float u_NearDistance;
+        uniform float u_FarDistance;
+
+        out vec4 out_Color;
+
+        void main()
+        {
+            vec4 sampled = texture(u_Texture, ex_Uv);
+            vec4 color = sampled;
+            if(u_SourceChannel >= 0)
+            {
+                color = vec4(vec3(sampled[u_SourceChannel]), 1.0);
+            }
+
+            if(u_Linearization == 1)
+            {
+                // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
+                float linearDepth = 
+                    (2 * u_NearDistance) 
+                    / (u_FarDistance + u_NearDistance - color.r * (u_FarDistance - u_NearDistance));
+                
+                color = vec4(vec3(linearDepth), 1.0);
+            }
+            else if(u_Linearization == 2)
+            {
+                // ATTENTION: This results in a black screen, this method does not seem to work with our projection
+
+                // see: http://web.archive.org/web/20130416194336/http://olivers.posterous.com/linear-depth-in-glsl-for-real
+
+                // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
+                float linearDepth = 
+                    (2 * u_NearDistance * u_FarDistance) 
+                    / (u_FarDistance + u_NearDistance - (2 * color.r - 1) * (u_FarDistance - u_NearDistance));
+                
+                color = vec4(vec3(linearDepth), 1.0);
+            }
+            else if(u_Linearization == 3)
+            {
+                // see: https://casual-effects.blogspot.com/2015/03/implemented-weighted-blended-order.html#2d_compositing_pass
+                color = vec4(color.rgb / max(color.a, 0.00001), 1.0);
+            }
+
+            //
+            // Gamma correction
+            //
+            float gamma = 2.2;
+            // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
+            // (The monitor will do the gamma expansion.)
+            out_Color = vec4(pow(color.xyz, vec3(1./gamma)), color.w);
+        }
+    )#";
+
+
+} // unnamed namespace
+
+
+void drawQuad(DrawQuadParameters aParameters)
+{
+    static graphics::VertexArrayObject dummyVao;
+    static graphics::Program program = 
+        graphics::makeLinkedProgram({
+            {GL_VERTEX_SHADER, gVertexShaderTex},
+            {GL_FRAGMENT_SHADER, gFragmentShaderTex},
+        });
+
+    // Sadly a non zero VAO must be bound for any draw call
+    graphics::ScopedBind boundVao{dummyVao};
+    graphics::ScopedBind boundProgram{program};
+
+    graphics::setUniform(program, "u_SourceChannel", aParameters.mSourceChannel);
+    graphics::setUniform(program, "u_Linearization", aParameters.mOperation);
+    graphics::setUniform(program, "u_NearDistance",  aParameters.mNearDistance);
+    graphics::setUniform(program, "u_FarDistance",   aParameters.mFarDistance);
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+
+QuadDrawer::QuadDrawer(graphics::ShaderSourceView aFragmentCode) :
+    mProgram{graphics::makeLinkedProgram({
+        {GL_VERTEX_SHADER, gVertexShaderTex},
+        {GL_FRAGMENT_SHADER, aFragmentCode},
+    })}
+{}
+
+
+void QuadDrawer::drawQuad() const
+{
+    static graphics::VertexArrayObject dummyVao;
+    // Sadly a non zero VAO must be bound for any draw call
+    graphics::ScopedBind boundVao{dummyVao};
+    graphics::ScopedBind boundProgram{mProgram};
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/DrawQuad.h
+++ b/src/apps/refactor_proto/refactor_proto/DrawQuad.h
@@ -1,134 +1,44 @@
 #pragma once
 
-#include <renderer/Uniforms.h>
+
+#include <renderer/GL_Loader.h>
 #include <renderer/Shading.h>
-#include <renderer/VertexSpecification.h>
 
 
 namespace ad::renderer {
 
 
-const char * gVertexShaderTex = R"#(
-    #version 420
-
-    const vec2 pos_data[4] = vec2[] (
-        vec2(-1.0, -1.0),
-        vec2( 1.0, -1.0),
-        vec2(-1.0,  1.0),
-        vec2( 1.0,  1.0)
-    );
-
-    const vec2 tex_data[4] = vec2[] (
-        vec2(0.0, 0.0),
-        vec2(1.0, 0.0),
-        vec2(0.0, 1.0),
-        vec2(1.0, 1.0)
-    );
-
-    out vec2 ex_Uv;
-
-    void main() 
-    {
-        ex_Uv = tex_data[gl_VertexID];
-        gl_Position = vec4(pos_data[gl_VertexID], 0.0, 1.0);
-    }
-)#";
-
-
-const char * gFragmentShaderTex = R"#(
-    #version 420
-
-    in vec2 ex_Uv;
-
-    layout(binding=0) uniform sampler2D u_Texture;
-
-    uniform int u_SourceChannel;
-
-    uniform unsigned int u_Linearization;
-    uniform float u_NearDistance;
-    uniform float u_FarDistance;
-
-    out vec4 out_Color;
-
-    void main()
-    {
-        vec4 sampled = texture(u_Texture, ex_Uv);
-        vec4 color = sampled;
-        if(u_SourceChannel >= 0)
-        {
-            color = vec4(vec3(sampled[u_SourceChannel]), 1.0);
-        }
-
-        if(u_Linearization == 1)
-        {
-            // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
-            float linearDepth = 
-                (2 * u_NearDistance) 
-                / (u_FarDistance + u_NearDistance - color.r * (u_FarDistance - u_NearDistance));
-            
-            color = vec4(vec3(linearDepth), 1.0);
-        }
-        else if(u_Linearization == 2)
-        {
-            // ATTENTION: This results in a black screen, this method does not seem to work with our projection
-
-            // see: http://web.archive.org/web/20130416194336/http://olivers.posterous.com/linear-depth-in-glsl-for-real
-
-            // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
-            float linearDepth = 
-                (2 * u_NearDistance * u_FarDistance) 
-                / (u_FarDistance + u_NearDistance - (2 * color.r - 1) * (u_FarDistance - u_NearDistance));
-            
-            color = vec4(vec3(linearDepth), 1.0);
-        }
-
-        //
-        // Gamma correction
-        //
-        float gamma = 2.2;
-        // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
-        // (The monitor will do the gamma expansion.)
-        out_Color = vec4(pow(color.xyz, vec3(1./gamma)), color.w);
-    }
-)#";
-
-
 struct DrawQuadParameters
 {
-    enum Linearization : GLuint
+    enum Operation : GLuint
     {
         None = 0,
-        DepthMethod1 = 1,
-        DepthMethod2 = 2,
+        DepthLinearize1 = 1,
+        DepthLinearize2 = 2,
+        AccumNormalize = 3, // For transparency accum texture
     };
 
     GLuint mTextureUnit = 0;
     GLint mSourceChannel = -1; // use all channels
-    Linearization mLinearization = None;
+    Operation mOperation = None;
     GLfloat mNearDistance;
     GLfloat mFarDistance;
 };
 
-inline void drawQuad(DrawQuadParameters aParameters = {})
+
+void drawQuad(DrawQuadParameters aParameters = {});
+
+
+struct QuadDrawer
 {
-    static graphics::VertexArrayObject dummyVao;
-    static graphics::Program program = 
-        graphics::makeLinkedProgram({
-            {GL_VERTEX_SHADER, gVertexShaderTex},
-            {GL_FRAGMENT_SHADER, gFragmentShaderTex},
-        });
+    QuadDrawer(graphics::ShaderSourceView aFragmentCode);
 
-    // Sadly a non zero VAO must be bound for any draw call
-    graphics::ScopedBind boundVao{dummyVao};
-    graphics::ScopedBind boundProgram{program};
+    void drawQuad() const;
 
-    graphics::setUniform(program, "u_SourceChannel", aParameters.mSourceChannel);
-    graphics::setUniform(program, "u_Linearization", aParameters.mLinearization);
-    graphics::setUniform(program, "u_NearDistance",  aParameters.mNearDistance);
-    graphics::setUniform(program, "u_FarDistance",   aParameters.mFarDistance);
-
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-}
+    // Should it be an introspect program?
+    // It should be accounted for by the storage, for statistics
+    graphics::Program mProgram;
+};
 
 
 } // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/DrawQuad.h
+++ b/src/apps/refactor_proto/refactor_proto/DrawQuad.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <renderer/VertexSpecification.h>
+#include <renderer/Uniforms.h>
 #include <renderer/Shading.h>
+#include <renderer/VertexSpecification.h>
 
 
 namespace ad::renderer {
@@ -41,21 +42,74 @@ const char * gFragmentShaderTex = R"#(
 
     layout(binding=0) uniform sampler2D u_Texture;
 
+    uniform int u_SourceChannel;
+
+    uniform unsigned int u_Linearization;
+    uniform float u_NearDistance;
+    uniform float u_FarDistance;
+
     out vec4 out_Color;
 
     void main()
     {
-        //out_Color = vec4(0., 1., 0., 1.);
+        vec4 sampled = texture(u_Texture, ex_Uv);
+        vec4 color = sampled;
+        if(u_SourceChannel >= 0)
+        {
+            color = vec4(vec3(sampled[u_SourceChannel]), 1.0);
+        }
 
-        vec4 color = texture(u_Texture, ex_Uv);
-        out_Color = color;
-        //vec4 color = vec4(vec3(texture(u_Texture, ex_Uv).r), 1.);
-        //out_Color = vec4(1., 1., 1., 1.) - ((vec4(1., 1., 1., 1.) - color) * 4);
+        if(u_Linearization == 1)
+        {
+            // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
+            float linearDepth = 
+                (2 * u_NearDistance) 
+                / (u_FarDistance + u_NearDistance - color.r * (u_FarDistance - u_NearDistance));
+            
+            color = vec4(vec3(linearDepth), 1.0);
+        }
+        else if(u_Linearization == 2)
+        {
+            // ATTENTION: This results in a black screen, this method does not seem to work with our projection
+
+            // see: http://web.archive.org/web/20130416194336/http://olivers.posterous.com/linear-depth-in-glsl-for-real
+
+            // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
+            float linearDepth = 
+                (2 * u_NearDistance * u_FarDistance) 
+                / (u_FarDistance + u_NearDistance - (2 * color.r - 1) * (u_FarDistance - u_NearDistance));
+            
+            color = vec4(vec3(linearDepth), 1.0);
+        }
+
+        //
+        // Gamma correction
+        //
+        float gamma = 2.2;
+        // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
+        // (The monitor will do the gamma expansion.)
+        out_Color = vec4(pow(color.xyz, vec3(1./gamma)), color.w);
     }
 )#";
 
 
-inline void drawQuad()
+struct DrawQuadParameters
+{
+    enum Linearization : GLuint
+    {
+        None = 0,
+        DepthMethod1 = 1,
+        DepthMethod2 = 2,
+    };
+
+    GLuint mTextureUnit = 0;
+    GLint mSourceChannel = -1; // use all channels
+    Linearization mLinearization = None;
+    GLfloat mNearDistance;
+    GLfloat mFarDistance;
+};
+
+inline void drawQuad(DrawQuadParameters aParameters = {})
 {
     static graphics::VertexArrayObject dummyVao;
     static graphics::Program program = 
@@ -67,6 +121,11 @@ inline void drawQuad()
     // Sadly a non zero VAO must be bound for any draw call
     graphics::ScopedBind boundVao{dummyVao};
     graphics::ScopedBind boundProgram{program};
+
+    graphics::setUniform(program, "u_SourceChannel", aParameters.mSourceChannel);
+    graphics::setUniform(program, "u_Linearization", aParameters.mLinearization);
+    graphics::setUniform(program, "u_NearDistance",  aParameters.mNearDistance);
+    graphics::setUniform(program, "u_FarDistance",   aParameters.mFarDistance);
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }

--- a/src/apps/refactor_proto/refactor_proto/DrawQuad.h
+++ b/src/apps/refactor_proto/refactor_proto/DrawQuad.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <renderer/VertexSpecification.h>
+#include <renderer/Shading.h>
+
+
+namespace ad::renderer {
+
+
+const char * gVertexShaderTex = R"#(
+    #version 420
+
+    const vec2 pos_data[4] = vec2[] (
+        vec2(-1.0, -1.0),
+        vec2( 1.0, -1.0),
+        vec2(-1.0,  1.0),
+        vec2( 1.0,  1.0)
+    );
+
+    const vec2 tex_data[4] = vec2[] (
+        vec2(0.0, 0.0),
+        vec2(1.0, 0.0),
+        vec2(0.0, 1.0),
+        vec2(1.0, 1.0)
+    );
+
+    out vec2 ex_Uv;
+
+    void main() 
+    {
+        ex_Uv = tex_data[gl_VertexID];
+        gl_Position = vec4(pos_data[gl_VertexID], 0.0, 1.0);
+    }
+)#";
+
+// TODO normalize options (e.g. linearize depth buffer, min-max clamping, ...)
+const char * gFragmentShaderTex = R"#(
+    #version 420
+
+    in vec2 ex_Uv;
+
+    layout(binding=0) uniform sampler2D u_Texture;
+
+    out vec4 out_Color;
+
+    void main()
+    {
+        //out_Color = vec4(0., 1., 0., 1.);
+
+        vec4 color = texture(u_Texture, ex_Uv);
+        out_Color = color;
+        //vec4 color = vec4(vec3(texture(u_Texture, ex_Uv).r), 1.);
+        //out_Color = vec4(1., 1., 1., 1.) - ((vec4(1., 1., 1., 1.) - color) * 4);
+    }
+)#";
+
+
+inline void drawQuad()
+{
+    static graphics::VertexArrayObject dummyVao;
+    static graphics::Program program = 
+        graphics::makeLinkedProgram({
+            {GL_VERTEX_SHADER, gVertexShaderTex},
+            {GL_FRAGMENT_SHADER, gFragmentShaderTex},
+        });
+
+    // Sadly a non zero VAO must be bound for any draw call
+    graphics::ScopedBind boundVao{dummyVao};
+    graphics::ScopedBind boundProgram{program};
+
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/DrawQuad.h
+++ b/src/apps/refactor_proto/refactor_proto/DrawQuad.h
@@ -34,7 +34,7 @@ const char * gVertexShaderTex = R"#(
     }
 )#";
 
-// TODO normalize options (e.g. linearize depth buffer, min-max clamping, ...)
+
 const char * gFragmentShaderTex = R"#(
     #version 420
 

--- a/src/apps/refactor_proto/refactor_proto/Loader.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Loader.cpp
@@ -832,7 +832,6 @@ IntrospectProgram Loader::loadProgram(const filesystem::path & aProgFile,
 
 
 Scene Loader::loadScene(const filesystem::path & aSceneFile,
-                        const filesystem::path & aEffectFile,
                         const GenericStream & aStream,
                         Storage & aStorage)
 {
@@ -849,7 +848,7 @@ Scene Loader::loadScene(const filesystem::path & aSceneFile,
 
         Node model = loadBinary(workingDir / modelFile,
                                 aStorage,
-                                loadEffect(aEffectFile, aStorage, defines),
+                                loadEffect(entry["effect"], aStorage, defines),
                                 aStream);
 
         // TODO store and load names in the binary file format

--- a/src/apps/refactor_proto/refactor_proto/Loader.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Loader.cpp
@@ -831,6 +831,12 @@ IntrospectProgram Loader::loadProgram(const filesystem::path & aProgFile,
 }
 
 
+graphics::ShaderSource Loader::loadShader(const filesystem::path & aShaderFile) const
+{
+    return graphics::ShaderSource::Preprocess(mFinder.pathFor(aShaderFile));
+}
+
+
 Scene Loader::loadScene(const filesystem::path & aSceneFile,
                         const GenericStream & aStream,
                         Storage & aStorage)

--- a/src/apps/refactor_proto/refactor_proto/Loader.h
+++ b/src/apps/refactor_proto/refactor_proto/Loader.h
@@ -67,6 +67,8 @@ struct Loader
                                   // TODO Ad 2023/10/03: #shader-system Remove this temporary.
                                   const std::vector<std::string> & aDefines_temp);
 
+    graphics::ShaderSource loadShader(const filesystem::path & aShaderFile) const;
+
     Scene loadScene(const filesystem::path & aSceneFile,
                     const GenericStream & aStream,
                     Storage & aStorage);

--- a/src/apps/refactor_proto/refactor_proto/Loader.h
+++ b/src/apps/refactor_proto/refactor_proto/Loader.h
@@ -68,7 +68,6 @@ struct Loader
                                   const std::vector<std::string> & aDefines_temp);
 
     Scene loadScene(const filesystem::path & aSceneFile,
-                    const filesystem::path & aEffectFile,
                     const GenericStream & aStream,
                     Storage & aStorage);
 

--- a/src/apps/refactor_proto/refactor_proto/Model.h
+++ b/src/apps/refactor_proto/refactor_proto/Model.h
@@ -45,7 +45,7 @@ static constexpr auto gNullHandle = nullptr;
 // (with a shared stride and instance divisor).
 // If we allow to store distinct logical objects in the same view, we can then use the view (or VertexStream) 
 // as an identifier to match VAOs (while batching).
-// Yet this mean that a Part will need an offset into its buffer views.
+// This implies that a Part will need an offset into its buffer views.
 // This offset in implemented by the Part m*First and m*Count members.
 struct BufferView
 {

--- a/src/apps/refactor_proto/refactor_proto/Pass.cpp
+++ b/src/apps/refactor_proto/refactor_proto/Pass.cpp
@@ -1,0 +1,305 @@
+#include "Pass.h"
+
+#include "Profiling.h"
+#include "SetupDrawing.h"
+
+
+namespace ad::renderer {
+
+    
+namespace {
+
+
+    // TODO Ad 2023/11/28: Move to some low-level masking helpers lib
+    /// @brief Make a 64 bit mask, with `aBitCount`'th low-order bits set to 1.
+    constexpr std::uint64_t makeMask(unsigned int aBitCount)
+    {
+        assert(aBitCount <= 64);
+        return (1 << aBitCount) - 1;
+    }
+
+
+    /// @brief Returns the VAO matching the given program and part.
+    /// Under the hood, the VAO is cached.
+    Handle<graphics::VertexArrayObject> getVao(const ConfiguredProgram & aProgram,
+                                               const Part & aPart,
+                                               Storage & aStorage)
+    {
+        // This is a common mistake, it would be nice to find a safer way
+        assert(aProgram.mConfig);
+
+        // Note: the config is via "handle", hosted by in cache that is mutable, so loosing the constness is correct.
+        return
+            [&, &entries = aProgram.mConfig->mEntries]() 
+            -> graphics::VertexArrayObject *
+            {
+                if(auto foundConfig = std::find_if(entries.begin(), entries.end(),
+                                                [&aPart](const auto & aEntry)
+                                                {
+                                                    return aEntry.mVertexStream == aPart.mVertexStream;
+                                                });
+                    foundConfig != entries.end())
+                {
+                    return foundConfig->mVao;
+                }
+                else
+                {
+                    aStorage.mVaos.push_back(prepareVAO(aProgram.mProgram, *aPart.mVertexStream));
+                    entries.push_back(
+                        ProgramConfig::Entry{
+                            .mVertexStream = aPart.mVertexStream,
+                            .mVao = &aStorage.mVaos.back(),
+                        });
+                    return entries.back().mVao;
+                }
+            }();
+    }
+
+
+    /// @brief Find the program satisfying all annotations.
+    /// @return The first program in aEffect for which all annotations are matching (i.e. present and same value),
+    /// or a null handle otherwise.
+    template <class T_iterator>
+    Handle<ConfiguredProgram> getProgram(const Effect & aEffect,
+                                         T_iterator aAnnotationsBegin, T_iterator aAnnotationsEnd)
+    {
+        for (const Technique & technique : aEffect.mTechniques)
+        {
+            if(std::all_of(aAnnotationsBegin, aAnnotationsEnd,
+                    [&technique](const Technique::Annotation & aRequiredAnnotation)
+                    {
+                        const auto & availableAnnotations = technique.mAnnotations;
+                        if(auto found = availableAnnotations.find(aRequiredAnnotation.mCategory);
+                            found != availableAnnotations.end())
+                        {
+                            return (found->second == aRequiredAnnotation.mValue);
+                        }
+                        return false;
+                    }))
+            {
+                return technique.mConfiguredProgram;
+            }
+        }
+
+        return nullptr;
+    }
+
+
+    /// @brief Specializes getProgram, returning first program matching provided pass name.
+    Handle<ConfiguredProgram> getProgramForPass(const Effect & aEffect, StringKey aPassName)
+    {
+        const std::array<Technique::Annotation, 2> annotations{/*aggregate init of std::array*/{/*aggregate init of inner C-array*/
+            {"pass", aPassName},
+            {"pass", aPassName},
+        }};
+        return getProgram(aEffect, annotations.begin(), annotations.end());
+    }
+    
+
+    // TODO Ad 2023/10/05: for OpenGL resource, maybe we should directly use the GL name?
+    // or do we want to reimplement Handle<> in term of index in storage containers?
+    /// @brief Hackish class, associating a resource to an integer value.
+    ///
+    /// The value is suitable to compose a DrawEntry::Key via bitwise operations.
+    template <class T_resource, unsigned int N_valueBits>
+    struct ResourceIdMap
+    {
+        static_assert(N_valueBits <= 16);
+        static constexpr std::uint16_t gMaxValue = (std::uint16_t)((1 << N_valueBits) - 1);
+
+        ResourceIdMap()
+        {
+            // By adding the nullptr as the zero value, this helps debugging
+            get(nullptr);
+            assert(get(nullptr)== 0);
+        }
+
+        /// @brief Get the value associated to provided resource.
+        /// A given map instance will always return the same value for the same resource.
+        std::uint16_t get(Handle<T_resource> aResource)
+        {
+            assert(mResourceToId.size() < gMaxValue);
+            auto [iterator, didInsert] = mResourceToId.try_emplace(aResource,
+                                                                   (std::uint16_t)mResourceToId.size());
+            return iterator->second;
+        }
+
+        /// @brief Return the resource from it value.
+        Handle<T_resource> reverseLookup(std::uint16_t aValue)
+        {
+            if(auto found = std::find_if(mResourceToId.begin(), mResourceToId.end(),
+                                         [aValue](const auto & aPair)
+                                         {
+                                             return aPair.second == aValue;
+                                         });
+               found != mResourceToId.end())
+            {
+                return found->first;
+            }
+            throw std::logic_error{"The provided value is not present in this ResourceIdMap."};
+        }
+
+        std::unordered_map<Handle<T_resource>, std::uint16_t> mResourceToId;
+    };
+
+
+    /// @brief Associate an integer key to a part.
+    /// Used to sort an array with one entry for each part, by manually composing a key by sort dimensions.
+    /// @see https://realtimecollisiondetection.net/blog/?p=86
+    struct DrawEntry
+    {
+        using Key = std::uint64_t;
+        static constexpr Key gInvalidKey = std::numeric_limits<Key>::max();
+
+        /// @brief Order purely by key.
+        /// @param aRhs 
+        /// @return 
+        bool operator<(const DrawEntry & aRhs) const
+        {
+            return mKey < aRhs.mKey;
+        }
+
+        Key mKey = 0;
+        std::size_t mPartListIdx;
+    };
+
+
+} // unnamed namespace
+
+
+
+PassCache preparePass(StringKey aPass,
+                      const PartList & aPartList,
+                      Storage & aStorage)
+{
+    PROFILER_SCOPE_RECURRING_SECTION("prepare_pass", CpuTime);
+
+    constexpr unsigned int gProgramIdBits = 16;
+    constexpr std::uint64_t gProgramIdMask = makeMask(gProgramIdBits);
+    using ProgramId = std::uint16_t;
+    assert(aStorage.mPrograms.size() < (1 << gProgramIdBits));
+
+    //constexpr unsigned int gPrimitiveModes = 12; // I counted 12 primitive modes
+    //unsigned int gPrimitiveModeIdBits = (unsigned int)std::ceil(std::log2(gPrimitiveModes));
+
+    constexpr unsigned int gVaoBits = 10;
+    constexpr std::uint64_t gVaoIdMask = makeMask(gVaoBits);
+    assert(aStorage.mVaos.size() < (1 << gVaoBits));
+    using VaoId = std::uint16_t;
+
+    constexpr unsigned int gMaterialContextBits = 10;
+    constexpr std::uint64_t gMaterialContextIdMask = makeMask(gMaterialContextBits);
+    assert(aStorage.mMaterialContexts.size() < (1 << gMaterialContextBits));
+    using MaterialContextId = std::uint16_t;
+
+    ResourceIdMap<ConfiguredProgram, gProgramIdBits> programToId;
+    ResourceIdMap<graphics::VertexArrayObject, gVaoBits> vaoToId;
+    ResourceIdMap<MaterialContext, gMaterialContextBits> materialContextToId;
+
+    //
+    // For each part, associated it to its sort key and store them in an array
+    // (this will already prune parts for which there is no program for aPass)
+    //
+    std::vector<DrawEntry> entries;
+    entries.reserve(aPartList.mParts.size());
+
+    for (std::size_t partIdx = 0; partIdx != aPartList.mParts.size(); ++partIdx)
+    {
+        const Part & part = *aPartList.mParts[partIdx];
+        const Material & material = *aPartList.mMaterials[partIdx];
+
+        // TODO Ad 2023/10/05: Also add those as sorting dimensions (to the LSB)
+        assert(part.mPrimitiveMode == GL_TRIANGLES);
+        assert(part.mVertexStream->mIndicesType == GL_UNSIGNED_INT);
+        
+        if(Handle<ConfiguredProgram> configuredProgram = getProgramForPass(*material.mEffect, aPass);
+            configuredProgram)
+        {
+            Handle<graphics::VertexArrayObject> vao = getVao(*configuredProgram, part, aStorage);
+
+            ProgramId programId = programToId.get(configuredProgram);
+            VaoId vaoId = vaoToId.get(vao);
+            MaterialContextId materialContextId = materialContextToId.get(material.mContext);
+
+            std::uint64_t key = vaoId ;
+            key |= materialContextId << gVaoBits;
+            key |= programId << (gVaoBits + gMaterialContextBits);
+
+            entries.push_back(DrawEntry{.mKey = key, .mPartListIdx = partIdx});
+        }
+    }
+
+    //
+    // Sort the entries
+    //
+    {
+        PROFILER_SCOPE_RECURRING_SECTION("sort_draw_entries", CpuTime);
+        std::sort(entries.begin(), entries.end());
+    }
+
+    //
+    // Traverse the sorted array to generate the actual draw commands and draw calls
+    //
+    PassCache result;
+    DrawEntry::Key drawKey = DrawEntry::gInvalidKey;
+    for(const DrawEntry & entry : entries)
+    {
+        const Part & part = *aPartList.mParts[entry.mPartListIdx];
+        const VertexStream & vertexStream = *part.mVertexStream;
+
+        // If true: this is the start of a new DrawCall
+        if(entry.mKey != drawKey)
+        {
+            // Record the new drawkey
+            drawKey = entry.mKey;
+
+            // Push the new DrawCall
+            result.mCalls.push_back(
+                DrawCall{
+                    .mPrimitiveMode = part.mPrimitiveMode,
+                    .mIndicesType = vertexStream.mIndicesType,
+                    .mProgram = 
+                        &programToId.reverseLookup(gProgramIdMask & (drawKey >> (gVaoBits + gMaterialContextBits)))
+                            ->mProgram,
+                    .mVao = vaoToId.reverseLookup(gVaoIdMask & drawKey),
+                    .mCallContext = materialContextToId.reverseLookup(gMaterialContextIdMask & (drawKey >> gVaoBits)),
+                    .mPartCount = 0,
+                }
+            );
+        }
+        
+        // Increment the part count of current DrawCall
+        ++result.mCalls.back().mPartCount;
+
+        const std::size_t indiceSize = graphics::getByteSize(vertexStream.mIndicesType);
+
+        // Indirect draw commands do not accept a (void*) offset, but a number of indices (firstIndex).
+        // This means the offset into the buffer must be aligned with the index size.
+        assert((vertexStream.mIndexBufferView.mOffset %  indiceSize) == 0);
+
+        result.mDrawCommands.push_back(
+            DrawElementsIndirectCommand{
+                .mCount = part.mIndicesCount,
+                // TODO Ad 2023/09/26: #bench Is it worth it to group identical parts and do "instanced" drawing?
+                // For the moment, draw a single instance for each part (i.e. no instancing)
+                .mInstanceCount = 1,
+                .mFirstIndex = (GLuint)(vertexStream.mIndexBufferView.mOffset / indiceSize)
+                                + part.mIndexFirst,
+                .mBaseVertex = part.mVertexFirst,
+                .mBaseInstance = (GLuint)result.mDrawInstances.size(), // pushed below
+            }
+        );
+
+        const Material & material = *aPartList.mMaterials[entry.mPartListIdx];
+
+        result.mDrawInstances.push_back(DrawInstance{
+            .mInstanceTransformIdx = aPartList.mTransformIdx[entry.mPartListIdx],
+            .mMaterialIdx = (GLsizei)material.mPhongMaterialIdx,
+        });
+    }
+
+    return result;
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/Pass.h
+++ b/src/apps/refactor_proto/refactor_proto/Pass.h
@@ -1,0 +1,79 @@
+#pragma once
+
+
+#include "Model.h"
+
+
+#include <renderer/GL_Loader.h>
+
+
+namespace ad::renderer {
+
+
+/// @brief A list of parts to be drawn, each associated to a Material and a transformation.
+/// It is intended to be reused accross distinct passes inside a frame (or even accross frame for static parts).
+struct PartList
+{
+    // The individual renderer::Objects transforms. Several parts might index to the same transform.
+    // (Same way several parts might index the same material parameters)
+    std::vector<math::AffineMatrix<4, GLfloat>> mInstanceTransforms;
+
+    // SOA
+    std::vector<const Part *> mParts;
+    std::vector<const Material *> mMaterials;
+    std::vector<GLsizei> mTransformIdx;
+};
+
+
+/// @brief Entry to populate the GL_DRAW_INDIRECT_BUFFER used with indexed (glDrawElements) geometry.
+struct DrawElementsIndirectCommand
+{
+    GLuint  mCount;
+    GLuint  mInstanceCount;
+    GLuint  mFirstIndex;
+    GLuint  mBaseVertex;
+    GLuint  mBaseInstance;
+};
+
+
+/// @brief Entry to populate the instance buffer (attribute divisor == 1).
+/// Each instance (mapping to a `Part` in client data model) has a pose and a material.
+struct DrawInstance
+{
+    GLsizei mInstanceTransformIdx; // index in the instance UBO
+    GLsizei mMaterialIdx;
+};
+
+
+/// @brief Store state and parameters required to issue a GL draw call.
+struct DrawCall
+{
+    GLenum mPrimitiveMode = 0;
+    GLenum mIndicesType = 0;
+
+    const IntrospectProgram * mProgram;
+    const graphics::VertexArrayObject * mVao;
+    // TODO I am not sure having the material context here is a good idea, it feels a bit high level
+    Handle<MaterialContext> mCallContext;
+
+    GLsizei mPartCount;
+};
+
+
+// TODO rename to DrawXxx
+struct PassCache
+{
+    std::vector<DrawCall> mCalls;
+
+    // SOA at the moment, one entry per part
+    std::vector<DrawElementsIndirectCommand> mDrawCommands;
+    std::vector<DrawInstance> mDrawInstances; // Intended to be loaded as a GL instance buffer
+};
+
+
+PassCache preparePass(StringKey aPass,
+                      const PartList & aPartList,
+                      Storage & aStorage);
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
@@ -156,7 +156,7 @@ namespace {
                 // Use the same program at the moment for the depth pass
                 Technique{
                     .mAnnotations{
-                        {"pass", "depth"},
+                        {"pass", "depth_opaque"},
                     },
                     .mConfiguredProgram = &aStorage.mPrograms.back(),
                 }
@@ -302,7 +302,7 @@ RenderGraph::RenderGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterfa
                    gInitialVFov,
                    Orbital{2/*initial radius*/}
     },
-    mGraph{mGlfwAppInterface, mStorage}
+    mGraph{mGlfwAppInterface, mStorage, mLoader}
 {
     registerGlfwCallbacks(*mGlfwAppInterface, mCameraControl, EscKeyBehaviour::Close, &aImguiUi);
     registerGlfwCallbacks(*mGlfwAppInterface, mFirstPersonControl, EscKeyBehaviour::Close, &aImguiUi);

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
@@ -1015,9 +1015,6 @@ void RenderGraph::render()
         // Note: with stencil, we could draw those rectangles first,
         // and prevent main rasterization behind them.
 
-        glViewport(0, 0,
-                    mGlfwAppInterface->getFramebufferSize().width() / 4,
-                    mGlfwAppInterface->getFramebufferSize().height() / 4);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(depthTexture->mTarget, *depthTexture);
@@ -1031,7 +1028,31 @@ void RenderGraph::render()
             glDepthMask(GL_FALSE);
         }
 
-        drawQuad();
+        auto [nearZ, farZ] = getNearFarPlanes(mCamera);
+
+        math::Size<2, int> fbSize = mGlfwAppInterface->getFramebufferSize();
+
+        glViewport(0, 0,
+                    fbSize.width() / 4,
+                    fbSize.height() / 4);
+
+        drawQuad({
+            .mSourceChannel = 0,
+            .mLinearization = DrawQuadParameters::DepthMethod1,
+            .mNearDistance = nearZ,
+            .mFarDistance = farZ,
+        });
+        
+        glViewport(0, fbSize.height() / 4,
+                   fbSize.width() / 4,
+                   fbSize.height() / 4);
+
+        drawQuad({
+            .mSourceChannel = 0,
+            .mLinearization = DrawQuadParameters::DepthMethod2,
+            .mNearDistance = nearZ,
+            .mFarDistance = farZ,
+        });
     }
 }
 

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
@@ -1,13 +1,15 @@
 #include "RenderGraph.h"
 
+// TODO Ad 2023/10/18: Should get rid of this repeated implementation
+#include "RendererReimplement.h" 
+
 #include "Cube.h"
 #include "GlApi.h"
 #include "Json.h"
 #include "Loader.h"
 #include "Logging.h"
+#include "Pass.h"
 #include "Profiling.h"
-#include "RendererReimplement.h" // TODO Ad 2023/10/18: Should get rid of this repeated implementation
-#include "SetupDrawing.h"
 
 #include <handy/vector_utils.h>
 
@@ -96,8 +98,6 @@ constexpr float gMinFarZ{-25.f};
 [[maybe_unused]] constexpr float gRadialDistancingFactor{1.5f};
 /// @brief The far plane will be at least at this factor times the model depth.
 constexpr float gDepthFactor{20.f};
-
-constexpr std::size_t gMaxDrawInstances = 2048;
 
 namespace {
 
@@ -211,79 +211,6 @@ namespace {
     }
 
 
-    void draw(const PassCache & aPassCache,
-              const RepositoryUbo & aUboRepository,
-              const RepositoryTexture & aTextureRepository)
-    {
-        //TODO Ad 2023/08/01: META todo, should we have "compiled state objects" (a-la VAO) for interface bocks, textures, etc
-        // where we actually map a state setup (e.g. which texture name to which image unit and which sampler)
-        // those could be "bound" before draw (potentially doing some binds and uniform setting, but not iterating the program)
-        // (We could even separate actual texture from the "format", allowing to change an underlying texture without revisiting the program)
-        // This would address the warnings repetitions (only issued when the compiled state is (re-)generated), and be better for perfs.
-
-        GLuint firstInstance = 0; 
-        for (const DrawCall & aCall : aPassCache.mCalls)
-        {
-            PROFILER_SCOPE_RECURRING_SECTION("drawcall_iteration", CpuTime);
-
-            PROFILER_PUSH_RECURRING_SECTION("discard_2", CpuTime);
-            const IntrospectProgram & selectedProgram = *aCall.mProgram;
-            const graphics::VertexArrayObject & vao = *aCall.mVao;
-            PROFILER_POP_RECURRING_SECTION;
-
-            // TODO Ad 2023/10/05: #perf #azdo 
-            // Only change what is necessary, instead of rebiding everything each time.
-            // Since we sorted our draw calls, it is very likely that program remain the same, and VAO changes.
-            {
-                PROFILER_PUSH_RECURRING_SECTION("bind_VAO", CpuTime);
-                graphics::ScopedBind vaoScope{vao};
-                PROFILER_POP_RECURRING_SECTION;
-                
-                {
-                    PROFILER_SCOPE_RECURRING_SECTION("set_buffer_backed_blocks", CpuTime);
-                    // TODO #repos This should be consolidated
-                    RepositoryUbo uboRepo{aUboRepository};
-                    if(aCall.mCallContext)
-                    {
-                        RepositoryUbo callRepo{aCall.mCallContext->mUboRepo};
-                        uboRepo.merge(callRepo);
-                    }
-                    setBufferBackedBlocks(selectedProgram, uboRepo);
-                }
-
-                {
-                    PROFILER_SCOPE_RECURRING_SECTION("set_textures", CpuTime);
-                    // TODO #repos This should be consolidated
-                    RepositoryTexture textureRepo{aTextureRepository};
-                    if(aCall.mCallContext)
-                    {
-                        RepositoryTexture callRepo{aCall.mCallContext->mTextureRepo};
-                        textureRepo.merge(callRepo);
-                    }
-                    setTextures(selectedProgram, textureRepo);
-                }
-
-                PROFILER_PUSH_RECURRING_SECTION("bind_program", CpuTime);
-                graphics::ScopedBind programScope{selectedProgram};
-                PROFILER_POP_RECURRING_SECTION;
-
-                {
-                    // TODO Ad 2023/08/23: Measuring GPU time here has a x2 impact on cpu performance
-                    // Can we have efficient GPU measures?
-                    PROFILER_SCOPE_RECURRING_SECTION("glDraw_call", CpuTime/*, GpuTime*/);
-                    
-                    gl.MultiDrawElementsIndirect(
-                        aCall.mPrimitiveMode,
-                        aCall.mIndicesType,
-                        (void *)(firstInstance * sizeof(DrawElementsIndirectCommand)),
-                        aCall.mPartCount,
-                        sizeof(DrawElementsIndirectCommand));
-                }
-            }
-            firstInstance += aCall.mPartCount;
-        }
-    }
-
     void populatePartList(PartList & aPartList, const Node & aNode, const Pose & aParentPose, const Material * aMaterialOverride)
     {
         const Instance & instance = aNode.mInstance;
@@ -321,291 +248,6 @@ namespace {
     }
 
 
-    /// @brief Find the program satisfying all annotations.
-    /// @return The first program in aEffect for which all annotations are matching (i.e. present and same value),
-    /// or a null handle otherwise.
-    template <class T_iterator>
-    Handle<ConfiguredProgram> getProgram(const Effect & aEffect,
-                                         T_iterator aAnnotationsBegin, T_iterator aAnnotationsEnd)
-    {
-        for (const Technique & technique : aEffect.mTechniques)
-        {
-            if(std::all_of(aAnnotationsBegin, aAnnotationsEnd,
-                    [&technique](const Technique::Annotation & aRequiredAnnotation)
-                    {
-                        const auto & availableAnnotations = technique.mAnnotations;
-                        if(auto found = availableAnnotations.find(aRequiredAnnotation.mCategory);
-                            found != availableAnnotations.end())
-                        {
-                            return (found->second == aRequiredAnnotation.mValue);
-                        }
-                        return false;
-                    }))
-            {
-                return technique.mConfiguredProgram;
-            }
-        }
-
-        return nullptr;
-    }
-
-
-    /// @brief Specializes getProgram, returning first program matching provided pass name.
-    Handle<ConfiguredProgram> getProgramForPass(const Effect & aEffect, StringKey aPassName)
-    {
-        const std::array<Technique::Annotation, 2> annotations{/*aggregate init of std::array*/{/*aggregate init of inner C-array*/
-            {"pass", aPassName},
-            {"pass", aPassName},
-        }};
-        return getProgram(aEffect, annotations.begin(), annotations.end());
-    }
-    
-
-    /// @brief Returns the VAO matching the given program and part.
-    /// Under the hood, the VAO is cached.
-    Handle<graphics::VertexArrayObject> getVao(const ConfiguredProgram & aProgram,
-                                               const Part & aPart,
-                                               Storage & aStorage)
-    {
-        // This is a common mistake, it would be nice to find a safer way
-        assert(aProgram.mConfig);
-
-        // Note: the config is via "handle", hosted by in cache that is mutable, so loosing the constness is correct.
-        return
-            [&, &entries = aProgram.mConfig->mEntries]() 
-            -> graphics::VertexArrayObject *
-            {
-                if(auto foundConfig = std::find_if(entries.begin(), entries.end(),
-                                                [&aPart](const auto & aEntry)
-                                                {
-                                                    return aEntry.mVertexStream == aPart.mVertexStream;
-                                                });
-                    foundConfig != entries.end())
-                {
-                    return foundConfig->mVao;
-                }
-                else
-                {
-                    aStorage.mVaos.push_back(prepareVAO(aProgram.mProgram, *aPart.mVertexStream));
-                    entries.push_back(
-                        ProgramConfig::Entry{
-                            .mVertexStream = aPart.mVertexStream,
-                            .mVao = &aStorage.mVaos.back(),
-                        });
-                    return entries.back().mVao;
-                }
-            }();
-    }
-
-
-    // TODO Ad 2023/10/05: for OpenGL resource, maybe we should directly use the GL name?
-    // or do we want to reimplement Handle<> in term of index in storage containers?
-    /// @brief Hackish class, associating a resource to an integer value.
-    ///
-    /// The value is suitable to compose a DrawEntry::Key via bitwise operations.
-    template <class T_resource, unsigned int N_valueBits>
-    struct ResourceIdMap
-    {
-        static_assert(N_valueBits <= 16);
-        static constexpr std::uint16_t gMaxValue = (std::uint16_t)((1 << N_valueBits) - 1);
-
-        ResourceIdMap()
-        {
-            // By adding the nullptr as the zero value, this helps debugging
-            get(nullptr);
-            assert(get(nullptr)== 0);
-        }
-
-        /// @brief Get the value associated to provided resource.
-        /// A given map instance will always return the same value for the same resource.
-        std::uint16_t get(Handle<T_resource> aResource)
-        {
-            assert(mResourceToId.size() < gMaxValue);
-            auto [iterator, didInsert] = mResourceToId.try_emplace(aResource,
-                                                                   (std::uint16_t)mResourceToId.size());
-            return iterator->second;
-        }
-
-        /// @brief Return the resource from it value.
-        Handle<T_resource> reverseLookup(std::uint16_t aValue)
-        {
-            if(auto found = std::find_if(mResourceToId.begin(), mResourceToId.end(),
-                                         [aValue](const auto & aPair)
-                                         {
-                                             return aPair.second == aValue;
-                                         });
-               found != mResourceToId.end())
-            {
-                return found->first;
-            }
-            throw std::logic_error{"The provided value is not present in this ResourceIdMap."};
-        }
-
-        std::unordered_map<Handle<T_resource>, std::uint16_t> mResourceToId;
-    };
-
-
-    /// @brief Associate an integer key to a part.
-    /// Used to sort an array with one entry for each part, by manually composing a key by sort dimensions.
-    /// @see https://realtimecollisiondetection.net/blog/?p=86
-    struct DrawEntry
-    {
-        using Key = std::uint64_t;
-        static constexpr Key gInvalidKey = std::numeric_limits<Key>::max();
-
-        /// @brief Order purely by key.
-        /// @param aRhs 
-        /// @return 
-        bool operator<(const DrawEntry & aRhs) const
-        {
-            return mKey < aRhs.mKey;
-        }
-
-        Key mKey = 0;
-        std::size_t mPartListIdx;
-    };
-
-
-    constexpr std::uint64_t makeMask(unsigned int aBitCount)
-    {
-        assert(aBitCount <= 64);
-        return (1 << aBitCount) - 1;
-    }
-
-
-    PassCache preparePass(StringKey aPass,
-                          const PartList & aPartList,
-                          Storage & aStorage)
-    {
-        PROFILER_SCOPE_RECURRING_SECTION("prepare_pass", CpuTime);
-
-        constexpr unsigned int gProgramIdBits = 16;
-        constexpr std::uint64_t gProgramIdMask = makeMask(gProgramIdBits);
-        using ProgramId = std::uint16_t;
-        assert(aStorage.mPrograms.size() < (1 << gProgramIdBits));
-
-        //constexpr unsigned int gPrimitiveModes = 12; // I counted 12 primitive modes
-        //unsigned int gPrimitiveModeIdBits = (unsigned int)std::ceil(std::log2(gPrimitiveModes));
-
-        constexpr unsigned int gVaoBits = 10;
-        constexpr std::uint64_t gVaoIdMask = makeMask(gVaoBits);
-        assert(aStorage.mVaos.size() < (1 << gVaoBits));
-        using VaoId = std::uint16_t;
-
-        constexpr unsigned int gMaterialContextBits = 10;
-        constexpr std::uint64_t gMaterialContextIdMask = makeMask(gMaterialContextBits);
-        assert(aStorage.mMaterialContexts.size() < (1 << gMaterialContextBits));
-        using MaterialContextId = std::uint16_t;
-
-        ResourceIdMap<ConfiguredProgram, gProgramIdBits> programToId;
-        ResourceIdMap<graphics::VertexArrayObject, gVaoBits> vaoToId;
-        ResourceIdMap<MaterialContext, gMaterialContextBits> materialContextToId;
-
-        //
-        // For each part, associated it to its sort key and store them in an array
-        // (this will already prune parts for which there is no program for aPass)
-        //
-        std::vector<DrawEntry> entries;
-        entries.reserve(aPartList.mParts.size());
-
-        for (std::size_t partIdx = 0; partIdx != aPartList.mParts.size(); ++partIdx)
-        {
-            const Part & part = *aPartList.mParts[partIdx];
-            const Material & material = *aPartList.mMaterials[partIdx];
-
-            // TODO Ad 2023/10/05: Also add those as sorting dimensions (to the LSB)
-            assert(part.mPrimitiveMode == GL_TRIANGLES);
-            assert(part.mVertexStream->mIndicesType == GL_UNSIGNED_INT);
-            
-            if(Handle<ConfiguredProgram> configuredProgram = getProgramForPass(*material.mEffect, aPass);
-               configuredProgram)
-            {
-                Handle<graphics::VertexArrayObject> vao = getVao(*configuredProgram, part, aStorage);
-
-                ProgramId programId = programToId.get(configuredProgram);
-                VaoId vaoId = vaoToId.get(vao);
-                MaterialContextId materialContextId = materialContextToId.get(material.mContext);
-
-                std::uint64_t key = vaoId ;
-                key |= materialContextId << gVaoBits;
-                key |= programId << (gVaoBits + gMaterialContextBits);
-
-                entries.push_back(DrawEntry{.mKey = key, .mPartListIdx = partIdx});
-            }
-        }
-
-        //
-        // Sort the entries
-        //
-        {
-            PROFILER_SCOPE_RECURRING_SECTION("sort_draw_entries", CpuTime);
-            std::sort(entries.begin(), entries.end());
-        }
-
-        //
-        // Traverse the sorted array to generate the actual draw commands and draw calls
-        //
-        PassCache result;
-        DrawEntry::Key drawKey = DrawEntry::gInvalidKey;
-        for(const DrawEntry & entry : entries)
-        {
-            const Part & part = *aPartList.mParts[entry.mPartListIdx];
-            const VertexStream & vertexStream = *part.mVertexStream;
-
-            // If true: this is the start of a new DrawCall
-            if(entry.mKey != drawKey)
-            {
-                // Record the new drawkey
-                drawKey = entry.mKey;
-
-                // Push the new DrawCall
-                result.mCalls.push_back(
-                    DrawCall{
-                        .mPrimitiveMode = part.mPrimitiveMode,
-                        .mIndicesType = vertexStream.mIndicesType,
-                        .mProgram = 
-                            &programToId.reverseLookup(gProgramIdMask & (drawKey >> (gVaoBits + gMaterialContextBits)))
-                                ->mProgram,
-                        .mVao = vaoToId.reverseLookup(gVaoIdMask & drawKey),
-                        .mCallContext = materialContextToId.reverseLookup(gMaterialContextIdMask & (drawKey >> gVaoBits)),
-                        .mPartCount = 0,
-                    }
-                );
-            }
-            
-            // Increment the part count of current DrawCall
-            ++result.mCalls.back().mPartCount;
-
-            const std::size_t indiceSize = graphics::getByteSize(vertexStream.mIndicesType);
-
-            // Indirect draw commands do not accept a (void*) offset, but a number of indices (firstIndex).
-            // This means the offset into the buffer must be aligned with the index size.
-            assert((vertexStream.mIndexBufferView.mOffset %  indiceSize) == 0);
-
-            result.mDrawCommands.push_back(
-                DrawElementsIndirectCommand{
-                    .mCount = part.mIndicesCount,
-                    // TODO Ad 2023/09/26: #bench Is it worth it to group identical parts and do "instanced" drawing?
-                    // For the moment, draw a single instance for each part (i.e. no instancing)
-                    .mInstanceCount = 1,
-                    .mFirstIndex = (GLuint)(vertexStream.mIndexBufferView.mOffset / indiceSize)
-                                    + part.mIndexFirst,
-                    .mBaseVertex = part.mVertexFirst,
-                    .mBaseInstance = (GLuint)result.mDrawInstances.size(), // pushed below
-                }
-            );
-
-            const Material & material = *aPartList.mMaterials[entry.mPartListIdx];
-
-            result.mDrawInstances.push_back(DrawInstance{
-                .mInstanceTransformIdx = aPartList.mTransformIdx[entry.mPartListIdx],
-                .mMaterialIdx = (GLsizei)material.mPhongMaterialIdx,
-            });
-        }
-
-        return result;
-    }
-
 } // unnamed namespace
 
 
@@ -617,22 +259,6 @@ PartList Scene::populatePartList() const
     renderer::populatePartList(partList, mRoot, mRoot.mInstance.mPose, 
                                mRoot.mInstance.mMaterialOverride ? &*mRoot.mInstance.mMaterialOverride : nullptr);
     return partList;
-}
-
-
-HardcodedUbos::HardcodedUbos(Storage & aStorage)
-{
-    aStorage.mUbos.emplace_back();
-    mFrameUbo = &aStorage.mUbos.back();
-    mUboRepository.emplace(semantic::gFrame, mFrameUbo);
-
-    aStorage.mUbos.emplace_back();
-    mViewingUbo = &aStorage.mUbos.back();
-    mUboRepository.emplace(semantic::gView, mViewingUbo);
-
-    aStorage.mUbos.emplace_back();
-    mModelTransformUbo = &aStorage.mUbos.back();
-    mUboRepository.emplace(semantic::gLocalToWorld, mModelTransformUbo);
 }
 
 
@@ -707,24 +333,23 @@ void registerGlfwCallbacks(graphics::AppInterface & aAppInterface,
 }
 
 
-RenderGraph::RenderGraph(const std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+RenderGraph::RenderGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
                          const std::filesystem::path & aSceneFile,
                          const imguiui::ImguiUi & aImguiUi) :
     mGlfwAppInterface{std::move(aGlfwAppInterface)},
     // TODO How do we handle the dynamic nature of the number of instance that might be renderered?
     // At the moment, hardcode a maximum number
-    mInstanceStream{makeInstanceStream(mStorage, gMaxDrawInstances)},
     mLoader{makeResourceFinder()},
-    mUbos{mStorage},
     mCameraControl{mGlfwAppInterface->getWindowSize(),
                    gInitialVFov,
                    Orbital{2/*initial radius*/}
-    }
+    },
+    mGraph{mGlfwAppInterface, mStorage}
 {
     registerGlfwCallbacks(*mGlfwAppInterface, mCameraControl, EscKeyBehaviour::Close, &aImguiUi);
     registerGlfwCallbacks(*mGlfwAppInterface, mFirstPersonControl, EscKeyBehaviour::Close, &aImguiUi);
 
-    mScene = mLoader.loadScene(aSceneFile, "effects/Mesh.sefx", mInstanceStream, mStorage);
+    mScene = mLoader.loadScene(aSceneFile, "effects/Mesh.sefx", mGraph.mInstanceStream, mStorage);
     /*const*/Node & model = mScene.mRoot.mChildren.front();
 
     // TODO Ad 2023/10/03: Sort out this bit of logic: remove hardcoded sections,
@@ -762,7 +387,7 @@ RenderGraph::RenderGraph(const std::shared_ptr<graphics::AppInterface> aGlfwAppI
 
     // Add basic shapes to the the scene
     Handle<Effect> simpleEffect = makeSimpleEffect(mStorage);
-    auto [triangle, cube] = loadTriangleAndCube(mStorage, simpleEffect, mInstanceStream);
+    auto [triangle, cube] = loadTriangleAndCube(mStorage, simpleEffect, mGraph.mInstanceStream);
     mScene.addToRoot(triangle);
     mScene.addToRoot(cube);
 }
@@ -786,33 +411,6 @@ void RenderGraph::update(float aDeltaTime)
 }
 
 
-// TODO Ad 2023/09/26: Could be splitted between the part list load (which should be valid accross passes)
-// and the pass cache load (which might only be valid for a single pass)
-// TODO Ad 2023/11/26: Even more, since the model transform is to world space (i.e. constant accross viewpoints)
-// and it is fetched from a buffer in the shaders, it could actually be pushed once per frame.
-// (and the pass would only index the transform for the objects it actually draws).
-void RenderGraph::loadDrawBuffers(const PartList & aPartList,
-                                  const PassCache & aPassCache)
-{
-    PROFILER_SCOPE_RECURRING_SECTION("load_draw_buffers", CpuTime, BufferMemoryWritten);
-
-    assert(aPassCache.mDrawInstances.size() <= gMaxDrawInstances);
-
-    proto::load(*mUbos.mModelTransformUbo,
-                std::span{aPartList.mInstanceTransforms},
-                graphics::BufferHint::DynamicDraw);
-
-    // TODO Ad 2023/11/23: this hardcoded access to first buffer view is ugly
-    proto::load(*mInstanceStream.mVertexBufferViews.at(0).mGLBuffer,
-                std::span{aPassCache.mDrawInstances},
-                graphics::BufferHint::DynamicDraw);
-
-    proto::load(mIndirectBuffer,
-                std::span{aPassCache.mDrawCommands},
-                graphics::BufferHint::DynamicDraw);
-}
-
-
 void RenderGraph::drawUi()
 {
     mSceneGui.present(mScene);
@@ -825,6 +423,9 @@ void RenderGraph::render()
     nvtx3::mark("RenderGraph::render()");
     NVTX3_FUNC_RANGE();
 
+    auto & mUbos = mGraph.mUbos;
+    auto & mIndirectBuffer = mGraph.mIndirectBuffer;
+
     // Empty placeholder for the moment.
     RepositoryTexture dummyTextureRepository;
 
@@ -836,6 +437,8 @@ void RenderGraph::render()
     {
         PROFILER_SCOPE_RECURRING_SECTION("load_frame_UBOs", CpuTime, GpuTime, BufferMemoryWritten);
         loadFrameUbo(*mUbos.mFrameUbo);
+        // Note in a more realistic application, several cameras would be used per frame.
+        loadCameraUbo(*mUbos.mViewingUbo, mCamera);
     }
 
     // Use the same indirect buffer for all drawings
@@ -843,114 +446,7 @@ void RenderGraph::render()
     // With the current approach, this binding could be done only once at construction
     graphics::bind(mIndirectBuffer, graphics::BufferType::DrawIndirect);
 
-    // Hack until we have proper lifetime: give access to the texture outside the scope
-    const graphics::Texture * depthTexture;
-
-    // ----
-    // PASS (depth)
-    // ----
-    {
-        PROFILER_SCOPE_RECURRING_SECTION("pass_depth", CpuTime, GpuTime);
-
-        // Can be done once for distinct camera, if there is no culling
-        PassCache passCache = preparePass("depth", partList, mStorage);
-
-        // Load the data for the part and pass related UBOs (TODO: SSBOs)
-        loadDrawBuffers(partList, passCache);
-
-        //
-        // Attaching a depth texture to a FBO
-        //
-        const math::Size<2, int> depthMapSize = mGlfwAppInterface->getFramebufferSize();
-        // TODO should be a data member somewhere
-        static graphics::Texture depthMap = [](math::Size<2, int> aTextureSize, GLenum aFiltering)
-        {
-            graphics::Texture depthMap{GL_TEXTURE_2D};
-            graphics::allocateStorage(depthMap, GL_DEPTH_COMPONENT24, aTextureSize);
-            {
-                graphics::ScopedBind boundDepthMap{depthMap};
-                // TODO take sampling and filtering out, it is about reading the texture, not writing it.
-                glTexParameteri(depthMap.mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-                glTexParameteri(depthMap.mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
-                glTexParameterfv(depthMap.mTarget, 
-                                 GL_TEXTURE_BORDER_COLOR,
-                                 math::hdr::Rgba_f{1.f, 0.f, 0.f, 0.f}.data());
-
-                glTexParameteri(depthMap.mTarget, GL_TEXTURE_MIN_FILTER, aFiltering);
-                glTexParameteri(depthMap.mTarget, GL_TEXTURE_MAG_FILTER, aFiltering);
-            }
-            return depthMap;
-        }(depthMapSize, GL_LINEAR/* seems required to get hardware pcf with sampler2DShadow */);
-
-        depthTexture = &depthMap;
-
-
-        //
-        // Set pipeline state
-        //
-        // Note: Must be set before any drawing operations, including glClear(),
-        // otherwise it becomes real mysterious real quick.
-        {
-            PROFILER_SCOPE_RECURRING_SECTION("set_pipeline_state", CpuTime);
-            glEnable(GL_CULL_FACE);
-            glEnable(GL_DEPTH_TEST);
-            glDepthMask(GL_TRUE);
-            glDisable(GL_BLEND);
-
-            // Viewport is coupled to the depth map here
-            glViewport(0, 0, depthMapSize.width(), depthMapSize.height());
-        }
-
-        static graphics::FrameBuffer depthFbo = [](const graphics::Texture & aTexture)
-        {
-            graphics::FrameBuffer depthFbo;
-            graphics::ScopedBind boundFbo{depthFbo};
-            // The attachment is permanent, no need to recreate it each time the FBO is bound
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, aTexture.mTarget, aTexture, /*mip map level*/0);
-            return depthFbo;
-        }(depthMap);
-        
-        graphics::ScopedBind boundFbo{depthFbo};
-
-        // Check FBO status before rendering
-        assert(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
-
-        // Clear must appear after the Framebuffer setup!
-        gl.Clear(GL_DEPTH_BUFFER_BIT);
-
-        ///// TODO remove
-        static graphics::Texture colorTex = [](math::Size<2, int> aTextureSize)
-        {
-            graphics::Texture tex{GL_TEXTURE_2D};
-            graphics::allocateStorage(tex, GL_RGBA8, aTextureSize);
-            return tex;
-        }(depthMapSize);
-
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTex.mTarget, colorTex, /*mip map level*/0);
-        const GLenum buffers[] = {GL_COLOR_ATTACHMENT0};
-        glDrawBuffers(1, buffers);
-
-        assert(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
-
-        gl.Clear(GL_COLOR_BUFFER_BIT);
-        /////
-
-        // Might loop over cameras, or any other variation
-        //for(whatever dimension)
-        {
-            {
-                PROFILER_SCOPE_RECURRING_SECTION("load_pass_UBOs", CpuTime, GpuTime, BufferMemoryWritten);
-                // Note in a more realistic application, several cameras would be used per frame.
-                // TODO do not write it inside the pass if it can be done once above for several passes
-                loadCameraUbo(*mUbos.mViewingUbo, mCamera);
-            }
-
-            {
-                PROFILER_SCOPE_RECURRING_SECTION("draw_instances", CpuTime, GpuTime, GpuPrimitiveGen, DrawCalls, BufferMemoryWritten);
-                draw(passCache, mUbos.mUboRepository, dummyTextureRepository);
-            }
-        }
-    }
+    mGraph.passDepth(partList, mStorage);
 
     // ----
     // PASS (forward)
@@ -961,7 +457,7 @@ void RenderGraph::render()
         PassCache passCache = preparePass("forward", partList, mStorage);
 
         // Load the data for the part and pass related UBOs (TODO: SSBOs)
-        loadDrawBuffers(partList, passCache);
+        mGraph.loadDrawBuffers(partList, passCache);
 
         // FBO (default framebuffer)
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
@@ -985,12 +481,6 @@ void RenderGraph::render()
         // Might loop over cameras, or any other variation
         //for(whatever dimension)
         {
-            {
-                PROFILER_SCOPE_RECURRING_SECTION("load_pass_UBOs", CpuTime, GpuTime, BufferMemoryWritten);
-                // Note in a more realistic application, several cameras would be used per frame.
-                loadCameraUbo(*mUbos.mViewingUbo, mCamera);
-            }
-
             // TODO should be done once per viewport
             glViewport(0, 0,
                        mGlfwAppInterface->getFramebufferSize().width(),
@@ -1017,7 +507,7 @@ void RenderGraph::render()
 
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
         glActiveTexture(GL_TEXTURE0);
-        glBindTexture(depthTexture->mTarget, *depthTexture);
+        glBindTexture(mGraph.mDepthMap.mTarget, mGraph.mDepthMap);
 
         // Would require scissor test to clear only part of the screen.
         //gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -1039,17 +529,6 @@ void RenderGraph::render()
         drawQuad({
             .mSourceChannel = 0,
             .mLinearization = DrawQuadParameters::DepthMethod1,
-            .mNearDistance = nearZ,
-            .mFarDistance = farZ,
-        });
-        
-        glViewport(0, fbSize.height() / 4,
-                   fbSize.width() / 4,
-                   fbSize.height() / 4);
-
-        drawQuad({
-            .mSourceChannel = 0,
-            .mLinearization = DrawQuadParameters::DepthMethod2,
             .mNearDistance = nearZ,
             .mFarDistance = farZ,
         });

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.cpp
@@ -307,7 +307,7 @@ RenderGraph::RenderGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterfa
     registerGlfwCallbacks(*mGlfwAppInterface, mCameraControl, EscKeyBehaviour::Close, &aImguiUi);
     registerGlfwCallbacks(*mGlfwAppInterface, mFirstPersonControl, EscKeyBehaviour::Close, &aImguiUi);
 
-    mScene = mLoader.loadScene(aSceneFile, "effects/Mesh.sefx", mGraph.mInstanceStream, mStorage);
+    mScene = mLoader.loadScene(aSceneFile, mGraph.mInstanceStream, mStorage);
     /*const*/Node & model = mScene.mRoot.mChildren.front();
 
     // TODO Ad 2023/10/03: Sort out this bit of logic: remove hardcoded sections,

--- a/src/apps/refactor_proto/refactor_proto/RenderGraph.h
+++ b/src/apps/refactor_proto/refactor_proto/RenderGraph.h
@@ -4,9 +4,9 @@
 #include "Camera.h"
 #include "Model.h"
 #include "Loader.h"
-#include "Repositories.h"
 #include "Scene.h"
 #include "SceneGui.h"
+#include "TheGraph.h"
 
 #include <graphics/ApplicationGlfw.h>
 
@@ -19,64 +19,12 @@ namespace ad::imguiui {
 namespace ad::renderer {
 
 
-/// @brief Entry to populate the GL_DRAW_INDIRECT_BUFFER used with indexed (glDrawElements) geometry.
-struct DrawElementsIndirectCommand
-{
-    GLuint  mCount;
-    GLuint  mInstanceCount;
-    GLuint  mFirstIndex;
-    GLuint  mBaseVertex;
-    GLuint  mBaseInstance;
-};
+struct PassCache;
 
-
-/// @brief Entry to populate the instance buffer (attribute divisor == 1).
-/// Each instance (mapping to a `Part` in client data model) has a pose and a material.
-struct DrawInstance
-{
-    GLsizei mInstanceTransformIdx; // index in the instance UBO
-    GLsizei mMaterialIdx;
-};
-
-
-/// @brief Store state and parameters required to issue a GL draw call.
-struct DrawCall
-{
-    GLenum mPrimitiveMode = 0;
-    GLenum mIndicesType = 0;
-
-    const IntrospectProgram * mProgram;
-    const graphics::VertexArrayObject * mVao;
-    // TODO I am not sure having the material context here is a good idea, it feels a bit high level
-    Handle<MaterialContext> mCallContext;
-
-    GLsizei mPartCount;
-};
-
-
-// TODO rename to DrawXxx
-struct PassCache
-{
-    std::vector<DrawCall> mCalls;
-
-    // SOA at the moment, one entry per part
-    std::vector<DrawElementsIndirectCommand> mDrawCommands;
-    std::vector<DrawInstance> mDrawInstances; // Intended to be loaded as a GL instance buffer
-};
-
-struct HardcodedUbos
-{
-    HardcodedUbos(Storage & aStorage);
-
-    RepositoryUbo mUboRepository;
-    graphics::UniformBufferObject * mFrameUbo;
-    graphics::UniformBufferObject * mViewingUbo;
-    graphics::UniformBufferObject * mModelTransformUbo;
-};
 
 struct RenderGraph
 {
-    RenderGraph(const std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+    RenderGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
                 const std::filesystem::path & aSceneFile,
                 const imguiui::ImguiUi & aImguiUi);
 
@@ -84,24 +32,21 @@ struct RenderGraph
     void update(float aDeltaTime);
     void render();
 
-    void loadDrawBuffers(const PartList & aPartList, const PassCache & aPassCache);
-
     void drawUi();
 
     std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
     Storage mStorage;
     Scene mScene;
-    GenericStream mInstanceStream;
     Loader mLoader;
     SceneGui mSceneGui{mLoader.loadEffect("effects/Highlight.sefx", mStorage), mStorage};
-    HardcodedUbos mUbos;
-    graphics::BufferAny mIndirectBuffer;
 
     Camera mCamera;
     
     // TODO #camera allow both control modes, ideally via DearImgui
     OrbitalControl mCameraControl;
     FirstPersonControl mFirstPersonControl;
+
+    TheGraph mGraph;
 };
 
 

--- a/src/apps/refactor_proto/refactor_proto/RendererReimplement.h
+++ b/src/apps/refactor_proto/refactor_proto/RendererReimplement.h
@@ -3,6 +3,8 @@
 
 #include "GlApi.h"
 
+#include <span>
+
 
 namespace ad::renderer {
 

--- a/src/apps/refactor_proto/refactor_proto/Scene.h
+++ b/src/apps/refactor_proto/refactor_proto/Scene.h
@@ -11,19 +11,7 @@
 namespace ad::renderer {
 
 
-/// @brief A list of parts to be drawn, each associated to a Material and a transformation.
-/// It is intended to be reused accross distinct passes inside a frame (or even accross frame for static parts).
-struct PartList
-{
-    // The individual renderer::Objects transforms. Several parts might index to the same transform.
-    // (Same way several parts might index the same material parameters)
-    std::vector<math::AffineMatrix<4, GLfloat>> mInstanceTransforms;
-
-    // SOA
-    std::vector<const Part *> mParts;
-    std::vector<const Material *> mMaterials;
-    std::vector<GLsizei> mTransformIdx;
-};
+struct PartList;
 
 
 struct Scene

--- a/src/apps/refactor_proto/refactor_proto/SetupDrawing.cpp
+++ b/src/apps/refactor_proto/refactor_proto/SetupDrawing.cpp
@@ -162,6 +162,10 @@ void setTextures(const IntrospectProgram & aProgram,
                 // TODO assertions regarding texture-sampler compatibility
                 auto guardImageUnit = graphics::activateTextureUnitGuard(textureImageUnit);
                 bind(*found->second); // should not be unbound when we exit the current scope.
+                // TODO Ad 2023/11/30: Currently, we are assigning texture image units to sampler uniforms of the shader program
+                // and binding the texture to the texture unit each time.
+                // Assuming we will bind the texture to the TU each time, we can set the uniforms only once for the shader program lifetime 
+                // (as long as the texture is bound to the same unit).
                 graphics::setUniform(aProgram, shaderUniform.mLocation, textureImageUnit);
                 ++textureImageUnit;
             }

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.cpp
@@ -1,0 +1,245 @@
+#include "TheGraph.h"
+
+// TODO Ad 2023/10/18: Should get rid of this repeated implementation
+#include "RendererReimplement.h" 
+
+#include "Camera.h"
+#include "Loader.h" // for semantics
+#include "Pass.h"
+#include "Profiling.h"
+#include "Scene.h"
+#include "SetupDrawing.h"
+
+
+namespace ad::renderer {
+
+
+constexpr std::size_t gMaxDrawInstances = 2048;
+
+
+//
+// HardcodedUbos
+//
+HardcodedUbos::HardcodedUbos(Storage & aStorage)
+{
+    aStorage.mUbos.emplace_back();
+    mFrameUbo = &aStorage.mUbos.back();
+    mUboRepository.emplace(semantic::gFrame, mFrameUbo);
+
+    aStorage.mUbos.emplace_back();
+    mViewingUbo = &aStorage.mUbos.back();
+    mUboRepository.emplace(semantic::gView, mViewingUbo);
+
+    aStorage.mUbos.emplace_back();
+    mModelTransformUbo = &aStorage.mUbos.back();
+    mUboRepository.emplace(semantic::gLocalToWorld, mModelTransformUbo);
+}
+
+
+//
+// Draw
+//
+void draw(const PassCache & aPassCache,
+          const RepositoryUbo & aUboRepository,
+          const RepositoryTexture & aTextureRepository)
+{
+    //TODO Ad 2023/08/01: META todo, should we have "compiled state objects" (a-la VAO) for interface bocks, textures, etc
+    // where we actually map a state setup (e.g. which texture name to which image unit and which sampler)
+    // those could be "bound" before draw (potentially doing some binds and uniform setting, but not iterating the program)
+    // (We could even separate actual texture from the "format", allowing to change an underlying texture without revisiting the program)
+    // This would address the warnings repetitions (only issued when the compiled state is (re-)generated), and be better for perfs.
+
+    GLuint firstInstance = 0; 
+    for (const DrawCall & aCall : aPassCache.mCalls)
+    {
+        PROFILER_SCOPE_RECURRING_SECTION("drawcall_iteration", CpuTime);
+
+        PROFILER_PUSH_RECURRING_SECTION("discard_2", CpuTime);
+        const IntrospectProgram & selectedProgram = *aCall.mProgram;
+        const graphics::VertexArrayObject & vao = *aCall.mVao;
+        PROFILER_POP_RECURRING_SECTION;
+
+        // TODO Ad 2023/10/05: #perf #azdo 
+        // Only change what is necessary, instead of rebiding everything each time.
+        // Since we sorted our draw calls, it is very likely that program remain the same, and VAO changes.
+        {
+            PROFILER_PUSH_RECURRING_SECTION("bind_VAO", CpuTime);
+            graphics::ScopedBind vaoScope{vao};
+            PROFILER_POP_RECURRING_SECTION;
+            
+            {
+                PROFILER_SCOPE_RECURRING_SECTION("set_buffer_backed_blocks", CpuTime);
+                // TODO #repos This should be consolidated
+                RepositoryUbo uboRepo{aUboRepository};
+                if(aCall.mCallContext)
+                {
+                    RepositoryUbo callRepo{aCall.mCallContext->mUboRepo};
+                    uboRepo.merge(callRepo);
+                }
+                setBufferBackedBlocks(selectedProgram, uboRepo);
+            }
+
+            {
+                PROFILER_SCOPE_RECURRING_SECTION("set_textures", CpuTime);
+                // TODO #repos This should be consolidated
+                RepositoryTexture textureRepo{aTextureRepository};
+                if(aCall.mCallContext)
+                {
+                    RepositoryTexture callRepo{aCall.mCallContext->mTextureRepo};
+                    textureRepo.merge(callRepo);
+                }
+                setTextures(selectedProgram, textureRepo);
+            }
+
+            PROFILER_PUSH_RECURRING_SECTION("bind_program", CpuTime);
+            graphics::ScopedBind programScope{selectedProgram};
+            PROFILER_POP_RECURRING_SECTION;
+
+            {
+                // TODO Ad 2023/08/23: Measuring GPU time here has a x2 impact on cpu performance
+                // Can we have efficient GPU measures?
+                PROFILER_SCOPE_RECURRING_SECTION("glDraw_call", CpuTime/*, GpuTime*/);
+                
+                gl.MultiDrawElementsIndirect(
+                    aCall.mPrimitiveMode,
+                    aCall.mIndicesType,
+                    (void *)(firstInstance * sizeof(DrawElementsIndirectCommand)),
+                    aCall.mPartCount,
+                    sizeof(DrawElementsIndirectCommand));
+            }
+        }
+        firstInstance += aCall.mPartCount;
+    }
+}
+
+
+//
+// TheGraph
+//
+TheGraph::TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+                   Storage & aStorage) :
+    mGlfwAppInterface{std::move(aGlfwAppInterface)},
+    mUbos{aStorage},
+    mInstanceStream{makeInstanceStream(aStorage, gMaxDrawInstances)}
+{
+    // TODO Ad 2023/11/28: Listen to framebuffer resize
+    mDepthMapSize = mGlfwAppInterface->getFramebufferSize();
+
+    graphics::allocateStorage(mDepthMap, GL_DEPTH_COMPONENT24, mDepthMapSize);
+    [this](GLenum aFiltering)
+    {
+        graphics::ScopedBind boundDepthMap{mDepthMap};
+        // TODO take sampling and filtering out, it is about reading the texture, not writing it.
+        glTexParameteri(mDepthMap.mTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+        glTexParameteri(mDepthMap.mTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+        glTexParameterfv(mDepthMap.mTarget, 
+                            GL_TEXTURE_BORDER_COLOR,
+                            math::hdr::Rgba_f{1.f, 0.f, 0.f, 0.f}.data());
+
+        glTexParameteri(mDepthMap.mTarget, GL_TEXTURE_MIN_FILTER, aFiltering);
+        glTexParameteri(mDepthMap.mTarget, GL_TEXTURE_MAG_FILTER, aFiltering);
+    }(GL_LINEAR/* seems required to get hardware pcf with sampler2DShadow */);
+
+    //
+    // Attaching a depth texture to a FBO
+    //
+    {
+        graphics::ScopedBind boundFbo{mDepthFbo};
+        // The attachment is permanent, no need to recreate it each time the FBO is bound
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, mDepthMap.mTarget, mDepthMap, /*mip map level*/0);
+    }
+}
+
+
+// TODO Ad 2023/09/26: Could be splitted between the part list load (which should be valid accross passes)
+// and the pass cache load (which might only be valid for a single pass)
+// TODO Ad 2023/11/26: Even more, since the model transform is to world space (i.e. constant accross viewpoints)
+// and it is fetched from a buffer in the shaders, it could actually be pushed once per frame.
+// (and the pass would only index the transform for the objects it actually draws).
+void TheGraph::loadDrawBuffers(const PartList & aPartList,
+                               const PassCache & aPassCache)
+{
+    PROFILER_SCOPE_RECURRING_SECTION("load_draw_buffers", CpuTime, BufferMemoryWritten);
+
+    assert(aPassCache.mDrawInstances.size() <= gMaxDrawInstances);
+
+    proto::load(*mUbos.mModelTransformUbo,
+                std::span{aPartList.mInstanceTransforms},
+                graphics::BufferHint::DynamicDraw);
+
+    // TODO Ad 2023/11/23: this hardcoded access to first buffer view is ugly
+    proto::load(*mInstanceStream.mVertexBufferViews.at(0).mGLBuffer,
+                std::span{aPassCache.mDrawInstances},
+                graphics::BufferHint::DynamicDraw);
+
+    proto::load(mIndirectBuffer,
+                std::span{aPassCache.mDrawCommands},
+                graphics::BufferHint::DynamicDraw);
+}
+
+
+
+void TheGraph::passDepth(const PartList & aPartList, Storage & aStorage)
+{
+    PROFILER_SCOPE_RECURRING_SECTION("pass_depth", CpuTime, GpuTime);
+
+    // Can be done once even for distinct cameras, if there is no culling
+    PassCache passCache = preparePass("depth", aPartList, aStorage);
+
+    // Load the data for the part and pass related UBOs (TODO: SSBOs)
+    loadDrawBuffers(aPartList, passCache);
+
+
+    //
+    // Set pipeline state
+    //
+    // Note: Must be set before any drawing operations, including glClear(),
+    // otherwise results becomes real mysterious real quick.
+    {
+        PROFILER_SCOPE_RECURRING_SECTION("set_pipeline_state", CpuTime);
+        glEnable(GL_CULL_FACE);
+        glEnable(GL_DEPTH_TEST);
+        glDepthMask(GL_TRUE);
+        glDisable(GL_BLEND);
+
+        // Viewport is coupled to the depth map here
+        glViewport(0, 0, mDepthMapSize.width(), mDepthMapSize.height());
+    }
+
+    graphics::ScopedBind boundFbo{mDepthFbo};
+
+    // Check bound FBO status before rendering
+    assert(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+
+    // Clear must appear after the Framebuffer setup!
+    gl.Clear(GL_DEPTH_BUFFER_BIT);
+
+    ///// TODO remove when it is used in another pass
+    //static graphics::Texture colorTex = [](math::Size<2, int> aTextureSize)
+    //{
+    //    graphics::Texture tex{GL_TEXTURE_2D};
+    //    graphics::allocateStorage(tex, GL_RGBA8, aTextureSize);
+    //    return tex;
+    //}(depthMapSize);
+
+    //glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, colorTex.mTarget, colorTex, /*mip map level*/0);
+    //const GLenum buffers[] = {GL_COLOR_ATTACHMENT0};
+    //glDrawBuffers(1, buffers);
+
+    //assert(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+
+    //gl.Clear(GL_COLOR_BUFFER_BIT);
+    /////
+
+    // Might loop over cameras, or any other variation
+    //for(whatever dimension)
+    {
+        {
+            PROFILER_SCOPE_RECURRING_SECTION("draw_instances", CpuTime, GpuTime, GpuPrimitiveGen, DrawCalls, BufferMemoryWritten);
+            draw(passCache, mUbos.mUboRepository, mDummyTextureRepository);
+        }
+    }
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.cpp
@@ -248,9 +248,9 @@ void TheGraph::renderFrame(const PartList & aPartList, const Camera & aCamera, S
 }
 
 
-void TheGraph::showDepthTexture(const graphics::Texture & aTexture,
-                                float aNearZ, float aFarZ,
-                                unsigned int aStackPosition)
+void TheGraph::showTexture(const graphics::Texture & aTexture,
+                           unsigned int aStackPosition,
+                           DrawQuadParameters aDrawParams)
 {
     assert(aStackPosition < 4);
 
@@ -277,15 +277,28 @@ void TheGraph::showDepthTexture(const graphics::Texture & aTexture,
                fbSize.width() / 4,
                fbSize.height() / 4);
 
-    drawQuad({
-        .mSourceChannel = 0,
-        .mLinearization = DrawQuadParameters::DepthMethod1,
-        .mNearDistance = aNearZ,
-        .mFarDistance = aFarZ,
-    });
+    drawQuad(aDrawParams);
 }
 
-void TheGraph::passDepth(const PartList & aPartList, Storage & aStorage)
+
+// TODO rewrite in terms of above
+void TheGraph::showDepthTexture(const graphics::Texture & aTexture,
+                                float aNearZ, float aFarZ,
+                                unsigned int aStackPosition)
+{
+    showTexture(
+        aTexture, 
+        aStackPosition,
+        {
+            .mSourceChannel = 0,
+            .mOperation = DrawQuadParameters::DepthLinearize1,
+            .mNearDistance = aNearZ,
+            .mFarDistance = aFarZ,
+        });
+}
+
+
+void TheGraph::passOpaqueDepth(const PartList & aPartList, Storage & aStorage)
 {
     PROFILER_SCOPE_RECURRING_SECTION("pass_depth", CpuTime, GpuTime);
 

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.cpp
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.cpp
@@ -4,6 +4,7 @@
 #include "RendererReimplement.h" 
 
 #include "Camera.h"
+#include "DrawQuad.h"
 #include "Loader.h" // for semantics
 #include "Pass.h"
 #include "Profiling.h"
@@ -11,10 +12,54 @@
 #include "SetupDrawing.h"
 
 
+
 namespace ad::renderer {
 
 
 constexpr std::size_t gMaxDrawInstances = 2048;
+
+
+namespace {
+
+
+    /// @brief Layout compatible with the shader's `ViewBlock`
+    struct GpuViewBlock
+    {
+        GpuViewBlock(
+            math::AffineMatrix<4, GLfloat> aWorldToCamera,
+            math::Matrix<4, 4, GLfloat> aProjection 
+        ) :
+            mWorldToCamera{aWorldToCamera},
+            mProjection{aProjection},
+            mViewingProjection{aWorldToCamera * aProjection}
+        {}
+
+        GpuViewBlock(const Camera & aCamera) :
+            GpuViewBlock{aCamera.getParentToCamera(), aCamera.getProjection()}
+        {}
+
+        math::AffineMatrix<4, GLfloat> mWorldToCamera; 
+        math::Matrix<4, 4, GLfloat> mProjection; 
+        math::Matrix<4, 4, GLfloat> mViewingProjection;
+    };
+
+
+    void loadFrameUbo(const graphics::UniformBufferObject & aUbo)
+    {
+        GLfloat time =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::high_resolution_clock::now().time_since_epoch()).count() / 1000.f;
+        proto::loadSingle(aUbo, time, graphics::BufferHint::DynamicDraw);
+    }
+
+
+    void loadCameraUbo(const graphics::UniformBufferObject & aUbo, const Camera & aCamera)
+    {
+        proto::loadSingle(aUbo, GpuViewBlock{aCamera}, graphics::BufferHint::DynamicDraw);
+    }
+
+
+} // unnamed namespace
 
 
 //
@@ -178,6 +223,67 @@ void TheGraph::loadDrawBuffers(const PartList & aPartList,
 }
 
 
+void TheGraph::renderFrame(const PartList & aPartList, const Camera & aCamera, Storage & aStorage)
+{
+    {
+        PROFILER_SCOPE_RECURRING_SECTION("load_frame_UBOs", CpuTime, GpuTime, BufferMemoryWritten);
+        loadFrameUbo(*mUbos.mFrameUbo);
+        // Note in a more realistic application, several cameras would be used per frame.
+        loadCameraUbo(*mUbos.mViewingUbo, aCamera);
+    }
+
+    // Use the same indirect buffer for all drawings
+    // Its content will be rewritten by distinct passes though
+    // With the current approach, this binding could be done only once at construction
+    graphics::bind(mIndirectBuffer, graphics::BufferType::DrawIndirect);
+
+    passDepth(aPartList, aStorage);
+    passForward(aPartList, aStorage);
+
+    //
+    // Debug rendering of the depth texture
+    //
+    auto [nearZ, farZ] = getNearFarPlanes(aCamera);
+    showDepthTexture(mDepthMap, nearZ, farZ) ;
+}
+
+
+void TheGraph::showDepthTexture(const graphics::Texture & aTexture,
+                                float aNearZ, float aFarZ,
+                                unsigned int aStackPosition)
+{
+    assert(aStackPosition < 4);
+
+    // Note: with stencil, we could draw those rectangles first,
+    // and prevent main rasterization behind them.
+
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(aTexture.mTarget, aTexture);
+
+    // Would require scissor test to clear only part of the screen.
+    //gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    {
+        glDisable(GL_DEPTH_TEST);
+        glDisable(GL_BLEND);
+        glDepthMask(GL_FALSE);
+    }
+
+    math::Size<2, int> fbSize = mGlfwAppInterface->getFramebufferSize();
+
+    glViewport(0,
+               aStackPosition * fbSize.height() / 4,
+               fbSize.width() / 4,
+               fbSize.height() / 4);
+
+    drawQuad({
+        .mSourceChannel = 0,
+        .mLinearization = DrawQuadParameters::DepthMethod1,
+        .mNearDistance = aNearZ,
+        .mFarDistance = aFarZ,
+    });
+}
 
 void TheGraph::passDepth(const PartList & aPartList, Storage & aStorage)
 {
@@ -241,5 +347,54 @@ void TheGraph::passDepth(const PartList & aPartList, Storage & aStorage)
     }
 }
 
+
+void TheGraph::passForward(const PartList & aPartList, Storage & mStorage)
+{
+    PROFILER_SCOPE_RECURRING_SECTION("pass_forward", CpuTime, GpuTime);
+
+    // Can be done once for distinct camera, if there is no culling
+    PassCache passCache = preparePass("forward", aPartList, mStorage);
+
+    // Load the data for the part and pass related UBOs (TODO: SSBOs)
+    loadDrawBuffers(aPartList, passCache);
+
+    // FBO (default framebuffer)
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+    //
+    // Set pipeline state
+    //
+    {
+        PROFILER_SCOPE_RECURRING_SECTION("set_pipeline_state", CpuTime);
+        // TODO handle pipeline state with an abstraction
+        glEnable(GL_CULL_FACE);
+        glEnable(GL_DEPTH_TEST);
+        glDepthMask(GL_TRUE);
+
+        // We implemented alpha testing (cut-out), no blending.
+        glDisable(GL_BLEND);
+    }
+
+    gl.Clear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    // Might loop over cameras, or any other variation
+    //for(whatever dimension)
+    {
+        // TODO should be done once per viewport
+        glViewport(0, 0,
+                    mGlfwAppInterface->getFramebufferSize().width(),
+                    mGlfwAppInterface->getFramebufferSize().height());
+
+        // Reset texture bindings (to make sure that texturing does not work by "accident")
+        // this could be extended to reset everything in the context.
+        glBindTexture(GL_TEXTURE_2D, 0);
+        glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+
+        {
+            PROFILER_SCOPE_RECURRING_SECTION("draw_instances", CpuTime, GpuTime, GpuPrimitiveGen, DrawCalls, BufferMemoryWritten);
+            draw(passCache, mUbos.mUboRepository, mDummyTextureRepository);
+        }
+    }
+}
 
 } // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.h
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "DrawQuad.h"
 #include "Model.h"
 #include "Repositories.h"
 
@@ -46,6 +47,10 @@ struct TheGraph
     void passForward(const PartList & aPartList, Storage & mStorage);
 
     void loadDrawBuffers(const PartList & aPartList, const PassCache & aPassCache);
+
+    void showTexture(const graphics::Texture & aTexture,
+                     unsigned int aStackPosition,
+                     DrawQuadParameters aDrawParams = {});
 
     void showDepthTexture(const graphics::Texture & aTexture,
                           float aNearZ, float aFarZ,

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.h
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "Model.h"
+#include "Repositories.h"
+
+#include <graphics/ApplicationGlfw.h>
+
+#include <renderer/FrameBuffer.h>
+#include <renderer/Texture.h>
+
+
+namespace ad::renderer {
+
+
+class Camera;
+struct PartList;
+struct PassCache;
+struct Storage;
+
+
+void draw(const PassCache & aPassCache,
+          const RepositoryUbo & aUboRepository,
+          const RepositoryTexture & aTextureRepository);
+
+
+struct HardcodedUbos
+{
+    HardcodedUbos(Storage & aStorage);
+
+    RepositoryUbo mUboRepository;
+    graphics::UniformBufferObject * mFrameUbo;
+    graphics::UniformBufferObject * mViewingUbo;
+    graphics::UniformBufferObject * mModelTransformUbo;
+};
+
+
+struct TheGraph
+{
+    TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+             Storage & aStorage);
+
+    void loadDrawBuffers(const PartList & aPartList, const PassCache & aPassCache);
+
+    // Note: Storage cannot be const, as it might be modified to insert missing VAOs, etc
+    void passDepth(const PartList & aPartList, Storage & mStorage);
+
+// Data members:
+    std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
+
+    HardcodedUbos mUbos;
+    RepositoryTexture mDummyTextureRepository;
+
+    GenericStream mInstanceStream;
+
+    graphics::BufferAny mIndirectBuffer;
+
+    math::Size<2, int> mDepthMapSize;
+    // Note Ad 2023/11/28: Might become a RenderTarger for optimal access if it is never sampled
+    graphics::Texture mDepthMap{GL_TEXTURE_2D};
+    graphics::FrameBuffer mDepthFbo;
+};
+
+
+} // namespace ad::renderer

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.h
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.h
@@ -39,11 +39,17 @@ struct TheGraph
     TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
              Storage & aStorage);
 
-    void loadDrawBuffers(const PartList & aPartList, const PassCache & aPassCache);
+    void renderFrame(const PartList & aPartList, const Camera & aCamera, Storage & aStorage);
 
     // Note: Storage cannot be const, as it might be modified to insert missing VAOs, etc
     void passDepth(const PartList & aPartList, Storage & mStorage);
+    void passForward(const PartList & aPartList, Storage & mStorage);
 
+    void loadDrawBuffers(const PartList & aPartList, const PassCache & aPassCache);
+
+    void showDepthTexture(const graphics::Texture & aTexture,
+                          float aNearZ, float aFarZ,
+                          unsigned int aStackPosition = 0);
 // Data members:
     std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
 

--- a/src/apps/refactor_proto/refactor_proto/TheGraph.h
+++ b/src/apps/refactor_proto/refactor_proto/TheGraph.h
@@ -14,6 +14,7 @@ namespace ad::renderer {
 
 
 class Camera;
+struct Loader;
 struct PartList;
 struct PassCache;
 struct Storage;
@@ -38,13 +39,16 @@ struct HardcodedUbos
 struct TheGraph
 {
     TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
-             Storage & aStorage);
+             Storage & aStorage,
+             const Loader & aLoader);
 
     void renderFrame(const PartList & aPartList, const Camera & aCamera, Storage & aStorage);
 
     // Note: Storage cannot be const, as it might be modified to insert missing VAOs, etc
-    void passDepth(const PartList & aPartList, Storage & mStorage);
+    void passOpaqueDepth(const PartList & aPartList, Storage & mStorage);
     void passForward(const PartList & aPartList, Storage & mStorage);
+    void passTransparencyAccumulation(const PartList & aPartList, Storage & mStorage);
+    void passTransparencyResolve(const PartList & aPartList, Storage & mStorage);
 
     void loadDrawBuffers(const PartList & aPartList, const PassCache & aPassCache);
 
@@ -65,10 +69,19 @@ struct TheGraph
 
     graphics::BufferAny mIndirectBuffer;
 
-    math::Size<2, int> mDepthMapSize;
+    math::Size<2, int> mRenderSize;
+
     // Note Ad 2023/11/28: Might become a RenderTarger for optimal access if it is never sampled
     graphics::Texture mDepthMap{GL_TEXTURE_2D};
     graphics::FrameBuffer mDepthFbo;
+
+    // Transparency
+    graphics::Texture mTransparencyAccum{GL_TEXTURE_2D};
+    graphics::Texture mTransparencyRevealage{GL_TEXTURE_2D};
+    graphics::FrameBuffer mTransparencyFbo;
+    QuadDrawer mTransparencyResolver;
+    static const GLint gAccumTextureUnit{0};
+    static const GLint gRevealageTextureUnit{1};
 };
 
 

--- a/src/apps/refactor_proto/refactor_proto/resources/effects/Mesh.sefx
+++ b/src/apps/refactor_proto/refactor_proto/resources/effects/Mesh.sefx
@@ -5,6 +5,12 @@
                 "pass": "forward"
             },
             "programfile": "shaders/ForwardPhongLighting.prog"
+        },
+        {
+            "annotations": {
+                "pass": "depth"
+            },
+            "programfile": "shaders/DepthMapping.prog"
         }
     ]
 }

--- a/src/apps/refactor_proto/refactor_proto/resources/effects/MeshOpaque.sefx
+++ b/src/apps/refactor_proto/refactor_proto/resources/effects/MeshOpaque.sefx
@@ -8,7 +8,7 @@
         },
         {
             "annotations": {
-                "pass": "depth"
+                "pass": "depth_opaque"
             },
             "programfile": "shaders/DepthMapping.prog"
         }

--- a/src/apps/refactor_proto/refactor_proto/resources/effects/MeshTransparent.sefx
+++ b/src/apps/refactor_proto/refactor_proto/resources/effects/MeshTransparent.sefx
@@ -1,0 +1,10 @@
+{
+    "techniques": [
+        {
+            "annotations": {
+                "pass": "transparent"
+            },
+            "programfile": "shaders/ForwardPhongLighting_transparent.prog"
+        }
+    ]
+}

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/Depth.frag
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/Depth.frag
@@ -1,0 +1,9 @@
+#version 420
+
+
+layout(location = 0) out vec4 out_Color;
+
+void main(void)
+{
+    // no need to write to gl_FragDepth, the depth buffer is updated automatically.
+}

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/DepthMapping.prog
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/DepthMapping.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "PhongLighting.vert",
+    "fragment": "Depth.frag"
+}

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/ForwardPhongLighting.prog
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/ForwardPhongLighting.prog
@@ -1,8 +1,4 @@
 {
-    "features": {
-        "texturing": ["TEXTURES"],
-        "shadow_receiver": ["SHADOW"]
-    },
     "vertex": "PhongLighting.vert",
     "fragment": "PhongLighting.frag"
 }

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/ForwardPhongLighting_transparent.prog
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/ForwardPhongLighting_transparent.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting_transparent.frag"
+}

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/Helpers.glsl
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/Helpers.glsl
@@ -2,3 +2,17 @@ float dotPlus(vec3 a, vec3 b)
 {
     return max(0.f, dot(a, b));
 }
+
+
+float maxCw(vec3 v)
+{
+    return max(max(v.x, v.y), v.z);
+}
+
+
+float maxCw(vec4 v)
+{
+    //see: https://stackoverflow.com/a/77071476
+    vec2 pairs = max(v.xy, v.zw);
+    return max(pairs.x, pairs.y);
+}

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/PhongLighting_transparent.frag
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/PhongLighting_transparent.frag
@@ -97,7 +97,10 @@ void main()
     vec3 phongColor = albedo.rgb * (lightColor * (diffuse + specular) + lightAmbientColor * ambient);
 
 
-    vec4 reflect = vec4(phongColor, 0.9); // Let's hardcode transparency atm
+    vec4 reflect = vec4(phongColor, 0.5); // Let's hardcode transparency atm
+    // Note: the opaque (or almost opaque) objects are problematic:
+    // They do hide the non-transparent objects as expected, but are still
+    // mutually transparent (because of how weighted accumulation works)
     //vec4 reflect = vec4(phongColor, 1); // Let's hardcode transparency atm
     vec3 transmit = vec3(0); // What is that?
     writePixel(reflect, transmit, 0);

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/PhongLighting_transparent.frag
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/PhongLighting_transparent.frag
@@ -1,0 +1,104 @@
+#version 420
+
+#include "Helpers.glsl"
+
+
+in vec3 ex_Position_cam;
+in vec3 ex_Normal_cam;
+
+#ifdef VERTEX_COLOR
+in vec4 ex_Color;
+#endif
+
+in vec2[4] ex_Uv;
+in flat uint ex_MaterialIdx;
+
+#ifdef TEXTURED
+uniform sampler2DArray u_DiffuseTexture;
+#endif
+
+struct PhongMaterial
+{
+    vec4 ambientColor;
+    vec4 diffuseColor;
+    vec4 specularColor;
+    uint textureIndex;
+    uint diffuseUvChannel;
+    float specularExponent;
+};
+
+layout(std140, binding = 2) uniform MaterialsBlock
+{
+    PhongMaterial ub_Phong[128];
+};
+
+
+layout(location = 0) out vec4  out_Accum;
+layout(location = 1) out float out_Revealage;
+
+
+// TODO what is transmit?
+// See: https://casual-effects.blogspot.com/2015/03/implemented-weighted-blended-order.html#3D_transparency_pass
+void writePixel(vec4 premultipliedReflect, vec3 transmit, float csZ) { 
+    // Modulate the net coverage for composition by the transmission. This does not affect the color channels of the
+    // transparent surface because the caller's BSDF model should have already taken into account if transmission modulates
+    // reflection. This model doesn't handled colored transmission, so it averages the color channels. See 
+    //    McGuire and Enderton, Colored Stochastic Shadow Maps, ACM I3D, February 2011
+    //    http://graphics.cs.williams.edu/papers/CSSM/
+    // for a full explanation and derivation.
+
+    premultipliedReflect.a *= 1.0 - clamp((transmit.r + transmit.g + transmit.b) * (1.0 / 3.0), 0, 1);
+
+    // You may need to adjust the w function if you have a very large or very small view volume; see the paper and
+    //   presentation slides at http://jcgt.org/published/0002/02/09/
+
+    // Intermediate terms to be cubed
+    float a = min(1.0, premultipliedReflect.a) * 8.0 + 0.01;
+    float b = -gl_FragCoord.z * 0.95 + 1.0;
+
+    // If your scene has a lot of content very close to the far plane,
+    //   then include this line (one rsqrt instruction):
+    //b /= sqrt(1e4 * abs(csZ));
+    float w    = clamp(a * a * a * 1e8 * b * b * b, 1e-2, 3e2);
+    out_Accum     = premultipliedReflect * w;
+    out_Revealage = premultipliedReflect.a;
+}
+
+
+void main()
+{
+    // Material
+    PhongMaterial material = ub_Phong[ex_MaterialIdx];
+
+#ifdef VERTEX_COLOR
+    vec4 albedo = ex_Color;
+#else
+    vec4 albedo = vec4(1., 1., 1., 1.);
+#endif
+
+#ifdef TEXTURED
+    albedo = albedo * texture(u_DiffuseTexture, vec3(ex_Uv[material.diffuseUvChannel], material.textureIndex));
+#endif
+
+    // TODO take the light(s) as UBO input
+    vec3 lightAmbientColor = vec3(0.5, 0.5, 0.5);
+    vec3 lightColor = vec3(1., 1., 1.);
+    vec3 lightDir_cam = normalize(vec3(-0.5, 0., 1.));
+
+    // Phong reflection model
+    vec3 view_cam = vec3(0., 0., 1.);
+    vec3 h_cam = normalize(view_cam + lightDir_cam);
+    vec3 normal_cam = normalize(ex_Normal_cam);
+
+    vec3 ambient = vec3(material.ambientColor);
+    vec3 diffuse = dotPlus(normal_cam, lightDir_cam) * vec3(material.diffuseColor);
+    vec3 specular = pow(dotPlus(normal_cam, h_cam), material.specularExponent) * vec3(material.specularColor);
+
+    vec3 phongColor = albedo.rgb * (lightColor * (diffuse + specular) + lightAmbientColor * ambient);
+
+
+    vec4 reflect = vec4(phongColor, 0.9); // Let's hardcode transparency atm
+    //vec4 reflect = vec4(phongColor, 1); // Let's hardcode transparency atm
+    vec3 transmit = vec3(0); // What is that?
+    writePixel(reflect, transmit, 0);
+}

--- a/src/apps/refactor_proto/refactor_proto/resources/shaders/TransparencyResolve.frag
+++ b/src/apps/refactor_proto/refactor_proto/resources/shaders/TransparencyResolve.frag
@@ -1,0 +1,36 @@
+#version 420
+
+#include "Helpers.glsl"
+
+
+// see: https://casual-effects.blogspot.com/2015/03/implemented-weighted-blended-order.html#2d_compositing_pass
+
+// sum(rgb * a, a)
+uniform sampler2D u_AccumTexture;
+
+// prod(1 - a)
+uniform sampler2D u_RevealageTexture;
+
+layout(location = 0) out vec4 out_Color;
+
+void main() 
+{
+    ivec2 coords = ivec2(gl_FragCoord.xy);
+
+    float revealage = texelFetch(u_RevealageTexture, coords, 0).r;
+    if (revealage == 1.0) {
+        // Save the blending and color texture fetch cost
+        discard; 
+    }
+
+    vec4 accum = texelFetch(u_AccumTexture, coords, 0);
+    // Suppress overflow
+    if (isinf(maxCw(abs(accum)))) {
+        accum.rgb = vec3(accum.a);
+    }
+    vec3 averageColor = accum.rgb / max(accum.a, 0.00001);
+
+    // dst' =  (accum.rgb / accum.a) * (1 - revealage) + dst * revealage
+    // TODO could we replace the `1 - revealage` with `revealge` by inverting the src and dst blend?
+    out_Color = vec4(averageColor, 1.0 - revealage);
+}

--- a/src/libs/snac-renderer/snac-renderer/Logging.h
+++ b/src/libs/snac-renderer/snac-renderer/Logging.h
@@ -2,6 +2,7 @@
 
 
 #include <spdlog/spdlog.h>
+#include <spdlog/fmt/ostr.h>
 
 
 namespace ad {

--- a/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
+++ b/src/libs/snac-renderer/snac-renderer/gltf/GltfLoad.cpp
@@ -63,7 +63,7 @@ namespace {
             {
                 const GLenum infered = T_buffer::GLTarget_v;
                 SELOG(trace)("Buffer view #{} does not have target defined. Infering {}.",
-                             aBufferView.id(), graphics::to_string(infered));
+                             fmt::streamed(aBufferView.id()), graphics::to_string(infered));
                 return infered;
             }
             else
@@ -119,7 +119,7 @@ namespace {
         {
             SELOG(critical)
                 ("Accessor \"{}\" with semantic {} does not define bounds.",
-                aAccessor.id(), to_string(aSemantic));
+                fmt::streamed(aAccessor.id()), to_string(aSemantic));
             throw std::logic_error{"Accessor MUST have bounds."};
         }
         // By the spec, position MUST be a VEC3 of float.
@@ -216,7 +216,7 @@ namespace {
 
         for(const auto & [gltfSemantic, accessorId] : aPrimitive->attributes)
         {
-            SELOG(debug)("Semantic \"{}\" is associated to accessor #{}", gltfSemantic, accessorId);
+            SELOG(debug)("Semantic \"{}\" is associated to accessor #{}", gltfSemantic, fmt::streamed(accessorId));
 
             Const_Owned<gltf::Accessor> accessor = aPrimitive.get(accessorId);
 
@@ -225,14 +225,15 @@ namespace {
             {
                 SELOG(critical)
                     ("Semantic \"{}\", accessor #{} has a count of {}, while previous accessors where {}.",
-                    gltfSemantic, accessorId, accessor->count, vertexCount);
+                    gltfSemantic, fmt::streamed(accessorId), accessor->count, vertexCount);
                 throw std::runtime_error{"Inconsistent accessors count."};
             }
             vertexCount = (GLsizei)accessor->count;
 
             if(!accessor->bufferView)
             {
-                SELOG(warn)("Skipping semantic \"{}\", associated to accessor #{} which does not have a buffer view.", gltfSemantic, accessorId);
+                SELOG(warn)("Skipping semantic \"{}\", associated to accessor #{} which does not have a buffer view.",
+                            gltfSemantic, fmt::streamed(accessorId));
                 continue;
             }
 
@@ -243,7 +244,7 @@ namespace {
             {
                 SELOG(trace)
                     ("Semantic \"{}\", associated to accessor #{}, reuses mesh buffer view #{}.",
-                    gltfSemantic, accessorId, found->second);
+                    gltfSemantic, fmt::streamed(accessorId), found->second);
                 bufferViewId = found->second;
             }
             else
@@ -270,18 +271,19 @@ namespace {
                     stream.mBoundingBox = getBoundingBox(accessor, *semantic);
                     SELOG(debug)
                         ("Mesh primitive #{} has bounding box {}.",
-                         aPrimitive.id(), fmt::streamed(stream.mBoundingBox));
+                         fmt::streamed(aPrimitive.id()), fmt::streamed(stream.mBoundingBox));
                 }
             }
             else
             {
-                SELOG(warn)("Skipping semantic \"{}\", associated to accessor #{}, which does not have a translation.", gltfSemantic, accessorId);
+                SELOG(warn)("Skipping semantic \"{}\", associated to accessor #{}, which does not have a translation.",
+                            gltfSemantic, fmt::streamed(accessorId));
             }
         }
 
         if(aPrimitive->indices)
         {
-            SELOG(debug)("Primitive #{} defines indexed geometry.", aPrimitive.id());
+            SELOG(debug)("Primitive #{} defines indexed geometry.", fmt::streamed(aPrimitive.id()));
             Const_Owned<gltf::Accessor> indicesAccessor = 
                 aPrimitive.get(&gltf::Primitive::indices);
 
@@ -291,7 +293,7 @@ namespace {
                 // This would be suboptimal, meaning we load two buffers with the same data
                 SELOG(error)
                     ("Primitive #{} indices reuses a buffer view used for vertex attributes.",
-                    aPrimitive.id());
+                     fmt::streamed(aPrimitive.id()));
             }
 
             auto gltfBufferView = checkedBufferView(indicesAccessor);


### PR DESCRIPTION
closes #115.
- Reorganize the frame drawing code, to better suit Pass.
- Render a deptmap, show it in the lower-right corner.
- Remove unused features at the .prog level.
- Implement more control over DrawQuad().
- Major refactoring: move the render graph to TheGraph, move pass code.
- Move remaining passes to TheGraph.
- Refactor DrawQuad.
- Read the effect file for models directly from the scene .sew file.
- Implement Weighted blended OIT.
