### PR TITLE
topic/snacman#121 skeletal animation v2

### DIFF
--- a/src/apps/asset_processor/asset_processor/AssimpUtils.h
+++ b/src/apps/asset_processor/asset_processor/AssimpUtils.h
@@ -5,6 +5,7 @@
 
 #include <math/Box.h>
 #include <math/Matrix.h>
+#include <math/Quaternion.h>
 #include <math/Vector.h>
 
 #include <cassert>
@@ -42,6 +43,18 @@ inline math::Matrix<4, 3, float> extractAffinePart(const aiNode * aNode)
 inline math::Position<3, float> toPosition(aiVector3D aVec)
 {
     return {aVec.x, aVec.y, aVec.z};
+}
+
+
+inline math::Vec<3, float> toVec(aiVector3D aVec)
+{
+    return {aVec.x, aVec.y, aVec.z};
+}
+
+
+inline math::Quaternion<float> toQuaternion(aiQuaternion aQuat)
+{
+    return {aQuat.x, aQuat.y, aQuat.z, aQuat.w};
 }
 
 

--- a/src/apps/asset_processor/asset_processor/AssimpUtils.h
+++ b/src/apps/asset_processor/asset_processor/AssimpUtils.h
@@ -1,0 +1,58 @@
+#pragma once
+
+
+#include <assimp/scene.h>
+
+#include <math/Box.h>
+#include <math/Matrix.h>
+#include <math/Vector.h>
+
+#include <cassert>
+
+
+namespace ad::renderer {
+
+
+inline [[maybe_unused]] bool hasTrianglesOnly(aiMesh * aMesh)
+{
+    //TODO Ad 2023/07/21: Understand what is this NGON encoding flag for.
+    return (aMesh->mPrimitiveTypes = (aiPrimitiveType_TRIANGLE | aiPrimitiveType_NGONEncodingFlag));
+}
+
+
+inline math::Matrix<4, 3, float> extractAffinePart(const aiMatrix4x4 & aAiMatrix)
+{
+    auto m = aAiMatrix;
+    assert(m.d1 == 0 && m.d2 == 0 && m.d3 == 0 && m.d4 == 1);
+    return math::Matrix<4, 3, float>{
+        m.a1, m.b1, m.c1,
+        m.a2, m.b2, m.c2,
+        m.a3, m.b3, m.c3,
+        m.a4, m.b4, m.c4,
+    };
+}
+
+
+inline math::Matrix<4, 3, float> extractAffinePart(const aiNode * aNode)
+{
+    return extractAffinePart(aNode->mTransformation);
+}
+
+
+inline math::Position<3, float> toPosition(aiVector3D aVec)
+{
+    return {aVec.x, aVec.y, aVec.z};
+}
+
+
+inline math::Box<float> extractAabb(const aiMesh * aMesh)
+{
+    aiAABB aiBox = aMesh->mAABB;
+    return{
+        .mPosition = toPosition(aiBox.mMin),
+        .mDimension = (toPosition(aiBox.mMax) - toPosition(aiBox.mMin)).as<math::Size>(),
+    };
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/asset_processor/asset_processor/CMakeLists.txt
+++ b/src/apps/asset_processor/asset_processor/CMakeLists.txt
@@ -5,7 +5,9 @@ set(REPO_FOLDER ${PROJECT_SOURCE_DIR})
 configure_file(build_info.h.in build_info.h @ONLY)
 
 set(${TARGET_NAME}_HEADERS
+    AssimpUtils.h
     Logging.h
+    ProcessAnimation.h
     Processor.h
 )
 
@@ -13,6 +15,7 @@ set(${TARGET_NAME}_SOURCES
     main.cpp
 
     Logging.cpp
+    ProcessAnimation.cpp
     Processor.cpp
 )
 

--- a/src/apps/asset_processor/asset_processor/ProcessAnimation.cpp
+++ b/src/apps/asset_processor/asset_processor/ProcessAnimation.cpp
@@ -1,0 +1,144 @@
+#include "ProcessAnimation.h"
+
+#include "AssimpUtils.h"
+
+#include <assimp/scene.h>
+
+#include <cassert>
+
+
+namespace ad::renderer {
+
+
+using NodeIndex = NodeTree<Rig::Pose>::Node::Index;
+
+
+namespace {
+
+    using NodePointerMap = std::unordered_map<const aiNode *, NodeTree<Rig::Pose>::Node::Index>;
+
+    NodeIndex recurseAssimpNode(const aiNode * aNode,
+                                NodeIndex aParentIndex,
+                                NodeTree<Rig::Pose> & aOutTree,
+                                NodePointerMap & aOutAiNodeToTreeNode)
+    {
+        NodeIndex nodeIdx = aOutTree.addNode(aParentIndex,
+                                             Rig::Pose{extractAffinePart(aNode)});
+        aOutTree.mNodeNames[nodeIdx] = aNode->mName.C_Str();
+        aOutAiNodeToTreeNode.emplace(aNode, nodeIdx);
+
+        for(std::size_t childIdx = 0; childIdx != aNode->mNumChildren; ++childIdx)
+        {
+            recurseAssimpNode(aNode->mChildren[childIdx], nodeIdx, aOutTree, aOutAiNodeToTreeNode);
+        }
+
+        return nodeIdx;
+    }
+
+
+    std::pair<NodeTree<Rig::Pose>, NodePointerMap> loadJoints(const aiNode * aArmature)
+    {
+        NodeTree<Rig::Pose> jointTree;
+
+        // We might need to get the armatureToModel transform if armature is not root
+        // (Past me put an assertion so future me knows when this has to be done).
+        assert(aArmature->mParent == nullptr);
+
+        NodePointerMap aiNodeToTreeNode;
+        // TODO #anim should only load the joints instead of the whole scene under the armature.
+        // (potential complication if there are non-joints between joints)
+        jointTree.mFirstRoot = 
+            recurseAssimpNode(aArmature,
+                              NodeTree<Rig::Pose>::Node::gInvalidIndex,
+                              jointTree,
+                              aiNodeToTreeNode);
+
+        return {jointTree, aiNodeToTreeNode};
+    }
+
+
+    /// @brief Utility class to add joint influences on vertices.
+    /// It is notably checking that the max number of allowed bones per vertex is not exceeded.
+    struct JointDataManager
+    {
+        using Counter_t = unsigned short;
+        static_assert(VertexJointData::gMaxBones < std::numeric_limits<Counter_t>::max());
+
+        JointDataManager(std::size_t aNumVertices) :
+            mVertexJointData{VertexJointData{
+                .mBoneIndices{aNumVertices, math::Vec<VertexJointData::gMaxBones, unsigned int>::Zero()},
+                .mBoneWeights{aNumVertices, math::Vec<VertexJointData::gMaxBones, float>::Zero()},
+            }},
+            mVertexJointNumber(aNumVertices, Counter_t{0})
+        {}
+
+        void addJoint(unsigned int aVertexIdx, unsigned int aBoneIdx, float aWeight)
+        {
+            Counter_t & nextInfluenceIdx = mVertexJointNumber[aVertexIdx];
+            assert(nextInfluenceIdx < VertexJointData::gMaxBones);
+            mVertexJointData.mBoneIndices[aVertexIdx][nextInfluenceIdx] = aBoneIdx;
+            mVertexJointData.mBoneWeights[aVertexIdx][nextInfluenceIdx] = aWeight;
+            ++nextInfluenceIdx;
+        }
+
+        VertexJointData mVertexJointData;
+        std::vector<Counter_t> mVertexJointNumber;
+    };
+
+
+} // unnamed namespace
+
+
+std::pair<Rig, VertexJointData> loadRig(const aiMesh * aMesh)
+{
+    assert(aMesh->mNumBones > 0);
+
+    aiNode * armature = aMesh->mBones[0]->mArmature;
+    assert(armature);
+    Rig result{
+        .mArmatureName = armature->mName.C_Str(),
+    };
+    NodePointerMap aiNodeToTreeNode;
+
+    //
+    // Load the NodeTree of joints, starting from the armature
+    //
+
+    // TODO Ad 2024/02/22: Is it correct to start from the armature?
+    std::tie(result.mJointTree, aiNodeToTreeNode) = loadJoints(armature);
+    // I expect this to always be the case, the assert is here to catch if it becomes wrong.
+    assert(result.mJointTree.mFirstRoot == 0);
+
+    //
+    // Iterate over all bones:
+    // * Populate the list of joints and their inverse bind matrices
+    // * Populate the joint data vertex attributes (array of VertexJointData)
+    //
+    JointDataManager jointData{aMesh->mNumVertices};
+
+    for(unsigned int boneIdx = 0; boneIdx != aMesh->mNumBones; ++boneIdx)
+    {
+        const aiBone & bone  = *aMesh->mBones[boneIdx];
+        // I am making the assumption that the armature is a common root node of a skeleton
+        // and thus it must be equal for all the bones.
+        assert(bone.mArmature == armature);
+        result.mInverseBindMatrices.push_back(
+            math::AffineMatrix<4, float>{extractAffinePart(bone.mOffsetMatrix)});
+        result.mJoints.push_back(aiNodeToTreeNode.at(bone.mNode));
+
+        for(unsigned int weightIdx = 0; weightIdx != bone.mNumWeights; ++weightIdx)
+        {
+            const aiVertexWeight & weight = bone.mWeights[weightIdx];
+            jointData.addJoint(weight.mVertexId, boneIdx, weight.mWeight);
+        }
+    }
+
+    //auto maxVal = 
+    //    *std::max_element(jointData.mVertexJointNumber.begin(), jointData.mVertexJointNumber.end());
+    //std::cout << "Maximum number of bones influencing a single vertex: " << val << std::endl;
+
+    return {result, jointData.mVertexJointData};
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/asset_processor/asset_processor/ProcessAnimation.h
+++ b/src/apps/asset_processor/asset_processor/ProcessAnimation.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <snac-renderer-V2/Rigging.h>
+
+
+struct aiMesh;
+
+
+namespace ad::renderer {
+
+
+//NodeTree<Rig::Pose> loadJoints(aiMesh * aMesh);
+
+std::pair<Rig, VertexJointData> loadRig(const aiMesh * aMesh);
+
+
+} // namespace ad::renderer

--- a/src/apps/asset_processor/asset_processor/ProcessAnimation.h
+++ b/src/apps/asset_processor/asset_processor/ProcessAnimation.h
@@ -1,9 +1,13 @@
 #pragma once
 
+
 #include <snac-renderer-V2/Rigging.h>
+
+#include <unordered_map>
 
 
 struct aiMesh;
+struct aiNode;
 
 
 namespace ad::renderer {
@@ -11,7 +15,14 @@ namespace ad::renderer {
 
 //NodeTree<Rig::Pose> loadJoints(aiMesh * aMesh);
 
-std::pair<Rig, VertexJointData> loadRig(const aiMesh * aMesh);
+using NodePointerMap = std::unordered_map<const aiNode *, NodeTree<Rig::Pose>::Node::Index>;
+
+std::pair<Rig, NodePointerMap> loadRig(const aiNode * aArmature);
+
+VertexJointData populateJointData(Rig::JointData & aOutJointData,
+                                  const aiMesh * aMesh,
+                                  const NodePointerMap & aAiNodeToTreeNode,
+                                  const aiNode * aExpectedArmature);
 
 
 } // namespace ad::renderer

--- a/src/apps/asset_processor/asset_processor/Processor.cpp
+++ b/src/apps/asset_processor/asset_processor/Processor.cpp
@@ -509,7 +509,7 @@ namespace {
 
         aWriter.writeRaw(std::span{materials});
         aWriter.write(materialNames);
-        dumpTextures(diffuseTexturePaths, aWriter);
+        dumpTextures(texturePaths, aWriter);
     }
 
 } // unnamed namespace

--- a/src/apps/asset_processor/asset_processor/Processor.cpp
+++ b/src/apps/asset_processor/asset_processor/Processor.cpp
@@ -375,10 +375,10 @@ namespace {
             filesystem::path upsampledDirAbsolute = baseDirAbsolute / upsampledDir;
             if(is_directory(upsampledDirAbsolute))
             {
+                bool foundUpsampledImage = false;
                 // Fixup paths for resampled images
                 for(auto & texture : aTexturePaths)
                 {
-                    bool foundUpsampledImage = false;
                     auto textureFilename = filesystem::path{texture}.filename();
                     auto upsampledTextureAbsolute = upsampledDirAbsolute / textureFilename;
                     // Why is it prepending, relative is actually not relative...
@@ -395,6 +395,12 @@ namespace {
                         // Replace the base texture relative path with the upsampled relative path
                         texture = (upsampledDir / textureFilename).string();
                     }
+                }
+
+                if(!foundUpsampledImage)
+                {
+                    SELOG(critical)("'{}' directory did not contain any expected texture.", upsampledDir.string());
+                    throw std::runtime_error("Upsampling directory cannot be left empty, please remove it.");
                 }
             }
             else

--- a/src/apps/asset_processor/asset_processor/Processor.cpp
+++ b/src/apps/asset_processor/asset_processor/Processor.cpp
@@ -563,9 +563,16 @@ namespace {
 
 void processModel(const std::filesystem::path & aFile)
 {
+    // Comment out to get verbose output from the importer, to stdout.
+    Assimp::DefaultLogger::create("", Assimp::Logger::VERBOSE, aiDefaultLogStream_STDOUT);
+
     // Create an instance of the Importer class
     Assimp::Importer importer;
-    // And have it read the given file with some example postprocessing
+
+    // This is really extra verbose, usually the default logger verbository
+    //importer.SetExtraVerbose(true); 
+
+    // Have the importer read the given file with some example postprocessing
     // Usually - if speed is not the most important aspect for you - you'll 
     // propably to request more postprocessing than we do in this example.
     const aiScene* scene = importer.ReadFile(
@@ -579,6 +586,9 @@ void processModel(const std::filesystem::path & aFile)
         aiProcess_GenSmoothNormals          |
         aiProcess_ValidateDataStructure     |
         aiProcess_FindDegenerates           |
+        // Note: Will remove "invalid" channels (e.g. all zero normals / tangents)
+        // This will causes issues when the UV / Tangent are not valid: it removes them
+        // which trips the `Processor` atm.
         aiProcess_FindInvalidData           |
         // Generate bouding boxes, see: https://stackoverflow.com/a/74331859/1027706
         aiProcess_GenBoundingBoxes          |
@@ -607,9 +617,9 @@ void processModel(const std::filesystem::path & aFile)
 
     std::cout << "\nResult: Dumped model with "
               << topResult.mVerticesCount << " vertices and " 
-              << topResult.mIndicesCount << " indices, bounding box: " 
-              << topResult.mAabb << ", " 
+              << topResult.mIndicesCount << " indices, "
               << scene->mNumMaterials << " materials."
+              << "\n  " << "bounding box: " << topResult.mAabb
               << "\n";
 
     // We're done. Everything will be cleaned up by the importer destructor

--- a/src/apps/asset_processor/asset_processor/Processor.cpp
+++ b/src/apps/asset_processor/asset_processor/Processor.cpp
@@ -18,6 +18,8 @@
 
 #include <fmt/ostream.h>
 
+#include <assimp/DefaultLogger.hpp>
+
 #include <fstream>
 #include <iostream>
 #include <span>

--- a/src/apps/asset_processor/asset_processor/Processor.cpp
+++ b/src/apps/asset_processor/asset_processor/Processor.cpp
@@ -503,7 +503,7 @@ namespace {
 
         aWriter.writeRaw(std::span{materials});
         aWriter.write(materialNames);
-        dumpTextures(texturePaths, aWriter);
+        dumpTextures(diffuseTexturePaths, aWriter);
     }
 
 } // unnamed namespace

--- a/src/apps/asset_processor/asset_processor/Processor.cpp
+++ b/src/apps/asset_processor/asset_processor/Processor.cpp
@@ -491,6 +491,13 @@ namespace {
 
             if(material->Get(AI_MATKEY_SHININESS, phongMaterial.mSpecularExponent) == AI_SUCCESS)
             {
+                // Correct the specular exponent if needed
+                if(phongMaterial.mSpecularExponent < 1)
+                {
+                    SELOG(warn)("Specular exponent value '{}' is too low, setting it to '1'.",
+                                phongMaterial.mSpecularExponent);
+                    phongMaterial.mSpecularExponent = 1;
+                }
                 std::cout << "  specular exponent: " << phongMaterial.mSpecularExponent << "\n";
             }
 

--- a/src/apps/asset_processor/asset_processor/Processor.h
+++ b/src/apps/asset_processor/asset_processor/Processor.h
@@ -8,6 +8,7 @@
 namespace ad::renderer {
 
 
+// TODO Rewrite as a class, there is state to be maintained accross the implementating functions.
 void processModel(const std::filesystem::path & aFile);
 
 

--- a/src/apps/skinning_sandbox/skinning_sandbox/Scene.cpp
+++ b/src/apps/skinning_sandbox/skinning_sandbox/Scene.cpp
@@ -139,9 +139,10 @@ void Scene::update(double aDelta)
 
     // TODO handle different playback modes (single, ping-pong, repeat)
     animation.animate((float)std::fmod(mAnimationTime, animation.mEndTime), nodeTree);
-    const auto sillyLValue = mSkin.mRig.computeJointMatrices();
+    // Need a lvalue to pass to span ctor
+    const auto jointMatrices = mSkin.mRig.computeJointMatrices();
     graphics::load(mJointMatrices,
-                   std::span{sillyLValue},
+                   std::span{jointMatrices},
                    graphics::BufferHint::StreamDraw);
 
     DebugDrawer::StartFrame();

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -200,7 +200,8 @@ cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
 
 file(GENERATE 
      OUTPUT $<TARGET_FILE_DIR:${TARGET_NAME}>/assets.json
-     CONTENT "{\"prefixes\": [\"${REPO_FOLDER}/src/libs/snac-renderer-V1/snac-renderer-V1/\",
+     # Uses dedicated shaders and effects, designed for renderer V2
+     CONTENT "{\"prefixes\": [\"${CMAKE_CURRENT_LIST_DIR}/renderer_V2_resources/\",
                               \"${REPO_FOLDER}/../snac-assets/\"]}")
 
 

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -212,6 +212,7 @@ find_package(spdlog CONFIG REQUIRED)
 
 target_link_libraries(${TARGET_NAME}
     PRIVATE
+        ad::profiler
         ad::snac-renderer-V1 # TODO #RV2 remove
         ad::snac-renderer-V2
 

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -212,7 +212,8 @@ find_package(spdlog CONFIG REQUIRED)
 
 target_link_libraries(${TARGET_NAME}
     PRIVATE
-        ad::snac-renderer-V1
+        ad::snac-renderer-V1 # TODO #RV2 remove
+        ad::snac-renderer-V2
 
         ad::arte
         ad::entity

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -14,24 +14,28 @@ set(${TARGET_NAME}_HEADERS
     Input.h
     Logging.h
     LoopSettings.h
-    QueryManipulation.h
     Profiling.h
     ProfilingGPU.h
+    QueryManipulation.h
     RenderThread.h
     Resources.h
     SparseSet.h
     Timing.h
+
+    simulations/sandbox/ModelLoader.h
 
     simulations/snacgame/EntityWrap.h
     simulations/snacgame/Entities.h
     simulations/snacgame/GameContext.h
     simulations/snacgame/GameParameters.h
     simulations/snacgame/GraphicState.h
+    simulations/snacgame/ImguiInhibiter.h
     simulations/snacgame/ImguiSceneEditor.h
     simulations/snacgame/InputConstants.h
     simulations/snacgame/InputCommandConverter.h
     simulations/snacgame/LevelHelper.h
     simulations/snacgame/ModelInfos.h
+    simulations/snacgame/OrbitalControlInput.h
     simulations/snacgame/PlayerSlotManager.h
     simulations/snacgame/Renderer.h
     simulations/snacgame/Renderer_V1.h
@@ -108,9 +112,12 @@ set(${TARGET_NAME}_SOURCES
     RenderThread.cpp
     Resources.cpp
 
+    simulations/sandbox/ModelLoader.cpp
+
     simulations/snacgame/Entities.cpp
     simulations/snacgame/GameContext.cpp
     simulations/snacgame/ImguiSceneEditor.cpp
+    simulations/snacgame/OrbitalControlInput.cpp
     simulations/snacgame/PlayerSlotManager.cpp
     simulations/snacgame/Renderer_V1.cpp
     simulations/snacgame/Renderer_V2.cpp

--- a/src/apps/snacman/snacman/CMakeLists.txt
+++ b/src/apps/snacman/snacman/CMakeLists.txt
@@ -34,6 +34,8 @@ set(${TARGET_NAME}_HEADERS
     simulations/snacgame/ModelInfos.h
     simulations/snacgame/PlayerSlotManager.h
     simulations/snacgame/Renderer.h
+    simulations/snacgame/Renderer_V1.h
+    simulations/snacgame/Renderer_V2.h
     simulations/snacgame/SceneGraph.h
     simulations/snacgame/SnacGame.h
     simulations/snacgame/SimulationControl.h
@@ -110,7 +112,8 @@ set(${TARGET_NAME}_SOURCES
     simulations/snacgame/GameContext.cpp
     simulations/snacgame/ImguiSceneEditor.cpp
     simulations/snacgame/PlayerSlotManager.cpp
-    simulations/snacgame/Renderer.cpp
+    simulations/snacgame/Renderer_V1.cpp
+    simulations/snacgame/Renderer_V2.cpp
     simulations/snacgame/SnacGame.cpp
     simulations/snacgame/SimulationControl.cpp
     simulations/snacgame/SceneGraph.cpp

--- a/src/apps/snacman/snacman/GraphicState.h
+++ b/src/apps/snacman/snacman/GraphicState.h
@@ -14,12 +14,6 @@ namespace ad {
 namespace snac {
 
 
-struct GraphicState
-{
-    math::sdr::Rgb color;
-};
-
-
 template <class T_state>
 class StateFifo
 {

--- a/src/apps/snacman/snacman/RenderThread.h
+++ b/src/apps/snacman/snacman/RenderThread.h
@@ -14,9 +14,12 @@
 
 #include <resource/ResourceFinder.h>
 
+// TODO Ad 2024/02/14: #RV2 Remove V1 includes
 #include <snac-renderer-V1/Camera.h>
 #include <snac-renderer-V1/Mesh.h>
 #include <snac-renderer-V1/text/Text.h>
+
+#include <snac-renderer-V2/Model.h>
 
 #include <future>
 #include <queue>
@@ -175,9 +178,10 @@ public:
     //    });
     //}
 
-    std::future<std::shared_ptr<snac::Model>> loadModel(filesystem::path aModel, 
-                                                        filesystem::path aEffect, 
-                                                        Resources & aResources)
+    std::future<typename T_renderer::template Handle_t<renderer::Node>> 
+    loadModel(filesystem::path aModel, 
+              filesystem::path aEffect, 
+              typename T_renderer::Resources_t & aResources)
     {
         // Almost certainly a programming error:
         // There is a risk the calling code will block on the future completion
@@ -186,14 +190,15 @@ public:
 
         // std::function require the type-erased functor to be copy constructible.
         // all captured types must be copyable.
-        auto promise = std::make_shared<std::promise<std::shared_ptr<snac::Model>>>();
-        std::future<std::shared_ptr<snac::Model>> future = promise->get_future();
+        using Handle_t = typename T_renderer::template Handle_t<renderer::Node>;
+        auto promise = std::make_shared<std::promise<Handle_t>>();
+        std::future<Handle_t> future = promise->get_future();
         push([promise = std::move(promise), shape = std::move(aModel), effect = std::move(aEffect), &aResources]
              (T_renderer & aRenderer) 
              {
                 try
                 {
-                    promise->set_value(aRenderer.LoadModel(shape, effect, aResources));
+                    promise->set_value(aRenderer.loadModel(shape, effect, aResources));
                 }
                 catch(...)
                 {

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -30,9 +30,7 @@ snacgame::Handle<renderer::Node> Resources::getModel(filesystem::path aModel, fi
     }
     else
     {
-        //return mModels.load(aModel, mFinder, aEffect, mRenderThread, mResources_V2);
-        // TODO Ad 2024/02/14: #RV2 Restore actual models name
-        return mModels.load("models/donut/donut.seum", mFinder, aEffect, mRenderThread, mResources_V2);
+        return mModels.load(aModel, mFinder, aEffect, mRenderThread, mResources_V2);
     }
 }
 

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -21,21 +21,18 @@ Resources::~Resources()
 }
 
 
-std::shared_ptr<Model> Resources::getModel(filesystem::path aModel, filesystem::path aEffect)
+snacgame::Handle<renderer::Node> Resources::getModel(filesystem::path aModel, filesystem::path aEffect)
 {
     // This is bad design, but lazy to get the result quickly
     if(aModel.string() == "CUBE")
     {
-        if (!mCube)
-        {
-            mCube = mRenderThread.loadModel(aModel, aEffect, *this)
-                .get(); // synchronize call
-        }
-        return mCube;
+        throw std::invalid_argument("'CUBE' hardcoded model is now deprecated.");
     }
     else
     {
-        return mModels.load(aModel, mFinder, aEffect, mRenderThread, *this);
+        //return mModels.load(aModel, mFinder, aEffect, mRenderThread, mResources_V2);
+        // TODO Ad 2024/02/14: #RV2 Restore actual models name
+        return mModels.load("models/donut/donut.seum", mFinder, aEffect, mRenderThread, mResources_V2);
     }
 }
 
@@ -75,11 +72,11 @@ std::shared_ptr<Font> Resources::FontLoader(
 }
 
 
-std::shared_ptr<Model> Resources::ModelLoader(
+snacgame::Handle<renderer::Node> Resources::ModelLoader(
     filesystem::path aModel, 
     filesystem::path aEffect,
     RenderThread<snacgame::Renderer_t> & aRenderThread,
-    Resources & aResources)
+    snacgame::Resources_V2 & aResources)
 {
     return aRenderThread.loadModel(aModel, aEffect, aResources)
             .get(); // synchronize call

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -1,7 +1,6 @@
 #include "Resources.h"
 
 #include "RenderThread.h"                   // for RenderThread
-#include "simulations/snacgame/Renderer.h"  // for Renderer
 
 #include <resource/ResourceManager.h>               // for ResourceManager
                                                     //
@@ -57,7 +56,7 @@ std::shared_ptr<Effect> Resources::getShaderEffect(filesystem::path aEffect)
 
 std::shared_ptr<Effect> Resources::EffectLoader(
     filesystem::path aEffect, 
-    RenderThread<snacgame::Renderer> & aRenderThread,
+    RenderThread<snacgame::Renderer_t> & aRenderThread,
     Resources & aResources)
 {
     return loadEffect(aEffect, aResources.getTechniqueLoader());
@@ -68,7 +67,7 @@ std::shared_ptr<Font> Resources::FontLoader(
     filesystem::path aFont, 
     unsigned int aPixelHeight,
     filesystem::path aEffect,
-    RenderThread<snacgame::Renderer> & aRenderThread,
+    RenderThread<snacgame::Renderer_t> & aRenderThread,
     Resources & aResources)
 {
     return aRenderThread.loadFont(aResources.getFreetype().load(aFont), aPixelHeight, aEffect, aResources)
@@ -79,7 +78,7 @@ std::shared_ptr<Font> Resources::FontLoader(
 std::shared_ptr<Model> Resources::ModelLoader(
     filesystem::path aModel, 
     filesystem::path aEffect,
-    RenderThread<snacgame::Renderer> & aRenderThread,
+    RenderThread<snacgame::Renderer_t> & aRenderThread,
     Resources & aResources)
 {
     return aRenderThread.loadModel(aModel, aEffect, aResources)

--- a/src/apps/snacman/snacman/Resources.cpp
+++ b/src/apps/snacman/snacman/Resources.cpp
@@ -30,6 +30,11 @@ snacgame::Handle<renderer::Node> Resources::getModel(filesystem::path aModel, fi
     }
     else
     {
+        if(aModel.extension() == ".gltf")
+        {
+            aModel.replace_extension(".seum");
+            SELOG(warn)("Live patching extension of '{}'.", aModel.string());
+        }
         return mModels.load(aModel, mFinder, aEffect, mRenderThread, mResources_V2);
     }
 }

--- a/src/apps/snacman/snacman/Resources.h
+++ b/src/apps/snacman/snacman/Resources.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "simulations/snacgame/Renderer.h"  // for Renderer
+
 // TODO might become useless once Resources itselfs become the Load<> implementer
 #include <snac-renderer-V1/ResourceLoad.h>
 
@@ -16,7 +18,6 @@
 
 namespace ad {
 
-namespace snacgame { class Renderer; }
 
 namespace snac {
 
@@ -32,7 +33,7 @@ class Resources
 public:
     Resources(resource::ResourceFinder aFinder,
               arte::Freetype & aFreetype,
-              RenderThread<snacgame::Renderer> & aRenderThread) :
+              RenderThread<snacgame::Renderer_t> & aRenderThread) :
         mFinder{std::move(aFinder)},
         mFreetype{aFreetype},
         mRenderThread{aRenderThread}
@@ -70,18 +71,18 @@ private:
         filesystem::path aFont, 
         unsigned int aPixelHeight,
         filesystem::path aEffect,
-        RenderThread<snacgame::Renderer> & aRenderThread,
+        RenderThread<snacgame::Renderer_t> & aRenderThread,
         Resources & aResources);
 
     static std::shared_ptr<Effect> EffectLoader(
         filesystem::path aProgram, 
-        RenderThread<snacgame::Renderer> & aRenderThread,
+        RenderThread<snacgame::Renderer_t> & aRenderThread,
         Resources & aResources);
 
     static std::shared_ptr<Model> ModelLoader(
         filesystem::path aModel, 
         filesystem::path aEffect,
-        RenderThread<snacgame::Renderer> & aRenderThread,
+        RenderThread<snacgame::Renderer_t> & aRenderThread,
         Resources & aResources);
     
     // There is a smelly circular dependency in this design:
@@ -89,7 +90,7 @@ private:
     // and the RenderThread uses Resources to load dependent resources (e.g. loading the texture from a model)
     resource::ResourceFinder mFinder;
     arte::Freetype & mFreetype;
-    RenderThread<snacgame::Renderer> & mRenderThread;
+    RenderThread<snacgame::Renderer_t> & mRenderThread;
     
     std::shared_ptr<Model> mCube = nullptr;
     resource::ResourceManager<std::shared_ptr<Font>,   resource::ResourceFinder, &Resources::FontLoader>   mFonts;

--- a/src/apps/snacman/snacman/SparseSet.h
+++ b/src/apps/snacman/snacman/SparseSet.h
@@ -17,6 +17,7 @@ namespace snac {
 #define TMP   T_value, N_universeSize, T_index
 
 
+// TODO Ad 2024/02/13: Move to Handy library
 template <TMA_D>
 class SparseSet
 {

--- a/src/apps/snacman/snacman/main.cpp
+++ b/src/apps/snacman/snacman/main.cpp
@@ -9,6 +9,9 @@
 
 #include <build_info.h>
 
+#include "simulations/sandbox/ModelLoader.h"
+
+#include "simulations/snacgame/ImguiInhibiter.h"
 #include "simulations/snacgame/SnacGame.h"
 #include "simulations/snacgame/Renderer.h"
 
@@ -34,6 +37,10 @@ using namespace ad::snac;
 
 // TODO find a better place than global
 constexpr bool gWaitByBusyLoop = true;
+
+
+//using Simulation_t = snacgame::SnacGame;
+using Simulation_t = snacgame::ModelLoader;
 
 
 resource::ResourceFinder makeResourceFinder()
@@ -161,7 +168,7 @@ void runApplication()
     //
     // Initialize scene
     //
-    snacgame::SnacGame simulation{
+    Simulation_t simulation{
         *glfwApp.getAppInterface(),
         renderingThread,
         imguiUi,

--- a/src/apps/snacman/snacman/main.cpp
+++ b/src/apps/snacman/snacman/main.cpp
@@ -39,8 +39,8 @@ using namespace ad::snac;
 constexpr bool gWaitByBusyLoop = true;
 
 
-//using Simulation_t = snacgame::SnacGame;
-using Simulation_t = snacgame::ModelLoader;
+using Simulation_t = snacgame::SnacGame;
+//using Simulation_t = snacgame::ModelLoader;
 
 
 resource::ResourceFinder makeResourceFinder()

--- a/src/apps/snacman/snacman/main.cpp
+++ b/src/apps/snacman/snacman/main.cpp
@@ -10,6 +10,7 @@
 #include <build_info.h>
 
 #include "simulations/snacgame/SnacGame.h"
+#include "simulations/snacgame/Renderer.h"
 
 // TODO we should not include something from detail.
 // So either move it out of detail, either use nholmann directly
@@ -131,7 +132,7 @@ void runApplication()
     // TODO we provide a Load<Technique> so the shadow pipeline can use it to load the effects for its cube.
     // this complicates the interface a lot, and since it does not use the ResourceManager those effects are not hot-recompilable.
     snac::TechniqueLoader techniqueLoader{finder};
-    snacgame::Renderer renderer{
+    snacgame::Renderer_t renderer{
         *glfwApp.getAppInterface(),
          techniqueLoader,
          freetype.load(finder.pathFor("fonts/FiraMono-Regular.ttf"))
@@ -141,7 +142,7 @@ void runApplication()
     // the render thread.
     glfwApp.removeCurrentContext();
 
-    GraphicStateFifo<snacgame::Renderer> graphicStates;
+    GraphicStateFifo<snacgame::Renderer_t> graphicStates;
     RenderThread renderingThread{
         glfwApp,
         graphicStates,

--- a/src/apps/snacman/snacman/renderer_V2_resources/effects/Mesh.sefx
+++ b/src/apps/snacman/snacman/renderer_V2_resources/effects/Mesh.sefx
@@ -1,19 +1,22 @@
 {
     "techniques": [
         {
-            "programfile": "shaders/PhongLightingVertexColorRigging.prog"
+            "annotations": {
+                "pass": "forward"
+            },
+            "programfile": "shaders/PhongLightingVertexColor.prog"
         },
         {
             "annotations": {
                 "pass": "forward_shadow"
             },
-            "programfile": "shaders/PhongLightingVertexColorShadowRigging.prog"
+            "programfile": "shaders/PhongLightingVertexColorShadow.prog"
         },
         {
             "annotations": {
                 "pass": "depth"
             },
-            "programfile": "shaders/DepthMapRigging.prog",
+            "programfile": "shaders/DepthMap.prog",
             "name": "shadow_mapping"
         }
     ]

--- a/src/apps/snacman/snacman/renderer_V2_resources/effects/MeshRigging.sefx
+++ b/src/apps/snacman/snacman/renderer_V2_resources/effects/MeshRigging.sefx
@@ -1,6 +1,9 @@
 {
     "techniques": [
         {
+            "annotations": {
+                "pass": "forward"
+            },
             "programfile": "shaders/PhongLightingVertexColorRigging.prog"
         },
         {

--- a/src/apps/snacman/snacman/renderer_V2_resources/effects/MeshRiggingTextures.sefx
+++ b/src/apps/snacman/snacman/renderer_V2_resources/effects/MeshRiggingTextures.sefx
@@ -1,13 +1,16 @@
 {
     "techniques": [
         {
-            "programfile": "shaders/PhongLightingVertexColorRigging.prog"
+            "annotations": {
+                "pass": "forward"
+            },
+            "programfile": "shaders/PhongLightingVertexColorRiggingTextures.prog"
         },
         {
             "annotations": {
                 "pass": "forward_shadow"
             },
-            "programfile": "shaders/PhongLightingVertexColorShadowRigging.prog"
+            "programfile": "shaders/PhongLightingVertexColorShadowRiggingTextures.prog"
         },
         {
             "annotations": {

--- a/src/apps/snacman/snacman/renderer_V2_resources/effects/MeshTextures.sefx
+++ b/src/apps/snacman/snacman/renderer_V2_resources/effects/MeshTextures.sefx
@@ -1,19 +1,22 @@
 {
     "techniques": [
         {
-            "programfile": "shaders/PhongLightingVertexColorRigging.prog"
+            "annotations": {
+                "pass": "forward"
+            },
+            "programfile": "shaders/PhongLightingTextures.prog"
         },
         {
             "annotations": {
                 "pass": "forward_shadow"
             },
-            "programfile": "shaders/PhongLightingVertexColorShadowRigging.prog"
+            "programfile": "shaders/PhongLightingTexturesShadow.prog"
         },
         {
             "annotations": {
                 "pass": "depth"
             },
-            "programfile": "shaders/DepthMapRigging.prog",
+            "programfile": "shaders/DepthMap.prog",
             "name": "shadow_mapping"
         }
     ]

--- a/src/apps/snacman/snacman/renderer_V2_resources/effects/Text.sefx
+++ b/src/apps/snacman/snacman/renderer_V2_resources/effects/Text.sefx
@@ -1,0 +1,7 @@
+{
+    "techniques": [
+        {
+            "programfile": "shaders/Text.prog"
+        }
+    ]
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/BillboardText.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/BillboardText.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["BILLBOARD"],
+    "vertex": "Text.vert",
+    "fragment": "Text.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/DebugDraw.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/DebugDraw.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "SimplePositionTransform.vert",
+    "fragment": "Solid.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/DebugDrawModelTransform.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/DebugDrawModelTransform.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["MODEL_MATRIX"],
+    "vertex": "SimplePositionTransform.vert",
+    "fragment": "Solid.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Depth.frag
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Depth.frag
@@ -1,0 +1,6 @@
+#version 420
+
+void main(void)
+{
+    // no need to write to gl_FragDepth, the depth buffer is updated automatically.
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/DepthMap.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/DepthMap.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["MODEL_MATRIX"],
+    "vertex": "SimplePositionTransform.vert",
+    "fragment": "Depth.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/DepthMapRigging.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/DepthMapRigging.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["MODEL_MATRIX", "RIGGING"],
+    "vertex": "SimplePositionTransform.vert",
+    "fragment": "Depth.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/DepthTexturing.frag
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/DepthTexturing.frag
@@ -1,0 +1,38 @@
+#version 420
+
+in vec2 ex_TextureCoords;
+
+uniform float u_NearDistance;
+uniform float u_FarDistance;
+uniform vec2 u_RenormalizationRange;
+
+uniform sampler2D u_BaseColorTexture;
+
+
+out vec4 out_Color;
+
+void main(void)
+{
+    vec4 color = texture(u_BaseColorTexture, ex_TextureCoords);
+
+    // Normalization of depth
+    // see: http://web.archive.org/web/20130416194336/http://olivers.posterous.com/linear-depth-in-glsl-for-real
+    // see: http://glampert.com/2014/01-26/visualizing-the-depth-buffer/
+    float linearDepth = 
+        (2 * u_NearDistance) 
+        / (u_FarDistance + u_NearDistance - color.r * (u_FarDistance - u_NearDistance));
+
+
+    // Renormalization
+    linearDepth -= u_RenormalizationRange.x;
+    linearDepth /= (u_RenormalizationRange.y - u_RenormalizationRange.x);
+
+
+    //
+    // Gamma correction
+    //
+    float gamma = 2.2;
+    // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
+    // (The monitor will do the gamma expansion.)
+    out_Color = vec4(pow(vec3(linearDepth), vec3(1./gamma)), color.w);
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Forward.vert
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Forward.vert
@@ -1,0 +1,12 @@
+#version 420
+
+in vec3 ve_Position_l;
+in vec2 ve_TextureCoords0;
+
+out vec2 ex_TextureCoords;
+
+void main(void)
+{
+    gl_Position = vec4(ve_Position_l, 1.f);
+    ex_TextureCoords = ve_TextureCoords0;
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Gamma.glsl
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Gamma.glsl
@@ -1,0 +1,8 @@
+uniform float u_Gamma = 2.2;
+
+vec4 correctGamma(vec4 aColor)
+{
+    // Gamma compression from linear color space to "simple sRGB", as expected by the monitor.
+    // (The monitor will do the gamma expansion.)
+    return vec4(pow(aColor.xyz, vec3(1./u_Gamma)), aColor.w);
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLighting.frag
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLighting.frag
@@ -29,11 +29,8 @@ uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8); // could be split between diffu
 #ifdef TEXTURES
 uniform sampler2DArray u_DiffuseTexture;
 
-// TODO: #RV2 port to V2
-// (i.e. UV channel indices should be part of the material, textures are in arrays)
-//uniform uint u_NormalUVIndex;
-//uniform float u_NormalMapScale;
-//uniform sampler2D u_NormalTexture;
+uniform sampler2DArray u_NormalsTexture;
+uniform float u_NormalMapScale = 1.0;
 #endif
 
 #ifdef SHADOW
@@ -61,6 +58,8 @@ struct PhongMaterial
     vec4 specularFactor;
     uint diffuseTextureIndex;
     uint diffuseUvChannel;
+    uint normalsTextureIndex;
+    uint normalsUvChannel;
     float specularExponent;
 };
 
@@ -86,7 +85,8 @@ void main(void)
         ex_Color
         * ex_BaseColorFactor // Note: should probably go away
 #ifdef TEXTURES
-        * texture(u_DiffuseTexture, vec3(ex_Uvs[material.diffuseUvChannel], material.diffuseTextureIndex))
+        //* texture(u_DiffuseTexture, vec3(ex_Uvs[material.diffuseUvChannel], material.diffuseTextureIndex))
+        * texture(u_NormalsTexture, vec3(ex_Uvs[material.normalsUvChannel], material.normalsTextureIndex))
 #endif
         ;
 

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLighting.vert
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLighting.vert
@@ -5,15 +5,19 @@ layout(location=1) in vec3 ve_Normal_l;
 layout(location=2) in vec4 ve_Tangent_l;
 
 #ifdef TEXTURES
-in vec2 ve_TextureCoords0;
-in vec2 ve_TextureCoords1;
+// The asset processor only handles 1 UV channel ATM (i.e. until we have a need for more)
+in vec2 ve_Uv;
 #endif
 
 // We need a default value of [1, 1, 1, 1], not [0, 0, 0, 1]
 // Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
-// At the moment, export our models with a white albedo on vertices by default.
-// Note: It could either be a vertex color, or an instance color (ve_ or in_).
-in vec4 a_Color_normalized;
+// In V1, we exported our models with a white albedo on vertices by default.
+// In V2, we try with a shader variation
+#ifdef BASECOLOR
+in vec4 a_Color_normalized; // Note: could either be per vertex or per instance (ve_ or in_).
+#else
+const vec4 a_Color_normalized = vec4(1.0);
+#endif
 
 #ifdef RIGGING
 #include "Rigging.glsl"
@@ -48,7 +52,7 @@ out vec4 ex_BaseColorFactor;
 out flat uint ex_MaterialIdx;
 
 #ifdef TEXTURES
-out vec2[2] ex_TextureCoords;
+out vec2[4] ex_Uvs; // Lay the ground-work for up to 4 UV channels (only 1 UV vertex attribute atm)
 #endif
 
 out vec4 ex_Color;
@@ -78,7 +82,7 @@ void main(void)
 
     ex_BaseColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;
 #ifdef TEXTURES
-    ex_TextureCoords = vec2[](ve_TextureCoords0, ve_TextureCoords1);
+    ex_Uvs[0] = ve_Uv;
 #endif
     ex_Color = a_Color_normalized;
     ex_MaterialIdx = in_MaterialIdx;

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingTextures.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingTextures.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["TEXTURES"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingTexturesShadow.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingTexturesShadow.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["TEXTURES", "SHADOW"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColor.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColor.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorRigging.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorRigging.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["RIGGING"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorRiggingTextures.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorRiggingTextures.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["RIGGING"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorShadow.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorShadow.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["SHADOW"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorShadowRigging.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorShadowRigging.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["SHADOW", "RIGGING"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorShadowRiggingTextures.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/PhongLightingVertexColorShadowRiggingTextures.prog
@@ -1,0 +1,5 @@
+{
+    "defines": ["SHADOW", "RIGGING", "TEXTURES"],
+    "vertex": "PhongLighting.vert",
+    "fragment": "PhongLighting.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Rigging.glsl
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Rigging.glsl
@@ -1,0 +1,21 @@
+in uvec4 ve_Joints0;
+in vec4  ve_Weights0;
+
+in uint in_MatrixPaletteOffset; // default value of 0 is what we need when a single palette is provided.
+
+// Having a fixed binding value in an included file is dangerous.
+// Yet this seems to be required to avoid collisions with other uniform blocks.
+layout(std140, binding = 1) uniform JointMatricesBlock
+{
+    mat4 joints[512];
+};
+
+mat4 assembleSkinningMatrix()
+{
+    return 
+          ve_Weights0[0] * joints[in_MatrixPaletteOffset + ve_Joints0[0]]
+        + ve_Weights0[1] * joints[in_MatrixPaletteOffset + ve_Joints0[1]]
+        + ve_Weights0[2] * joints[in_MatrixPaletteOffset + ve_Joints0[2]]
+        + ve_Weights0[3] * joints[in_MatrixPaletteOffset + ve_Joints0[3]]
+    ;
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/ShowDepth.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/ShowDepth.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "Forward.vert",
+    "fragment": "DepthTexturing.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/SimplePositionTransform.vert
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/SimplePositionTransform.vert
@@ -1,0 +1,35 @@
+#version 420
+
+in vec3 ve_Position_l;
+in vec4 ve_Albedo;
+in vec2 ve_TextureCoords0;
+
+#ifdef MODEL_MATRIX
+in mat4 in_LocalToWorld;
+#endif
+
+#ifdef RIGGING
+#include "Rigging.glsl"
+#endif
+
+uniform mat4 u_ViewingMatrix;
+
+out vec4 ex_Albedo;
+out vec2 ex_TextureCoords;
+
+void main(void)
+{
+    gl_Position = 
+        u_ViewingMatrix  
+#ifdef MODEL_MATRIX
+        * in_LocalToWorld
+#endif
+#ifdef RIGGING
+        * assembleSkinningMatrix()
+#endif
+        * vec4(ve_Position_l, 1.f)
+        ;
+
+    ex_Albedo = ve_Albedo;
+    ex_TextureCoords = ve_TextureCoords0;
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Solid.frag
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Solid.frag
@@ -1,0 +1,12 @@
+#version 420
+
+#include "Gamma.glsl"
+
+in vec4 ex_Albedo;
+
+out vec4 out_Color;
+
+void main(void)
+{
+    out_Color = correctGamma(ex_Albedo);
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Text.frag
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Text.frag
@@ -1,0 +1,24 @@
+#version 420
+
+in vec4 ex_Albedo;
+in vec2 ex_AtlasCoords;
+in float ex_Scale;
+
+out vec4 out_Color;
+
+uniform sampler2DRect u_FontAtlas;
+
+const float preSmoothing = 0.25 / 2.;
+
+void main(void)
+{
+    // The right smoothing value is 0.25 / (spread * scale)
+    float smoothing = preSmoothing / ex_Scale;
+    float atlasOpacity = texture(u_FontAtlas, ex_AtlasCoords).r;
+    float sdfOpacity = smoothstep(0.5 - smoothing, 0.5 + smoothing, atlasOpacity);
+
+    // Gamma correction
+    float gamma = 2.2;
+    out_Color = vec4(pow(ex_Albedo.rgb, vec3(1./gamma)), ex_Albedo.a * sdfOpacity);
+    /* out_Color = vec4(pow(ex_Albedo.rgb, vec3(1./gamma)), ex_Albedo.a * atlasOpacity); */
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Text.prog
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Text.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "Text.vert",
+    "fragment": "Text.frag"
+}

--- a/src/apps/snacman/snacman/renderer_V2_resources/shaders/Text.vert
+++ b/src/apps/snacman/snacman/renderer_V2_resources/shaders/Text.vert
@@ -1,0 +1,90 @@
+#version 420
+
+// TODO This should not be hardcoded, but somehow provided by client code
+#define GlyphMetricsLength 106
+
+layout(location=0) in vec2 ve_Position_u; // expect a quad, from [0, -1] to [1, 0]
+layout(location=1) in vec2 ve_TextureCoords0_u;
+
+layout(location= 4) in vec2  in_InstancePosition_pix;
+layout(location= 5) in mat4  in_LocalToWorld;
+layout(location= 9) in vec4  in_Albedo;
+layout(location= 10) in uint in_GlyphIndex;
+
+uniform ivec2 u_FramebufferResolution_p;
+
+
+uniform mat4 u_ViewingMatrix;
+
+
+struct Metrics 
+{
+  vec2 bounding;
+  vec2 bearing;
+  uint linearOffset;
+};
+
+layout(std140) uniform GlyphMetricsBlock
+{
+    Metrics glyphs[GlyphMetricsLength];
+};
+
+out float ex_Scale;
+out vec2 ex_AtlasCoords;
+out vec4 ex_Albedo;
+
+void main(void)
+{
+    // Unpack the glyph entry
+    ivec2 textureOffset = ivec2(glyphs[in_GlyphIndex].linearOffset, 0);
+    vec2 boundingBox = glyphs[in_GlyphIndex].bounding;
+    vec2 bearing = glyphs[in_GlyphIndex].bearing;
+
+    // We consider the glyph coordinate system to go from [0, 0] to [+width, -height]
+    // This way, the bearing provided by FreeType can be applied directly.
+    vec2 vertexPositionInGlyph_pix = (ve_Position_u * boundingBox) + bearing;
+
+    vec2 vertexPositionInString_pix = vertexPositionInGlyph_pix  + in_InstancePosition_pix;
+
+#ifdef BILLBOARD
+    // The last column of the matrix is the translation component.
+    vec4 stringOrigin_world = in_LocalToWorld[3];
+    vec4 stringOrigin_clip = u_ViewingMatrix * stringOrigin_world;
+
+    // Manually apply perspective division now, so it is not wrongfully applied to the pixel values added later.
+    stringOrigin_clip /= stringOrigin_clip.w;
+
+    gl_Position = 
+        vec4(
+            stringOrigin_clip.xy + (vertexPositionInString_pix / (u_FramebufferResolution_p/2)),
+            stringOrigin_clip.z,
+            1.
+        );
+#else
+    gl_Position = 
+        u_ViewingMatrix
+        * in_LocalToWorld 
+        * vec4(vertexPositionInString_pix, 0., 1.);
+#endif
+
+    // TODO: Franz, please add some comments regarding how this is computed and why this is required : )
+    ex_Scale = 
+        2 // The division by FB resolution was fixed by introducing a division by 2, the glyphs since appear twice bigger.
+        // Take into account the scaling on the summed "modelling" transform
+        * sqrt(  in_LocalToWorld[0][0] * in_LocalToWorld[0][0]
+                + in_LocalToWorld[0][1] * in_LocalToWorld[0][1])
+        // Take into account the scaling on the viewing
+        * sqrt(  u_ViewingMatrix[0][0] * u_ViewingMatrix[0][0]
+                + u_ViewingMatrix[0][1] * u_ViewingMatrix[0][1])
+        // Take into account the effect of the perspective on the scale
+        / gl_Position.w;
+        ;
+
+    mat4 m = u_ViewingMatrix * in_LocalToWorld;
+    ex_Scale = length(vec3(length(m[0].xyz), length(m[1].xyz), length(m[2].xyz))) / gl_Position.w;
+
+    ex_Scale = 2.;
+
+    ex_AtlasCoords = textureOffset + (ve_TextureCoords0_u * boundingBox);
+    ex_Albedo = in_Albedo;
+}

--- a/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
+++ b/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
@@ -1,0 +1,197 @@
+#include "ModelLoader.h"
+
+#include <snacman/Profiling.h>
+#include <snacman/Resources.h>
+
+#include <snacman/simulations/snacgame/GameParameters.h>
+#include <snacman/simulations/snacgame/GraphicState.h>
+#include <snacman/simulations/snacgame/ImguiInhibiter.h>
+
+
+namespace ad {
+struct RawInput;
+
+namespace snacgame {
+
+
+ModelLoader::ModelLoader(graphics::AppInterface & aAppInterface,
+                         snac::RenderThread<Renderer_t> & aRenderThread,
+                         imguiui::ImguiUi & aImguiUi,
+                         resource::ResourceFinder aResourceFinder,
+                         arte::Freetype & aFreetype,
+                         RawInput & aInput) :
+    mAppInterface{&aAppInterface},
+    mImguiUi{aImguiUi},
+    mOrbitalControl{
+        .mOrbital = {
+            gInitialCameraSpherical.radius(),
+            gInitialCameraSpherical.polar(),
+            gInitialCameraSpherical.azimuthal()
+        },
+    }
+{
+    snac::Resources resources{
+        std::move(aResourceFinder),
+        aFreetype,
+        aRenderThread
+    };
+
+    mModel ={
+        .mIndex = 0,
+        .mNode = resources.getModel("models/donut/donut.seum", "effects/Mesh.sefx"),
+    };
+}
+
+void ModelLoader::drawDebugUi(snac::ConfigurableSettings & aSettings,
+                              ImguiInhibiter & aInhibiter,
+                              RawInput & aInput)
+{
+    TIME_RECURRING_FUNC(Main);
+
+    {
+        std::lock_guard lock{mImguiUi.mFrameMutex};
+
+        mImguiUi.newFrame();
+        Guard renderGuard{[this]() { this->mImguiUi.render(); }};
+
+        aInhibiter.resetCapture(static_cast<ImguiInhibiter::WantCapture>(
+            (mImguiUi.isCapturingMouse() ? ImguiInhibiter::Mouse
+                                         : ImguiInhibiter::Null)
+            | (mImguiUi.isCapturingKeyboard() ? ImguiInhibiter::Keyboard
+                                              : ImguiInhibiter::Null)));
+        //ImGui::Begin("Silly window");
+        //ImGui::End();
+    }
+}
+
+bool ModelLoader::update(snac::Clock::duration & aUpdatePeriod, RawInput & aInput)
+{
+    snac::DebugDrawer::StartFrame();
+
+    mOrbitalControl.update(
+        aInput,
+        snac::Camera::gDefaults.vFov, // TODO Should be dynamic
+        mAppInterface->getWindowSize().height());
+
+
+    return aInput.mKeyboard.mKeyState[GLFW_KEY_ESCAPE];
+}
+
+std::unique_ptr<visu::GraphicState> ModelLoader::makeGraphicState()
+{
+    TIME_RECURRING_FUNC(Main);
+
+    auto state = std::make_unique<visu::GraphicState>();
+
+    //ent::Phase nomutation;
+
+    ////
+    //// Worldspace models
+    ////
+    //mQueryRenderable.get(nomutation)
+    //    .each(
+    //        [&state](ent::Handle<ent::Entity> aHandle,
+    //                 const component::GlobalPose & aGlobPose,
+    //                 // TODO #anim restore this constness (for the moment,
+    //                 // animation mutate the rig's scene)
+    //                 /*const*/ component::VisualModel & aVisualModel)
+    //        {
+    //    // Note: This feels bad to test component presence here
+    //    // but we do not want to handle VisualModel the same way depending on
+    //    // the presence of RigAnimation (and we do not have "negation" on
+    //    // Queries, to separately get VisualModels without RigAnimation)
+    //    visu::Entity::SkeletalAnimation skeletal;
+    //    if (auto entity = *aHandle.get(); entity.has<component::RigAnimation>())
+    //    {
+    //        // TODO #RV2 animation
+    //        //const auto & rigAnimation =
+    //        //    aHandle.get()->get<component::RigAnimation>();
+    //        //skeletal = visu::Entity::SkeletalAnimation{
+    //        //    .mRig = &aVisualModel.mModel->mRig,
+    //        //    .mAnimation = rigAnimation.mAnimation,
+    //        //    .mParameterValue = rigAnimation.mParameterValue,
+    //        //};
+    //    }
+        state->mEntities.insert(
+            mModel.mIndex,
+            visu::Entity{
+                .mPosition_world = math::Position<3, GLfloat>{},
+                .mScaling = {1.f, 1.f, 1.f},
+                .mOrientation = math::Quaternion<GLfloat>::Identity(),
+                .mColor = math::hdr::gWhite<GLfloat>,
+                .mModel = mModel.mNode,
+                //.mRigging = std::move(skeletal),
+                //.mDisableInterpolation = aVisualModel.mDisableInterpolation,
+            });
+    //    // Note: Although it does not feel correct, this is a convenient place
+    //    // to reset this flag
+    //    aVisualModel.mDisableInterpolation = false;
+    //    });
+
+    ////
+    //// Worldspace Text
+    ////
+    //mQueryTextWorld.get(nomutation)
+    //    .each(
+    //        [&state](ent::Handle<ent::Entity> aHandle, component::Text & aText,
+    //                 component::GlobalPose & aGlobPose)
+    //        {
+    //    state->mTextWorldEntities.insert(
+    //        aHandle.id(),
+    //        visu::Text{
+    //            .mPosition_world = aGlobPose.mPosition,
+    //            // TODO remove the hardcoded value of 100
+    //            // Note hardcoded 100 scale down. Because I'd like a value of 1
+    //            // for the scale of the component to still mean "about visible".
+    //            .mScaling =
+    //                aGlobPose.mInstanceScaling * aGlobPose.mScaling / 100.f,
+    //            .mOrientation = aGlobPose.mOrientation,
+    //            .mString = aText.mString,
+    //            .mFont = aText.mFont,
+    //            .mColor = aText.mColor,
+    //        });
+    //    });
+
+    ////
+    //// Screenspace Text
+    ////
+    //mQueryTextScreen.get(nomutation)
+    //    .each(
+    //        [&state, this](ent::Handle<ent::Entity> aHandle,
+    //                       component::Text & aText,
+    //                       component::PoseScreenSpace & aPose)
+    //        {
+    //    math::Position<3, float> position_screenPix{
+    //        aPose.mPosition_u.cwMul(
+    //            // TODO this multiplication should be done once and cached
+    //            // but it should be refreshed on framebuffer resizing.
+    //            static_cast<math::Position<2, GLfloat>>(
+    //                this->mAppInterface->getFramebufferSize())
+    //            / 2.f),
+    //        0.f};
+
+    //    state->mTextScreenEntities.insert(
+    //        aHandle.id(),
+    //        visu::Text{
+    //            .mPosition_world = position_screenPix,
+    //            .mScaling = math::Size<3, float>{aPose.mScale, 1.f},
+    //            .mOrientation =
+    //                math::Quaternion{
+    //                    math::UnitVec<3, float>::MakeFromUnitLength(
+    //                        {0.f, 0.f, 1.f}),
+    //                    aPose.mRotationCCW},
+    //            .mString = aText.mString,
+    //            .mFont = aText.mFont,
+    //            .mColor = aText.mColor,
+    //        });
+    //    });
+
+    state->mCamera = mOrbitalControl.getCameraState();
+
+    //state->mDebugDrawList = snac::DebugDrawer::EndFrame();
+
+    return state;
+}
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
+++ b/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
@@ -38,7 +38,7 @@ ModelLoader::ModelLoader(graphics::AppInterface & aAppInterface,
 
     mModel ={
         .mIndex = 0,
-        .mNode = resources.getModel("models/stage/stage.seum", "effects/MeshTextures.sefx"),
+        .mNode = resources.getModel("models/square_biscuit/square_biscuit.seum", "effects/MeshTextures.sefx"),
     };
 }
 

--- a/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
+++ b/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
@@ -38,6 +38,7 @@ ModelLoader::ModelLoader(graphics::AppInterface & aAppInterface,
 
     mModel ={
         .mIndex = 0,
+        //.mNode = resources.getModel("models/stage/stage.seum", "effects/MeshTextures.sefx"),
         .mNode = resources.getModel("models/square_biscuit/square_biscuit.seum", "effects/MeshTextures.sefx"),
     };
 }

--- a/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
+++ b/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
@@ -39,7 +39,8 @@ ModelLoader::ModelLoader(graphics::AppInterface & aAppInterface,
     mModel ={
         .mIndex = 0,
         //.mNode = resources.getModel("models/stage/stage.seum", "effects/MeshTextures.sefx"),
-        .mNode = resources.getModel("models/square_biscuit/square_biscuit.seum", "effects/MeshTextures.sefx"),
+        //.mNode = resources.getModel("models/square_biscuit/square_biscuit.seum", "effects/MeshTextures.sefx"),
+        .mNode = resources.getModel("models/donut/donut.seum", "effects/Mesh.sefx"),
     };
 }
 

--- a/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
+++ b/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.cpp
@@ -38,7 +38,7 @@ ModelLoader::ModelLoader(graphics::AppInterface & aAppInterface,
 
     mModel ={
         .mIndex = 0,
-        .mNode = resources.getModel("models/donut/donut.seum", "effects/Mesh.sefx"),
+        .mNode = resources.getModel("models/stage/stage.seum", "effects/MeshTextures.sefx"),
     };
 }
 

--- a/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.h
+++ b/src/apps/snacman/snacman/simulations/sandbox/ModelLoader.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <snacman/Input.h>
+#include <snacman/Timing.h>
+
+#include <snacman/simulations/snacgame/OrbitalControlInput.h>
+#include <snacman/simulations/snacgame/Renderer.h>
+
+#include <resource/ResourceFinder.h>
+
+#include <platform/Filesystem.h>
+
+#include <imgui.h>
+
+
+namespace ad {
+
+namespace graphics { class AppInterface; }
+namespace imguiui { class ImguiUi; }
+namespace snac {
+    struct ConfigurableSettings; 
+    template <class T_renderer> class RenderThread;
+}
+
+namespace snacgame {
+
+class ImguiInhibiter;
+
+namespace visu {
+    struct GraphicState;
+}
+
+
+class ModelLoader
+{
+public:
+    /// \brief Initialize the scene;
+    ModelLoader(graphics::AppInterface & aAppInterface,
+                snac::RenderThread<Renderer_t> & aRenderThread,
+                imguiui::ImguiUi & aImguiUi,
+                resource::ResourceFinder aResourceFinder,
+                arte::Freetype & aFreetype,
+                RawInput & aInput);
+
+    bool update(snac::Clock::duration & aUpdatePeriod, RawInput & aInput);
+
+    void drawDebugUi(snac::ConfigurableSettings & aSettings,
+                     ImguiInhibiter & aInhibiter,
+                     RawInput & aInput);
+
+    std::unique_ptr<visu::GraphicState> makeGraphicState();
+
+private:
+    struct Model
+    {
+        std::size_t mIndex;  // for sparse set
+        Handle<renderer::Node> mNode;
+    };
+
+    graphics::AppInterface * mAppInterface;
+    imguiui::ImguiUi & mImguiUi;
+    OrbitalControlInput mOrbitalControl;
+    Model mModel;
+};
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -71,15 +71,16 @@ void addGeoNode(GameContext & aContext,
         .add(component::GlobalPose{});
 }
 
-std::shared_ptr<snac::Model> addMeshGeoNode(GameContext & aContext,
-                                            Entity & aEnt,
-                                            const char * aModelPath,
-                                            const char * aEffectPath,
-                                            Pos3 aPos,
-                                            float aScale,
-                                            Size3 aInstanceScale,
-                                            Quat_f aOrientation,
-                                            HdrColor_f aColor)
+snacgame::Handle<renderer::Node> addMeshGeoNode(
+    GameContext & aContext,
+    Entity & aEnt,
+    const char * aModelPath,
+    const char * aEffectPath,
+    Pos3 aPos,
+    float aScale,
+    Size3 aInstanceScale,
+    Quat_f aOrientation,
+    HdrColor_f aColor)
 {
     auto model = aContext.mResources.getModel(aModelPath, aEffectPath);
     aEnt.add(component::Geometry{.mPosition = aPos,
@@ -145,20 +146,21 @@ createAnimatedTest(GameContext & aContext,
 {
     auto handle = aContext.mWorld.addEntity();
     Entity entity = *handle.get(aPhase);
-    std::shared_ptr<snac::Model> model = addMeshGeoNode(
+    auto model = addMeshGeoNode(
         aContext, entity, "models/anim/anim.gltf", "effects/MeshRigging.sefx",
         {static_cast<float>(aGridPos.x()), static_cast<float>(aGridPos.y()),
          gLevelHeight},
         0.45f, lLevelElementScaling,
         math::Quaternion<float>{math::UnitVec<3, float>{{1.f, 0.f, 0.f}},
                                 math::Turn<float>{0.25f}});
-    const snac::NodeAnimation & animation = model->mAnimations.begin()->second;
-    entity.add(component::RigAnimation{
-        .mAnimation = &animation,
-        .mStartTime = aStartTime,
-        .mParameter =
-            decltype(component::RigAnimation::mParameter){animation.mEndTime},
-    });
+    // TODO #RV2 animation
+    //const snac::NodeAnimation & animation = model->mAnimations.begin()->second;
+    //entity.add(component::RigAnimation{
+    //    .mAnimation = &animation,
+    //    .mStartTime = aStartTime,
+    //    .mParameter =
+    //        decltype(component::RigAnimation::mParameter){animation.mEndTime},
+    //});
     entity.add(component::GameTransient{});
 
     return handle;
@@ -437,24 +439,25 @@ EntHandle createPlayerModel(GameContext & aContext, EntHandle aSlotHandle)
         Phase createModel;
         Entity model = *playerModelHandle.get(createModel);
 
-        std::shared_ptr<snac::Model> modelData = addMeshGeoNode(
+        auto modelData = addMeshGeoNode(
             aContext, model, "models/donut/donut.gltf",
             "effects/MeshRiggingTextures.sefx", Pos3::Zero(), 1.f,
             gBasePlayerModelInstanceScaling, gBasePlayerModelOrientation,
             gSlotColors.at(slot.mSlotIndex));
 
-        std::string animName = "idle";
-        const snac::NodeAnimation & animation =
-            modelData->mAnimations.at(animName);
-        model.add(component::RigAnimation{
-            .mAnimName = animName,
-            .mAnimation = &animation,
-            .mAnimationMap = &modelData->mAnimations,
-            .mStartTime = snac::Clock::now(),
-            .mParameter =
-                decltype(component::RigAnimation::mParameter){
-                    animation.mEndTime},
-        });
+        // TODO #RV2 animation
+        //std::string animName = "idle";
+        //const snac::NodeAnimation & animation =
+        //    modelData->mAnimations.at(animName);
+        //model.add(component::RigAnimation{
+        //    .mAnimName = animName,
+        //    .mAnimation = &animation,
+        //    .mAnimationMap = &modelData->mAnimations,
+        //    .mStartTime = snac::Clock::now(),
+        //    .mParameter =
+        //        decltype(component::RigAnimation::mParameter){
+        //            animation.mEndTime},
+        //});
     }
 
     return playerModelHandle;
@@ -466,7 +469,7 @@ ent::Handle<ent::Entity> createCrown(GameContext & aContext)
     EntHandle crownHandle = aContext.mWorld.addEntity();
     Entity crown = *crownHandle.get(createCrown);
 
-    std::shared_ptr<snac::Model> crownData = addMeshGeoNode(
+    addMeshGeoNode(
         aContext, crown, "models/crown/crown.gltf",
         "effects/MeshTextures.sefx", gBaseCrownPosition, 1.f,
         gBaseCrownInstanceScaling, gBaseCrownOrientation);

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.cpp
@@ -441,7 +441,10 @@ EntHandle createPlayerModel(GameContext & aContext, EntHandle aSlotHandle)
 
         auto modelData = addMeshGeoNode(
             aContext, model, "models/donut/donut.gltf",
-            "effects/MeshRiggingTextures.sefx", Pos3::Zero(), 1.f,
+            // TODO #RV2 animation Change back to the rigging effect!
+            //"effects/MeshRiggingTextures.sefx",
+            "effects/Mesh.sefx",
+            Pos3::Zero(), 1.f,
             gBasePlayerModelInstanceScaling, gBasePlayerModelOrientation,
             gSlotColors.at(slot.mSlotIndex));
 
@@ -703,8 +706,9 @@ EntHandle createPortalImage(GameContext & aContext,
         Phase addPortalImage;
         component::Geometry modelGeo =
             aPlayerData.mModel.get()->get<component::Geometry>();
-        component::RigAnimation animation =
-            aPlayerData.mModel.get()->get<component::RigAnimation>();
+        // TODO #RV2 animation
+        //component::RigAnimation animation =
+        //    aPlayerData.mModel.get()->get<component::RigAnimation>();
         Entity portal = *newPortalImage.get(addPortalImage);
         Vec2 relativePos =
             aPortal.mMirrorSpawnPosition.xy() - aPlayerData.mCurrentPortalPos;
@@ -714,14 +718,16 @@ EntHandle createPortalImage(GameContext & aContext,
                        modelGeo.mScaling, modelGeo.mInstanceScaling,
                        modelGeo.mOrientation, modelGeo.mColor);
         portal.add(component::Collision{component::gPlayerHitbox})
-            .add(component::RigAnimation{
-                .mAnimName = animation.mAnimName,
-                .mAnimation = animation.mAnimation,
-                .mStartTime = animation.mStartTime,
-                .mParameter =
-                    decltype(component::RigAnimation::mParameter){
-                        animation.mAnimation->mEndTime},
-            });
+            // TODO #RV2 animation
+            //.add(component::RigAnimation{
+            //    .mAnimName = animation.mAnimName,
+            //    .mAnimation = animation.mAnimation,
+            //    .mStartTime = animation.mStartTime,
+            //    .mParameter =
+            //        decltype(component::RigAnimation::mParameter){
+            //            animation.mAnimation->mEndTime},
+            //})
+            ;
         aPlayerData.mPortalImage = newPortalImage;
     }
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Entities.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Entities.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "GameParameters.h"
+#include "Handle_V2.h"
 #include "component/PowerUp.h"
 
 #include <snacman/Timing.h>
@@ -10,6 +11,9 @@
 #include <math/Color.h>
 #include <math/Quaternion.h>
 #include <math/Vector.h>
+
+#include <snac-renderer-V2/Model.h>
+
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -48,7 +52,8 @@ void addGeoNode(
     math::Size<3, float> aInstanceScale = {1.f, 1.f, 1.f},
     math::Quaternion<float> aOrientation = math::Quaternion<float>::Identity(),
     math::hdr::Rgba_f aColor = math::hdr::gWhite<float>);
-std::shared_ptr<snac::Model> addMeshGeoNode(
+
+snacgame::Handle<renderer::Node> addMeshGeoNode(
     GameContext & aContext,
     ent::Entity & aEnt,
     const char * aModelPath,

--- a/src/apps/snacman/snacman/simulations/snacgame/GameContext.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameContext.cpp
@@ -9,7 +9,7 @@
 namespace ad {
 namespace snacgame {
 
-GameContext::GameContext(snac::Resources aResources, snac::RenderThread<Renderer> & aRenderThread) :
+GameContext::GameContext(snac::Resources aResources, snac::RenderThread<Renderer_t> & aRenderThread) :
     mResources{aResources},
     mRenderThread{aRenderThread},
     mSceneStack{mWorld},

--- a/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameContext.h
@@ -33,15 +33,14 @@ namespace component {
 struct LevelSetupData;
 } // namespace component
 
-class Renderer;
 
 struct GameContext
 {
-    GameContext(snac::Resources aResources, snac::RenderThread<Renderer> & aRenderThread);
+    GameContext(snac::Resources aResources, snac::RenderThread<Renderer_t> & aRenderThread);
 
     snac::Resources mResources;
     ent::EntityManager mWorld;
-    snac::RenderThread<Renderer> & mRenderThread;
+    snac::RenderThread<Renderer_t> & mRenderThread;
     SimulationControl mSimulationControl;
 
     ent::Wrap<system::SceneStack> mSceneStack;

--- a/src/apps/snacman/snacman/simulations/snacgame/GameParameters.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GameParameters.h
@@ -16,8 +16,10 @@ constexpr const char * gGameSceneName = "Game";
 constexpr const char * gJoinGameSceneName = "JoinGame";
 
 constexpr math::Spherical<float> gInitialCameraSpherical{
-    20.f, math::Turn<float>{0.075f},
-    math::Turn<float>{0.f}};
+    20.f,
+    math::Turn<float>{0.075f},
+    math::Turn<float>{0.f}
+};
 
 constexpr std::array<math::hdr::Rgba_f, 5> gSlotColors{
     math::hdr::Rgba_f{1.f, 1.f, 1.f, 1.f},

--- a/src/apps/snacman/snacman/simulations/snacgame/GraphicState.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GraphicState.h
@@ -37,7 +37,7 @@ struct Entity
     struct SkeletalAnimation
     {
         //TODO #anim (a48c8) this is **not** const because animation writes to the underlying scene,
-        // but this is very smelly (and an invitatin to race conditions)
+        // but this is very smelly (and an invitation to race conditions)
         snac::Rig *mRig = nullptr;
         const snac::NodeAnimation * mAnimation = nullptr;
         double mParameterValue = 0.;

--- a/src/apps/snacman/snacman/simulations/snacgame/GraphicState.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/GraphicState.h
@@ -1,6 +1,7 @@
 #pragma once
 
 
+#include "Handle_V2.h"
 #include "../../SparseSet.h"
 
 #include <math/Angle.h>
@@ -29,7 +30,7 @@ struct Entity
     math::Size<3, float> mScaling; // TODO were is it used?
     math::Quaternion<float> mOrientation;
     math::hdr::Rgba_f mColor;
-    std::shared_ptr<snac::Model> mModel;
+    Handle<renderer::Node> mModel;
 
     // TODO #anim would be better to interpolate the animation time (Parameter)
     // between each GPU frame, instead of providing fixed parameter value

--- a/src/apps/snacman/snacman/simulations/snacgame/Handle_V2.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Handle_V2.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <snac-renderer-V2/Model.h>
+
+#include <memory>
+
+namespace ad::snacgame {
+
+
+template <class T_resource>
+using Handle = std::shared_ptr<T_resource>;
+
+
+} // namespace ad::snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/ImguiInhibiter.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/ImguiInhibiter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <snacman/Input.h>
+
+
+namespace ad::snacgame {
+
+
+/// \brief Implement HidManager's Inhibiter protocol, for Imgui.
+/// Allowing the app to discard input events that are handled by DearImgui.
+class ImguiInhibiter : public snac::HidManager::Inhibiter
+{
+public:
+    enum WantCapture
+    {
+        Null,
+        Mouse = 1 << 0,
+        Keyboard = 1 << 1,
+    };
+
+    void resetCapture(WantCapture aCaptures) { mCaptures = aCaptures; }
+    bool isCapturingMouse() const override
+    {
+        return (mCaptures & Mouse) == Mouse;
+    }
+    bool isCapturingKeyboard() const override
+    {
+        return (mCaptures & Keyboard) == Keyboard;
+    }
+
+private:
+    std::uint8_t mCaptures{0};
+};
+
+
+} // namespace ad::snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/OrbitalControlInput.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/OrbitalControlInput.cpp
@@ -1,0 +1,42 @@
+#include "OrbitalControlInput.h"
+
+#include "GraphicState.h"
+
+#include <snacman/Input.h>
+
+
+namespace ad::snacgame {
+
+
+void OrbitalControlInput::update(const RawInput & aInput,
+                                 math::Radian<float> aVerticalFov,
+                                 int aWindowHeight_screen)
+{
+    if(aInput.mMouse.get(MouseButton::Left))
+    {
+        // Orbiting
+        mOrbital.incrementOrbitRadians(-aInput.mMouse.mCursorDisplacement.cwMul(gMouseControlFactor));              
+    }
+    else if(aInput.mMouse.get(MouseButton::Middle))
+    {
+        // Panning
+        float viewedHeightOrbitPlane_world = 2 * tan(aVerticalFov / 2) * std::abs(mOrbital.radius());
+        float factor = viewedHeightOrbitPlane_world / (float)aWindowHeight_screen;
+        mOrbital.pan(aInput.mMouse.mCursorDisplacement * factor);              
+    }
+
+    // Mouse scroll
+    float factor = (1 - aInput.mMouse.mScrollOffset.y() * gScrollFactor);
+    mOrbital.radius() *= factor;
+}
+
+
+visu::Camera OrbitalControlInput::getCameraState()
+{
+    return {
+        .mWorldToCamera = mOrbital.getParentToLocal(),
+    };
+}
+
+
+} // namespace ad::snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/OrbitalControlInput.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/OrbitalControlInput.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/Angle.h>
+
+#include <snac-renderer-V2/Camera.h>
+
+namespace ad {
+    struct RawInput;
+} // namespace ad
+
+namespace ad::snacgame {
+
+
+namespace visu {
+    struct Camera;
+} // namespace visu
+
+/// @brief Controls an orbital from RawInput
+struct OrbitalControlInput
+{
+    void update(const RawInput & aInput,
+                math::Radian<float> aVerticalFov,
+                int aWindowHeight_screen);
+    
+
+    visu::Camera getCameraState();
+
+    renderer::Orbital mOrbital;
+
+private:
+    static constexpr math::Vec<2, GLfloat> gMouseControlFactor{1 / 500.f,
+                                                               1 / 500.f};
+    static constexpr float gScrollFactor = 0.05f;
+};
+
+
+} // namespace ad::snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -1,93 +1,11 @@
 #pragma once
 
 
-#include "GraphicState.h"
-
-#include <snac-renderer-V1/Camera.h>
-#include <snac-renderer-V1/DebugRenderer.h>
-#include <snac-renderer-V1/LoadInterface.h>
-#include <snac-renderer-V1/Mesh.h>
-#include <snac-renderer-V1/Render.h>
-#include <snac-renderer-V1/text/TextRenderer.h>
-#include <snac-renderer-V1/UniformParameters.h>
-
-#include <snac-renderer-V1/pipelines/ForwardShadows.h>
-
-#include <filesystem>
-#include <memory>
-
-namespace ad {
-namespace arte { class FontFace; }
-namespace graphics { class AppInterface; }
-
-// Forward declarations
-namespace snac {
-    class Resources;
-    struct Font;
-} // namespace snac
-
-namespace snacgame {
+#include "Renderer_V2.h"
 
 
-class Renderer
-{
-    friend struct TextRenderer;
+namespace ad::snacgame {
 
-    struct Control
-    {
-        MovableAtomic<bool> mRenderModels{true};
-        MovableAtomic<bool> mRenderText{true};
-        MovableAtomic<bool> mRenderDebug{true};
+using Renderer_t = Renderer_V2;
 
-        // This boolean is only accessed by main thread
-        bool mShowShadowControls{false};
-    };
-
-public:
-    using GraphicState_t = visu::GraphicState;
-
-    Renderer(graphics::AppInterface & aAppInterface,
-             snac::Load<snac::Technique> & aTechniqueAccess,
-             arte::FontFace aDebugFontFace);
-
-    //void resetProjection(float aAspectRatio, snac::Camera::Parameters aParameters);
-
-    // TODO Extend beyond cubes.
-    static std::shared_ptr<snac::Model> LoadModel(filesystem::path aModel,
-                                                  filesystem::path aEffect,
-                                                  snac::Resources & aResources);
-
-    std::shared_ptr<snac::Font> loadFont(arte::FontFace aFontFace,
-                                         unsigned int aPixelHeight,
-                                         filesystem::path aEffect,
-                                         snac::Resources & aResources);
-
-    void continueGui();
-
-    void render(const visu::GraphicState & aState);
-
-    /// \brief Forwards the request to reset repositories down to the generic renderer.
-    void resetRepositories()
-    { mRenderer.resetRepositories(); }
-
-private:
-    template <class T_range>
-    void renderText(const T_range & aTexts, snac::ProgramSetup & aProgramSetup);
-
-    Control mControl;
-    graphics::AppInterface & mAppInterface;
-    snac::Renderer mRenderer;
-    // TODO Is it the correct place to host the pipeline instance?
-    // This notably force to instantiate it with the Renderer (before the Resources manager is available).
-    snac::ForwardShadows mPipelineShadows;
-    snac::Camera mCamera;
-    snac::CameraBuffer mCameraBuffer;
-    snac::TextRenderer mTextRenderer;
-    snac::GlyphInstanceStream mDynamicStrings;
-    snac::DebugRenderer mDebugRenderer;
-    graphics::UniformBufferObject mJointMatrices;
-};
-
-
-} // namespace snacgame
-} // namespace ad
+} // namespace ad::snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer.h
@@ -7,5 +7,6 @@
 namespace ad::snacgame {
 
 using Renderer_t = Renderer_V2;
+using Resources_t = Renderer_t::Resources_t;
 
 } // namespace ad::snacgame

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V1.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V1.cpp
@@ -1,0 +1,283 @@
+#include "Renderer_V1.h"
+
+#include "renderer/ScopeGuards.h"
+
+#include <graphics/AppInterface.h>
+
+#include <imguiui/Widgets.h> 
+
+#include <math/Transformations.h>
+#include <math/VectorUtilities.h>
+
+#include <platform/Filesystem.h>
+
+#include <renderer/BufferLoad.h>
+
+#include <snac-renderer-V1/text/Text.h>
+#include <snac-renderer-V1/Instances.h>
+#include <snac-renderer-V1/Semantic.h>
+#include <snac-renderer-V1/Render.h>
+#include <snac-renderer-V1/Mesh.h>
+#include <snac-renderer-V1/ResourceLoad.h>
+
+#include <snacman/Profiling.h>
+#include <snacman/ProfilingGPU.h>
+#include <snacman/Resources.h>
+
+// TODO #generic-render remove once all geometry and shader programs are created
+// outside.
+
+
+static constexpr unsigned int gMaxBones = 32;
+static constexpr unsigned int gMaxRiggedInstances = 16;
+
+
+namespace ad {
+namespace snacgame {
+
+
+
+Renderer::Renderer(graphics::AppInterface & aAppInterface,
+                   snac::Load<snac::Technique> & aTechniqueAccess,
+                   arte::FontFace aDebugFontFace) :
+    mAppInterface{aAppInterface},
+    mPipelineShadows{aAppInterface, aTechniqueAccess},
+    mCamera{math::getRatio<float>(mAppInterface.getWindowSize()), snac::Camera::gDefaults},
+    mDebugRenderer{aTechniqueAccess, std::move(aDebugFontFace)}
+{
+    graphics::initialize<math::AffineMatrix<4, float>>(mJointMatrices,
+                                                       gMaxBones * gMaxRiggedInstances,
+                                                       graphics::BufferHint::DynamicDraw);
+    mPipelineShadows.getControls().mShadowBias = 0.0005f;
+}
+
+//void Renderer::resetProjection(float aAspectRatio,
+//                               snac::Camera::Parameters aParameters)
+//{
+//    mCamera.resetProjection(aAspectRatio, aParameters);
+//}
+
+std::shared_ptr<snac::Model> Renderer::LoadModel(filesystem::path aModel,
+                                                 filesystem::path aEffect, 
+                                                 snac::Resources & aResources)
+{
+    if (aModel.string() == "CUBE")
+    {
+        auto model = std::make_shared<snac::Model>();
+        model->mParts.push_back({snac::loadCube(aResources.getShaderEffect(aEffect))});
+        return model;
+    }
+    else
+    {
+        return std::make_shared<snac::Model>(
+            loadModel(aModel, aResources.getShaderEffect(aEffect)));
+    }
+}
+
+std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
+                                               unsigned int aPixelHeight,
+                                               filesystem::path aEffect,
+                                               snac::Resources & aResources)
+{
+    return std::make_shared<snac::Font>(
+        std::move(aFontFace),
+        aPixelHeight,
+        aResources.getShaderEffect(aEffect)
+    );
+}
+
+
+void Renderer::continueGui()
+{
+    using namespace imguiui;
+
+    addCheckbox("Render models", mControl.mRenderModels);
+    addCheckbox("Render text", mControl.mRenderText);
+    addCheckbox("Render debug", mControl.mRenderDebug);
+
+    ImGui::Checkbox("Show shadow controls", &mControl.mShowShadowControls);
+    if (mControl.mShowShadowControls)
+    {
+        mPipelineShadows.drawGui();
+    }
+}
+
+
+template <class T_range>
+void Renderer::renderText(const T_range & aTexts, snac::ProgramSetup & aProgramSetup)
+{
+    // Note: this is pessimised code.
+    // Most of these expensive operations should be taken out and the results
+    // cached.
+    for (const visu::Text & text : aTexts)
+    {
+        auto localToWorld = 
+            math::trans3d::scale(text.mScaling)
+            * text.mOrientation.toRotationMatrix()
+            * math::trans3d::translate(text.mPosition_world.as<math::Vec>());
+
+        // TODO should be cached once in the string and forwarded here
+        std::vector<snac::GlyphInstance> textBufferData =
+            text.mFont->mFontData.populateInstances(text.mString,
+                                                    to_sdr(text.mColor),
+                                                    localToWorld);
+
+        // TODO should be consolidated, a single call for all string of the same
+        // font.
+        mDynamicStrings.respecifyData(std::span{textBufferData});
+        BEGIN_RECURRING_GL("Draw string", drawStringProfile);
+        mTextRenderer.render(mDynamicStrings, *text.mFont, mRenderer, aProgramSetup);
+        END_RECURRING_GL(drawStringProfile);
+    }
+}
+
+
+void Renderer::render(const visu::GraphicState & aState)
+{
+    TIME_RECURRING_GL("Render");
+
+    // Stream the instance buffer data
+    std::map<snac::Model *, std::vector<snac::PoseColorSkeleton>> sortedModels;
+
+    BEGIN_RECURRING_GL("Sort_meshes", sortModelProfile);
+    GLuint jointMatricesCount = 0;
+    for (const visu::Entity & entity : aState.mEntities)
+    {
+        GLuint matrixPaletteOffset = std::numeric_limits<GLuint>::max();
+        if(entity.mRigging.mAnimation != nullptr)
+        {
+            {
+                TIME_RECURRING_GL("Prepare_joint_matrices");
+
+                entity.mRigging.mAnimation->animate(
+                    (float)entity.mRigging.mParameterValue,
+                    entity.mRigging.mRig->mScene);
+
+                const auto jointMatrices = entity.mRigging.mRig->computeJointMatrices();
+                graphics::replaceSubset(mJointMatrices, jointMatricesCount, std::span{jointMatrices});
+            }
+
+            matrixPaletteOffset = jointMatricesCount;
+            jointMatricesCount += (GLuint)entity.mRigging.mRig->mJoints.size();
+        }
+
+        sortedModels[entity.mModel.get()].push_back(snac::PoseColorSkeleton{
+            .pose = math::trans3d::scale(entity.mScaling)
+                    * entity.mOrientation.toRotationMatrix()
+                    * math::trans3d::translate(
+                        entity.mPosition_world.as<math::Vec>()),
+            .albedo = to_sdr(entity.mColor),
+            .matrixPaletteOffset = matrixPaletteOffset,
+        });
+    }
+    END_RECURRING_GL(sortModelProfile);
+
+    // Position camera
+    // TODO #camera The Camera instance should come from the graphic state directly
+    mCamera.setPose(aState.mCamera.mWorldToCamera);
+    mCameraBuffer.set(mCamera);
+
+
+    static const math::AffineMatrix<4, GLfloat> worldToLight = 
+        math::trans3d::rotateX(math::Degree<float>{60.f})
+        * math::trans3d::translate<GLfloat>({0.f, 2.5f, -16.f});
+
+    math::Position<3, GLfloat> lightPosition_cam = 
+        (math::homogeneous::makePosition(math::Position<3, GLfloat>::Zero()) // light position in light space is the origin
+        * worldToLight.inverse()
+        * aState.mCamera.mWorldToCamera).xyz();
+
+    math::hdr::Rgb_f lightColor = to_hdr<float>(math::sdr::gWhite) * 0.8f;
+    math::hdr::Rgb_f ambientColor = math::hdr::Rgb_f{0.4f, 0.4f, 0.4f};
+
+    const math::Size<2, int> framebufferSize = mAppInterface.getFramebufferSize();
+
+    snac::ProgramSetup programSetup{
+        .mUniforms{
+            {snac::Semantic::LightColor, snac::UniformParameter{lightColor}},
+            {snac::Semantic::LightPosition, {lightPosition_cam}},
+            {snac::Semantic::AmbientColor, {ambientColor}},
+            {snac::Semantic::FramebufferResolution, framebufferSize},
+            {snac::Semantic::ViewingMatrix, mCamera.assembleViewMatrix()}
+        },
+        .mUniformBlocks{
+            {snac::BlockSemantic::Viewing, &mCameraBuffer.mViewing},
+            {snac::BlockSemantic::JointMatrices, &mJointMatrices},
+        }
+    };
+
+    if (mControl.mRenderModels)
+    {
+        static snac::Camera shadowLightViewPoint{1, 
+            {
+                .vFov = math::Degree<float>(95.f),
+                .zNear = -1.f,
+                .zFar = -50.f,
+            }};
+        shadowLightViewPoint.setPose(worldToLight);
+
+        TIME_RECURRING_GL("Draw_meshes");
+        // Poor man's pool
+        static std::list<snac::InstanceStream> instanceStreams;
+        while(instanceStreams.size() < sortedModels.size())
+        {
+            instanceStreams.push_back(snac::initializeInstanceStream<snac::PoseColorSkeleton>());
+        }
+
+        auto streamIt = instanceStreams.begin();
+        std::vector<snac::Pass::Visual> visuals;
+        for (const auto & [model, instances] : sortedModels)
+        {
+            streamIt->respecifyData(std::span{instances});
+            for (const auto & mesh : model->mParts)
+            {
+                visuals.push_back({&mesh, &*streamIt});
+            }
+            ++streamIt;
+        }
+        mPipelineShadows.execute(visuals, shadowLightViewPoint, mRenderer, programSetup);
+    }
+
+    //
+    // Text
+    //
+    {
+        TIME_RECURRING_GL("Draw_texts");
+
+        // 3D world text
+        if (mControl.mRenderText)
+        {
+            // This text should be occluded by geometry in front of it.
+            // WARNING: (smelly) the text rendering disable depth writes,
+            //          so it must be drawn last to occlude other visuals in the 3D world.
+            auto scopeDepth = graphics::scopeFeature(GL_DEPTH_TEST, true);
+            renderText(aState.mTextWorldEntities, programSetup);
+        }
+
+        // For the screen space text, the viewing transform is composed as follows:
+        // The world-to-camera is identity
+        // The projection is orthographic, mapping framebuffer resolution (with origin at screen center) to NDC.
+        auto scope = programSetup.mUniforms.push(
+            snac::Semantic::ViewingMatrix,
+            math::trans3d::orthographicProjection(
+                math::Box<float>{
+                    {-static_cast<math::Position<2, float>>(framebufferSize) / 2, -1.f},
+                    {static_cast<math::Size<2, float>>(framebufferSize), 2.f}
+                })
+        );
+
+        if (mControl.mRenderText)
+        {
+            renderText(aState.mTextScreenEntities, programSetup);
+        }
+    }
+
+    if (mControl.mRenderDebug)
+    {
+        TIME_RECURRING_GL("Draw_debug");
+        mDebugRenderer.render(aState.mDebugDrawList, mRenderer, programSetup);
+    }
+}
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V1.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V1.cpp
@@ -137,7 +137,7 @@ void Renderer::render(const visu::GraphicState & aState)
     TIME_RECURRING_GL("Render");
 
     // Stream the instance buffer data
-    std::map<snac::Model *, std::vector<snac::PoseColorSkeleton>> sortedModels;
+    std::map<renderer::Node *, std::vector<snac::PoseColorSkeleton>> sortedModels;
 
     BEGIN_RECURRING_GL("Sort_meshes", sortModelProfile);
     GLuint jointMatricesCount = 0;
@@ -206,37 +206,39 @@ void Renderer::render(const visu::GraphicState & aState)
         }
     };
 
-    if (mControl.mRenderModels)
-    {
-        static snac::Camera shadowLightViewPoint{1, 
-            {
-                .vFov = math::Degree<float>(95.f),
-                .zNear = -1.f,
-                .zFar = -50.f,
-            }};
-        shadowLightViewPoint.setPose(worldToLight);
+    // TODO #RV2 Remove this segment, when we have a V2 Render Graph
+    // In the process of being decommissioned
+    //if (mControl.mRenderModels)
+    //{
+    //    static snac::Camera shadowLightViewPoint{1, 
+    //        {
+    //            .vFov = math::Degree<float>(95.f),
+    //            .zNear = -1.f,
+    //            .zFar = -50.f,
+    //        }};
+    //    shadowLightViewPoint.setPose(worldToLight);
 
-        TIME_RECURRING_GL("Draw_meshes");
-        // Poor man's pool
-        static std::list<snac::InstanceStream> instanceStreams;
-        while(instanceStreams.size() < sortedModels.size())
-        {
-            instanceStreams.push_back(snac::initializeInstanceStream<snac::PoseColorSkeleton>());
-        }
+    //    TIME_RECURRING_GL("Draw_meshes");
+    //    // Poor man's pool
+    //    static std::list<snac::InstanceStream> instanceStreams;
+    //    while(instanceStreams.size() < sortedModels.size())
+    //    {
+    //        instanceStreams.push_back(snac::initializeInstanceStream<snac::PoseColorSkeleton>());
+    //    }
 
-        auto streamIt = instanceStreams.begin();
-        std::vector<snac::Pass::Visual> visuals;
-        for (const auto & [model, instances] : sortedModels)
-        {
-            streamIt->respecifyData(std::span{instances});
-            for (const auto & mesh : model->mParts)
-            {
-                visuals.push_back({&mesh, &*streamIt});
-            }
-            ++streamIt;
-        }
-        mPipelineShadows.execute(visuals, shadowLightViewPoint, mRenderer, programSetup);
-    }
+    //    auto streamIt = instanceStreams.begin();
+    //    std::vector<snac::Pass::Visual> visuals;
+    //    for (const auto & [model, instances] : sortedModels)
+    //    {
+    //        streamIt->respecifyData(std::span{instances});
+    //        for (const auto & mesh : model->mParts)
+    //        {
+    //            visuals.push_back({&mesh, &*streamIt});
+    //        }
+    //        ++streamIt;
+    //    }
+    //    mPipelineShadows.execute(visuals, shadowLightViewPoint, mRenderer, programSetup);
+    //}
 
     //
     // Text

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V1.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V1.h
@@ -1,0 +1,92 @@
+#pragma once
+
+
+#include "GraphicState.h"
+
+#include <snac-renderer-V1/Camera.h>
+#include <snac-renderer-V1/DebugRenderer.h>
+#include <snac-renderer-V1/LoadInterface.h>
+#include <snac-renderer-V1/Mesh.h>
+#include <snac-renderer-V1/Render.h>
+#include <snac-renderer-V1/text/TextRenderer.h>
+#include <snac-renderer-V1/UniformParameters.h>
+
+#include <snac-renderer-V1/pipelines/ForwardShadows.h>
+
+#include <filesystem>
+#include <memory>
+
+namespace ad {
+namespace arte { class FontFace; }
+namespace graphics { class AppInterface; }
+
+// Forward declarations
+namespace snac {
+    class Resources;
+    struct Font;
+} // namespace snac
+
+namespace snacgame {
+
+
+class Renderer
+{
+    friend struct TextRenderer;
+
+    struct Control
+    {
+        MovableAtomic<bool> mRenderModels{true};
+        MovableAtomic<bool> mRenderText{true};
+        MovableAtomic<bool> mRenderDebug{true};
+
+        // This boolean is only accessed by main thread
+        bool mShowShadowControls{false};
+    };
+
+public:
+    using GraphicState_t = visu::GraphicState;
+
+    Renderer(graphics::AppInterface & aAppInterface,
+             snac::Load<snac::Technique> & aTechniqueAccess,
+             arte::FontFace aDebugFontFace);
+
+    //void resetProjection(float aAspectRatio, snac::Camera::Parameters aParameters);
+
+    static std::shared_ptr<snac::Model> LoadModel(filesystem::path aModel,
+                                                  filesystem::path aEffect,
+                                                  snac::Resources & aResources);
+
+    std::shared_ptr<snac::Font> loadFont(arte::FontFace aFontFace,
+                                         unsigned int aPixelHeight,
+                                         filesystem::path aEffect,
+                                         snac::Resources & aResources);
+
+    void continueGui();
+
+    void render(const visu::GraphicState & aState);
+
+    /// \brief Forwards the request to reset repositories down to the generic renderer.
+    void resetRepositories()
+    { mRenderer.resetRepositories(); }
+
+private:
+    template <class T_range>
+    void renderText(const T_range & aTexts, snac::ProgramSetup & aProgramSetup);
+
+    Control mControl;
+    graphics::AppInterface & mAppInterface;
+    snac::Renderer mRenderer;
+    // TODO Is it the correct place to host the pipeline instance?
+    // This notably force to instantiate it with the Renderer (before the Resources manager is available).
+    snac::ForwardShadows mPipelineShadows;
+    snac::Camera mCamera;
+    snac::CameraBuffer mCameraBuffer;
+    snac::TextRenderer mTextRenderer;
+    snac::GlyphInstanceStream mDynamicStrings;
+    snac::DebugRenderer mDebugRenderer;
+    graphics::UniformBufferObject mJointMatrices;
+};
+
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
@@ -274,6 +274,8 @@ void Renderer_V2::render(const visu::GraphicState & aState)
                         repositoryUbo[semantic::gViewProjection] = &mCameraBuffer.mViewing;
 
                         renderer::setBufferBackedBlocks(configuredProgram->mProgram, repositoryUbo);
+
+                        renderer::setTextures(configuredProgram->mProgram, part.mMaterial.mContext->mTextureRepo);
             
                         // TODO #RV2 make a block for lighting (with an array of lights)
                         graphics::setUniform(configuredProgram->mProgram, "u_AmbientColor", ambientColor); // single contribution for all lights

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
@@ -275,10 +275,10 @@ void Renderer_V2::render(const visu::GraphicState & aState)
 
                         renderer::setBufferBackedBlocks(configuredProgram->mProgram, repositoryUbo);
             
-                        // TODO #RV2 make a block for lights
+                        // TODO #RV2 make a block for lighting (with an array of lights)
+                        graphics::setUniform(configuredProgram->mProgram, "u_AmbientColor", ambientColor); // single contribution for all lights
                         graphics::setUniform(configuredProgram->mProgram, "u_LightColor", lightColor);
                         graphics::setUniform(configuredProgram->mProgram, "u_LightPosition", lightPosition_cam);
-                        graphics::setUniform(configuredProgram->mProgram, "u_AmbientColor", ambientColor);
 
                         renderer::Handle<graphics::VertexArrayObject> vao =
                             renderer::getVao(*configuredProgram, part, mRendererToKeep.mStorage);

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
@@ -258,7 +258,7 @@ void Renderer_V2::render(const visu::GraphicState & aState)
                         aEntity.albedo,
                         (GLuint)part.mMaterial.mPhongMaterialIdx,
                     };
-                    renderer::proto::loadSingle(*mRendererToKeep.mRenderGraph.getBufferView(semantic::gLocalToWorld).mGLBuffer,
+                    renderer::proto::loadSingle(*getBufferView(mRendererToKeep.mRenderGraph.mInstanceStream, semantic::gLocalToWorld).mGLBuffer,
                                                 instanceData,          
                                                 // TODO #azdo change to DynamicDraw when properly handling AZDO
                                                 graphics::BufferHint::StreamDraw);

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
@@ -292,6 +292,7 @@ void Renderer_V2::render(const visu::GraphicState & aState)
                         glEnable(GL_CULL_FACE);
                         glEnable(GL_DEPTH_TEST);
                         glDepthMask(GL_TRUE);
+                        //glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 
                         gl.DrawElementsInstancedBaseVertex(
                             part.mPrimitiveMode,

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.cpp
@@ -1,4 +1,4 @@
-#include "Renderer.h"
+#include "Renderer_V2.h"
 
 #include "renderer/ScopeGuards.h"
 
@@ -37,7 +37,7 @@ namespace snacgame {
 
 
 
-Renderer::Renderer(graphics::AppInterface & aAppInterface,
+Renderer_V2::Renderer_V2(graphics::AppInterface & aAppInterface,
                    snac::Load<snac::Technique> & aTechniqueAccess,
                    arte::FontFace aDebugFontFace) :
     mAppInterface{aAppInterface},
@@ -57,7 +57,7 @@ Renderer::Renderer(graphics::AppInterface & aAppInterface,
 //    mCamera.resetProjection(aAspectRatio, aParameters);
 //}
 
-std::shared_ptr<snac::Model> Renderer::LoadModel(filesystem::path aModel,
+std::shared_ptr<snac::Model> Renderer_V2::LoadModel(filesystem::path aModel,
                                                  filesystem::path aEffect, 
                                                  snac::Resources & aResources)
 {
@@ -74,7 +74,7 @@ std::shared_ptr<snac::Model> Renderer::LoadModel(filesystem::path aModel,
     }
 }
 
-std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
+std::shared_ptr<snac::Font> Renderer_V2::loadFont(arte::FontFace aFontFace,
                                                unsigned int aPixelHeight,
                                                filesystem::path aEffect,
                                                snac::Resources & aResources)
@@ -87,7 +87,7 @@ std::shared_ptr<snac::Font> Renderer::loadFont(arte::FontFace aFontFace,
 }
 
 
-void Renderer::continueGui()
+void Renderer_V2::continueGui()
 {
     using namespace imguiui;
 
@@ -104,7 +104,7 @@ void Renderer::continueGui()
 
 
 template <class T_range>
-void Renderer::renderText(const T_range & aTexts, snac::ProgramSetup & aProgramSetup)
+void Renderer_V2::renderText(const T_range & aTexts, snac::ProgramSetup & aProgramSetup)
 {
     // Note: this is pessimised code.
     // Most of these expensive operations should be taken out and the results
@@ -132,7 +132,7 @@ void Renderer::renderText(const T_range & aTexts, snac::ProgramSetup & aProgramS
 }
 
 
-void Renderer::render(const visu::GraphicState & aState)
+void Renderer_V2::render(const visu::GraphicState & aState)
 {
     TIME_RECURRING_GL("Render");
 

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.h
@@ -41,8 +41,10 @@ namespace semantic {
 
     SEM(LocalToWorld);
     SEM(Albedo);
+    SEM(MaterialIdx);
 
     BLOCK_SEM(ViewProjection);
+    BLOCK_SEM(Materials);
 
     #undef SEMANTIC
 } // namespace semantic
@@ -55,6 +57,7 @@ struct SnacGraph
     {
         math::AffineMatrix<4, GLfloat> mModelTransform;
         math::sdr::Rgba mAlbedo;
+        GLuint mMaterialIdx;
     };
 
     static renderer::GenericStream makeInstanceStream(renderer::Storage & aStorage, std::size_t aInstanceCount)
@@ -87,6 +90,17 @@ struct SnacGraph
                             .mDimension = 4,
                             .mOffset = offsetof(InstanceData, mAlbedo),
                             .mComponentType = GL_UNSIGNED_BYTE,
+                        },
+                    }
+                },
+                {
+                    semantic::gMaterialIdx,
+                    renderer::AttributeAccessor{
+                        .mBufferViewIndex = 0, // view is added above
+                        .mClientDataFormat{
+                            .mDimension = 1,
+                            .mOffset = offsetof(InstanceData, mMaterialIdx),
+                            .mComponentType = GL_UNSIGNED_INT,
                         },
                     }
                 },

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.h
@@ -1,0 +1,92 @@
+#pragma once
+
+
+#include "GraphicState.h"
+
+#include <snac-renderer-V1/Camera.h>
+#include <snac-renderer-V1/DebugRenderer.h>
+#include <snac-renderer-V1/LoadInterface.h>
+#include <snac-renderer-V1/Mesh.h>
+#include <snac-renderer-V1/Render.h>
+#include <snac-renderer-V1/text/TextRenderer.h>
+#include <snac-renderer-V1/UniformParameters.h>
+
+#include <snac-renderer-V1/pipelines/ForwardShadows.h>
+
+#include <filesystem>
+#include <memory>
+
+
+namespace ad {
+namespace arte { class FontFace; }
+namespace graphics { class AppInterface; }
+
+// Forward declarations
+namespace snac {
+    class Resources;
+    struct Font;
+} // namespace snac
+
+namespace snacgame {
+
+
+class Renderer_V2
+{
+    friend struct TextRenderer;
+
+    struct Control
+    {
+        MovableAtomic<bool> mRenderModels{true};
+        MovableAtomic<bool> mRenderText{true};
+        MovableAtomic<bool> mRenderDebug{true};
+
+        // This boolean is only accessed by main thread
+        bool mShowShadowControls{false};
+    };
+
+public:
+    using GraphicState_t = visu::GraphicState;
+
+    Renderer_V2(graphics::AppInterface & aAppInterface,
+                snac::Load<snac::Technique> & aTechniqueAccess,
+                arte::FontFace aDebugFontFace);
+
+    //void resetProjection(float aAspectRatio, snac::Camera::Parameters aParameters);
+
+    static std::shared_ptr<snac::Model> LoadModel(filesystem::path aModel,
+                                                  filesystem::path aEffect,
+                                                  snac::Resources & aResources);
+
+    std::shared_ptr<snac::Font> loadFont(arte::FontFace aFontFace,
+                                         unsigned int aPixelHeight,
+                                         filesystem::path aEffect,
+                                         snac::Resources & aResources);
+
+    void continueGui();
+
+    void render(const visu::GraphicState & aState);
+
+    /// \brief Forwards the request to reset repositories down to the generic renderer.
+    void resetRepositories()
+    { mRenderer.resetRepositories(); }
+
+private:
+    template <class T_range>
+    void renderText(const T_range & aTexts, snac::ProgramSetup & aProgramSetup);
+
+    Control mControl;
+    graphics::AppInterface & mAppInterface;
+    snac::Renderer mRenderer;
+    // TODO Is it the correct place to host the pipeline instance?
+    // This notably force to instantiate it with the Renderer (before the Resources manager is available).
+    snac::ForwardShadows mPipelineShadows;
+    snac::Camera mCamera;
+    snac::CameraBuffer mCameraBuffer;
+    snac::TextRenderer mTextRenderer;
+    snac::GlyphInstanceStream mDynamicStrings;
+    snac::DebugRenderer mDebugRenderer;
+    graphics::UniformBufferObject mJointMatrices;};
+
+
+} // namespace snacgame
+} // namespace ad

--- a/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/Renderer_V2.h
@@ -108,13 +108,6 @@ struct SnacGraph
         };
     }
 
-    // TODO This should be handled by the Renderer library
-    const renderer::BufferView & getBufferView(renderer::Semantic aSemantic) const
-    {
-        return mInstanceStream.mVertexBufferViews[
-            mInstanceStream.mSemanticToAttribute.at(aSemantic).mBufferViewIndex];
-    }
-
     // TODO #RV2: It should be implementing the frame rendering of models, instead of 
     // having it inline in Renderer_V2::render()
     //void renderFrame()

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -434,13 +434,14 @@ std::unique_ptr<visu::GraphicState> SnacGame::makeGraphicState()
         visu::Entity::SkeletalAnimation skeletal;
         if (auto entity = *aHandle.get(); entity.has<component::RigAnimation>())
         {
-            const auto & rigAnimation =
-                aHandle.get()->get<component::RigAnimation>();
-            skeletal = visu::Entity::SkeletalAnimation{
-                .mRig = &aVisualModel.mModel->mRig,
-                .mAnimation = rigAnimation.mAnimation,
-                .mParameterValue = rigAnimation.mParameterValue,
-            };
+            // TODO #RV2 animation
+            //const auto & rigAnimation =
+            //    aHandle.get()->get<component::RigAnimation>();
+            //skeletal = visu::Entity::SkeletalAnimation{
+            //    .mRig = &aVisualModel.mModel->mRig,
+            //    .mAnimation = rigAnimation.mAnimation,
+            //    .mParameterValue = rigAnimation.mParameterValue,
+            //};
         }
         state->mEntities.insert(
             aHandle.id(),

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -1,5 +1,7 @@
 #include "SnacGame.h"
 
+#include "ImguiInhibiter.h"
+
 #include "component/AllowedMovement.h"
 #include "component/Context.h"
 #include "component/Controller.h"

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.cpp
@@ -519,9 +519,6 @@ std::unique_ptr<visu::GraphicState> SnacGame::makeGraphicState()
             });
         });
 
-    auto font =
-        mGameContext.mResources.getFont("fonts/TitanOne-Regular.ttf", 120);
-
     state->mCamera = mSystemOrbitalCamera->getCamera();
 
     state->mDebugDrawList = snac::DebugDrawer::EndFrame();

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
@@ -2,7 +2,7 @@
 
 #include "EntityWrap.h"
 #include "GameContext.h"
-#include "Renderer.h"
+#include "Renderer_V2.h"
 #include "ImguiSceneEditor.h"
 
 #include "component/PlayerSlot.h"
@@ -114,7 +114,7 @@ private:
 class SnacGame
 {
 public:
-    using Renderer_t = Renderer;
+    using Renderer_t = Renderer_V2;
 
     /// \brief Initialize the scene;
     SnacGame(graphics::AppInterface & aAppInterface,

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
@@ -34,6 +34,8 @@ template <class T_renderer> class RenderThread;
 
 namespace snacgame {
 
+class ImguiInhibiter;
+
 namespace component {
 struct GlobalPose;
 struct MappingContext;
@@ -84,31 +86,6 @@ struct ImguiDisplays
         ImGui::Checkbox("ImguiDemo", &mShowImguiDemo);
         ImGui::End();
     }
-};
-/// \brief Implement HidManager's Inhibiter protocol, for Imgui.
-/// Allowing the app to discard input events that are handled by DearImgui.
-class ImguiInhibiter : public snac::HidManager::Inhibiter
-{
-public:
-    enum WantCapture
-    {
-        Null,
-        Mouse = 1 << 0,
-        Keyboard = 1 << 1,
-    };
-
-    void resetCapture(WantCapture aCaptures) { mCaptures = aCaptures; }
-    bool isCapturingMouse() const override
-    {
-        return (mCaptures & Mouse) == Mouse;
-    }
-    bool isCapturingKeyboard() const override
-    {
-        return (mCaptures & Keyboard) == Keyboard;
-    }
-
-private:
-    std::uint8_t mCaptures{0};
 };
 
 class SnacGame

--- a/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/SnacGame.h
@@ -114,8 +114,6 @@ private:
 class SnacGame
 {
 public:
-    using Renderer_t = Renderer_V2;
-
     /// \brief Initialize the scene;
     SnacGame(graphics::AppInterface & aAppInterface,
              snac::RenderThread<Renderer_t> & aRenderThread,

--- a/src/apps/snacman/snacman/simulations/snacgame/component/VisualModel.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/component/VisualModel.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <snac-renderer-V1/Mesh.h>
+#include <snac-renderer-V2/Model.h>
 
 namespace ad {
 namespace snacgame {
@@ -9,7 +9,7 @@ namespace component {
 
 struct VisualModel
 {
-    std::shared_ptr<snac::Model> mModel;
+    std::shared_ptr<renderer::Node> mModel;
     bool mDisableInterpolation = false;
 };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/GameScene.cpp
@@ -150,7 +150,7 @@ GameScene::GameScene(GameContext & aGameContext,
     }
 
     EntHandle camera = snac::getFirstHandle(mCameraQuery);
-    snac::Orbital & camOrbital = camera.get()->get<snac::Orbital>();
+    renderer::Orbital & camOrbital = snac::getComponent<snacgame::OrbitalControlInput>(camera).mOrbital;
     camOrbital.mSpherical.polar() = gInitialCameraSpherical.polar();
     camOrbital.mSpherical.radius() = gInitialCameraSpherical.radius();
 

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/JoinGameScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/JoinGameScene.cpp
@@ -54,7 +54,7 @@ JoinGameScene::JoinGameScene(GameContext & aGameContext,
     insertEntityInScene(mJoinGameRoot, mGameContext.mSceneRoot);
 
     EntHandle camera = snac::getFirstHandle(mCameraQuery);
-    snac::Orbital & camOrbital = snac::getComponent<snac::Orbital>(camera);
+    renderer::Orbital & camOrbital = snac::getComponent<snacgame::OrbitalControlInput>(camera).mOrbital;
     camOrbital.mSpherical.polar() = math::Turn<float>{0.22f};
     camOrbital.mSpherical.radius() = 15.f;
 }

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/MenuScene.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/MenuScene.cpp
@@ -3,6 +3,11 @@
 #include "snacman/simulations/snacgame/system/InputProcessor.h"
 #include "snacman/simulations/snacgame/system/MenuManager.h"
 
+#include "../Entities.h"
+#include "../GameParameters.h"
+#include "../InputCommandConverter.h"
+#include "../OrbitalControlInput.h"
+
 #include "../component/Context.h"
 #include "../component/Controller.h"
 #include "../component/Geometry.h"
@@ -15,9 +20,6 @@
 #include "../component/SceneNode.h"
 #include "../component/Tags.h"
 #include "../component/Text.h"
-#include "../Entities.h"
-#include "../GameParameters.h"
-#include "../InputCommandConverter.h"
 #include "../scene/DataScene.h"
 #include "../scene/GameScene.h"
 #include "../scene/JoinGameScene.h"
@@ -76,8 +78,8 @@ MenuScene::MenuScene(GameContext & aGameContext,
     insertEntityInScene(background, mGameContext.mSceneRoot);
 
     EntHandle camera = snac::getFirstHandle(mCameraQuery);
-    snac::Orbital & camOrbital = snac::getComponent<snac::Orbital>(camera);
-    camOrbital.mSpherical = gInitialCameraSpherical;
+    OrbitalControlInput & orbitalControl = snac::getComponent<OrbitalControlInput>(camera);
+    orbitalControl.mOrbital.mSpherical = gInitialCameraSpherical;
 }
 
 void MenuScene::onEnter(Transition aTransition) {}

--- a/src/apps/snacman/snacman/simulations/snacgame/scene/Scene.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/scene/Scene.h
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "entity/Query.h"
+#include "../OrbitalControlInput.h"
+
 #include "../component/SceneNode.h"
 
 #include <entity/Entity.h>
 #include <entity/EntityManager.h>
+#include <entity/Query.h>
 #include <entity/Wrap.h>
 
 #include <map>
@@ -107,7 +109,7 @@ protected:
     ent::Handle<ent::Entity> mSystems;
     std::vector<ent::Handle<ent::Entity>> mOwnedEntities;
     ent::Wrap<component::MappingContext> & mMappingContext;
-    ent::Query<snac::Orbital> mCameraQuery;
+    ent::Query<OrbitalControlInput> mCameraQuery;
 };
 
 } // namespace scene

--- a/src/apps/snacman/snacman/simulations/snacgame/system/AnimationManager.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/AnimationManager.cpp
@@ -34,18 +34,19 @@ void AnimationManager::update()
             animSpeed = 1.3f;
         }
 
-        component::RigAnimation & playerAnim = aRoundData.mModel.get(animPhase)->get<component::RigAnimation>();
+        // TODO #RV2 animation
+        //component::RigAnimation & playerAnim = aRoundData.mModel.get(animPhase)->get<component::RigAnimation>();
 
-        if (newAnimName != playerAnim.mAnimName)
-        {
-            playerAnim.mAnimation = &playerAnim.mAnimationMap->at(newAnimName);
-            playerAnim.mAnimName = newAnimName;
-            playerAnim.mStartTime = snac::Clock::now();
-            playerAnim.mParameter = decltype(component::RigAnimation::mParameter){
-                playerAnim.mAnimation->mEndTime,
-                animSpeed
-            };
-        }
+        //if (newAnimName != playerAnim.mAnimName)
+        //{
+        //    playerAnim.mAnimation = &playerAnim.mAnimationMap->at(newAnimName);
+        //    playerAnim.mAnimName = newAnimName;
+        //    playerAnim.mStartTime = snac::Clock::now();
+        //    playerAnim.mParameter = decltype(component::RigAnimation::mParameter){
+        //        playerAnim.mAnimation->mEndTime,
+        //        animSpeed
+        //    };
+        //}
     });
 }
 } // namespace system

--- a/src/apps/snacman/snacman/simulations/snacgame/system/Debug_BoundingBoxes.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/Debug_BoundingBoxes.cpp
@@ -47,7 +47,7 @@ void Debug_BoundingBoxes::update()
                     .mScaling = aGlobalPose.mInstanceScaling * aGlobalPose.mScaling,
                     .mOrientation = aGlobalPose.mOrientation,
                 },
-                aModel.mModel->mBoundingBox
+                aModel.mModel->mAabb
             );
         };
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/SystemOrbitalCamera.cpp
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/SystemOrbitalCamera.cpp
@@ -10,9 +10,14 @@ namespace snacgame {
 namespace system {
 
 OrbitalCamera::OrbitalCamera(ent::EntityManager & aWorld) :
-    mCamera{aWorld, gInitialCameraSpherical.radius(),
-            gInitialCameraSpherical.polar(),
-            gInitialCameraSpherical.azimuthal()}
+    mControl{aWorld,
+             OrbitalControlInput{
+                .mOrbital = {
+                    gInitialCameraSpherical.radius(),
+                    gInitialCameraSpherical.polar(),
+                    gInitialCameraSpherical.azimuthal()
+                }
+             }}
 {}
 
 
@@ -20,31 +25,13 @@ void OrbitalCamera::update(const RawInput & aInput,
                            math::Radian<float> aVerticalFov,
                            int aWindowHeight_screen)
 {
-    if(aInput.mMouse.get(MouseButton::Left))
-    {
-        // Orbiting
-        mCamera->incrementOrbitRadians(-aInput.mMouse.mCursorDisplacement.cwMul(gMouseControlFactor));              
-    }
-    else if(aInput.mMouse.get(MouseButton::Middle))
-    {
-        // Panning
-        snac::Orbital & orbital = *mCamera;
-        float viewedHeightOrbitPlane_world = 2 * tan(aVerticalFov / 2) * std::abs(orbital.radius());
-        float factor = viewedHeightOrbitPlane_world / (float)aWindowHeight_screen;
-        orbital.pan(aInput.mMouse.mCursorDisplacement * factor);              
-    }
-
-    // Mouse scroll
-    float factor = (1 - aInput.mMouse.mScrollOffset.y() * gScrollFactor);
-    mCamera->radius() *= factor;
+    mControl->update(aInput, aVerticalFov, aWindowHeight_screen);
 }
 
 
 visu::Camera OrbitalCamera::getCamera() const
 {
-    return {
-        .mWorldToCamera = mCamera->getParentToLocal(),
-    };
+    return mControl->getCameraState();
 }
 
 

--- a/src/apps/snacman/snacman/simulations/snacgame/system/SystemOrbitalCamera.h
+++ b/src/apps/snacman/snacman/simulations/snacgame/system/SystemOrbitalCamera.h
@@ -2,6 +2,7 @@
 
 #include "../EntityWrap.h"
 #include "../GraphicState.h"
+#include "../OrbitalControlInput.h"
 
 #include <snacman/Input.h>
 
@@ -28,11 +29,7 @@ public:
     visu::Camera getCamera() const;
 
 private:
-    static constexpr math::Vec<2, GLfloat> gMouseControlFactor{1 / 500.f,
-                                                               1 / 500.f};
-    static constexpr float gScrollFactor = 0.05f;
-
-    EntityWrap<snac::Orbital> mCamera;
+    EntityWrap<OrbitalControlInput> mControl;
 };
 
 } // namespace system

--- a/src/apps/viewer/viewer/SceneGui.cpp
+++ b/src/apps/viewer/viewer/SceneGui.cpp
@@ -139,6 +139,32 @@ Node * SceneGui::presentNodeTree(Node & aNode, unsigned int aIndex)
 }
 
 
+void SceneGui::presentAnimations(Handle<AnimatedRig> mAnimatedRig)
+{
+    if(ImGui::TreeNodeEx("[Animations]", gBaseFlags))
+    {
+        int flags = gLeafFlags;
+        for(const auto & [key, rigAnimation] : mAnimatedRig->mNameToAnimation)
+        {
+            bool opened = ImGui::TreeNodeEx(&rigAnimation, flags, "%s", rigAnimation.mName.c_str());
+            if(opened)
+            {
+                ImGui::TreePop();
+            }
+            if(isItemDoubleClicked())
+            {
+                mSelectedAnimation = AnimationSelection{
+                    .mAnimatedRig = mAnimatedRig,
+                    .mAnimation = &rigAnimation,
+                };
+            }
+        }
+
+        ImGui::TreePop();
+    }
+}
+
+
 // When the main scene graph in our Model becomes a DOD NodeTree, this should be 
 // factorized with main traversal in presentNodeTree()
 void SceneGui::presentJointTree(const NodeTree<Rig::Pose> & aTree,
@@ -208,12 +234,14 @@ void SceneGui::presentObject(const Object & aObject)
         ImGui::TreePop();
     }
 
-    if(aObject.mRig != gNullHandle)
+    if(aObject.mAnimatedRig != gNullHandle)
     {
         // TODO I suspect this shared name is not ensuring unicity of the "RIG" node state.
         if(ImGui::TreeNodeEx("[Rig]", gBaseFlags))
         {
-            presentJointTree(aObject.mRig->mJointTree, aObject.mRig->mJointTree.mFirstRoot);
+            presentAnimations(aObject.mAnimatedRig);
+            presentJointTree(aObject.mAnimatedRig->mRig.mJointTree,
+                             aObject.mAnimatedRig->mRig.mJointTree.mFirstRoot);
             ImGui::TreePop();
         }
     }

--- a/src/apps/viewer/viewer/SceneGui.cpp
+++ b/src/apps/viewer/viewer/SceneGui.cpp
@@ -208,11 +208,12 @@ void SceneGui::presentObject(const Object & aObject)
         ImGui::TreePop();
     }
 
-    if(aObject.mRigTree != gNullHandle)
+    if(aObject.mRig != gNullHandle)
     {
+        // TODO I suspect this shared name is not ensuring unicity of the "RIG" node state.
         if(ImGui::TreeNodeEx("[Rig]", gBaseFlags))
         {
-            presentJointTree(*aObject.mRigTree, aObject.mRigTree->mFirstRoot) ;
+            presentJointTree(aObject.mRig->mJointTree, aObject.mRig->mJointTree.mFirstRoot);
             ImGui::TreePop();
         }
     }

--- a/src/apps/viewer/viewer/SceneGui.h
+++ b/src/apps/viewer/viewer/SceneGui.h
@@ -12,6 +12,8 @@ struct Scene;
 
 class SceneGui
 {
+    friend struct ViewerApplication;
+
 public:
     SceneGui(Handle<Effect> aHighlight, const Storage & aStorage) :
         mHighlightMaterial{
@@ -28,6 +30,7 @@ private:
     void presentObject(const Object & aObject);
     void presentEffect(Handle<const Effect> aEffect);
     void presentShaders(const IntrospectProgram & aIntrospectProgram);
+    void presentAnimations(Handle<AnimatedRig> mAnimatedRig);
     static void presentJointTree(const NodeTree<Rig::Pose> & aTree,
                                  NodeTree<Rig::Pose>::Node::Index aNodeIdx);
 
@@ -56,6 +59,14 @@ private:
     Node * mSelectedNode = nullptr;
     Node * mHighlightedNode = nullptr;
     const std::string * mSelectedShaderSource = nullptr;
+
+    struct AnimationSelection
+    {
+        // Note: Cannot be const, because we might animate the selected rig
+        // (which mutates in place the Rig's JointTree).
+        Handle</*const */AnimatedRig> mAnimatedRig = gNullHandle;
+        const RigAnimation * mAnimation = nullptr;
+    } mSelectedAnimation;
 
     Material mHighlightMaterial;
 

--- a/src/apps/viewer/viewer/SceneGui.h
+++ b/src/apps/viewer/viewer/SceneGui.h
@@ -28,6 +28,8 @@ private:
     void presentObject(const Object & aObject);
     void presentEffect(Handle<const Effect> aEffect);
     void presentShaders(const IntrospectProgram & aIntrospectProgram);
+    static void presentJointTree(const NodeTree<Rig::Pose> & aTree,
+                                 NodeTree<Rig::Pose>::Node::Index aNodeIdx);
 
     void presentSelection();
 

--- a/src/apps/viewer/viewer/TheGraph.cpp
+++ b/src/apps/viewer/viewer/TheGraph.cpp
@@ -172,7 +172,8 @@ TheGraph::TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
     mUbos{aStorage},
     mInstanceStream{makeInstanceStream(aStorage, gMaxDrawInstances)},
     mRenderSize{mGlfwAppInterface->getFramebufferSize()}, // TODO Ad 2023/11/28: Listen to framebuffer resize
-    mTransparencyResolver{aLoader.loadShader("shaders/TransparencyResolve.frag")}
+    mTransparencyResolver{aLoader.loadShader("shaders/TransparencyResolve.frag")},
+    mDebugRenderer{aStorage, aLoader}
 {
     graphics::allocateStorage(mDepthMap, GL_DEPTH_COMPONENT24, mRenderSize);
     [this](GLenum aFiltering)
@@ -285,6 +286,15 @@ void TheGraph::renderFrame(const PartList & aPartList, const Camera & aCamera, S
     showDepthTexture(mDepthMap, nearZ, farZ) ;
     showTexture(mTransparencyAccum, 1, {.mOperation = DrawQuadParameters::AccumNormalize}) ;
     showTexture(mTransparencyRevealage, 2, {.mSourceChannel = 0}) ;
+}
+
+
+void TheGraph::renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage)
+{
+    // Fullscreen viewport
+    glViewport(0, 0, mRenderSize.width(), mRenderSize.height());
+
+    mDebugRenderer.render(std::move(aDrawList), mUbos.mUboRepository, aStorage);
 }
 
 

--- a/src/apps/viewer/viewer/TheGraph.cpp
+++ b/src/apps/viewer/viewer/TheGraph.cpp
@@ -82,6 +82,11 @@ HardcodedUbos::HardcodedUbos(Storage & aStorage)
     aStorage.mUbos.emplace_back();
     mModelTransformUbo = &aStorage.mUbos.back();
     mUboRepository.emplace(semantic::gLocalToWorld, mModelTransformUbo);
+
+    // TODO #jointproto refactor
+    aStorage.mUbos.emplace_back();
+    mJointMatrixPalette = &aStorage.mUbos.back();
+    mUboRepository.emplace(semantic::gJointMatrices, mJointMatrixPalette);
 }
 
 
@@ -257,13 +262,19 @@ void TheGraph::loadDrawBuffers(const PartList & aPartList,
 }
 
 
-void TheGraph::renderFrame(const PartList & aPartList, const Camera & aCamera, Storage & aStorage)
+void TheGraph::renderFrame(const PartList & aPartList, 
+                           const Camera & aCamera,
+                           Storage & aStorage,
+                           std::span<const Rig::Pose> aJointMatrixPalette)
 {
     {
         PROFILER_SCOPE_RECURRING_SECTION("load_frame_UBOs", CpuTime, GpuTime, BufferMemoryWritten);
         loadFrameUbo(*mUbos.mFrameUbo);
         // Note in a more realistic application, several cameras would be used per frame.
         loadCameraUbo(*mUbos.mViewingUbo, aCamera);
+
+        // TODO #jointproto refactor
+        proto::load(*mUbos.mJointMatrixPalette, std::span{aJointMatrixPalette}, graphics::BufferHint::StaticDraw);
     }
 
     // Use the same indirect buffer for all drawings

--- a/src/apps/viewer/viewer/TheGraph.h
+++ b/src/apps/viewer/viewer/TheGraph.h
@@ -35,6 +35,9 @@ struct HardcodedUbos
     graphics::UniformBufferObject * mFrameUbo;
     graphics::UniformBufferObject * mViewingUbo;
     graphics::UniformBufferObject * mModelTransformUbo;
+
+    // TODO #jointproto refactor
+    graphics::UniformBufferObject * mJointMatrixPalette;
 };
 
 
@@ -45,7 +48,11 @@ struct TheGraph
              Storage & aStorage,
              const Loader & aLoader);
 
-    void renderFrame(const PartList & aPartList, const Camera & aCamera, Storage & aStorage);
+    void renderFrame(const PartList & aPartList, 
+                     const Camera & aCamera,
+                     Storage & aStorage,
+                     // TODO #jointproto the matrix palette should not be passed, need to define a proper API
+                     std::span<const Rig::Pose> aJointMatrixPalette);
 
     void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage);
 

--- a/src/apps/viewer/viewer/TheGraph.h
+++ b/src/apps/viewer/viewer/TheGraph.h
@@ -9,6 +9,7 @@
 
 #include <snac-renderer-V2/Model.h>
 #include <snac-renderer-V2/Repositories.h>
+#include <snac-renderer-V2/debug/DebugRenderer.h>
 
 
 namespace ad::renderer {
@@ -45,6 +46,8 @@ struct TheGraph
              const Loader & aLoader);
 
     void renderFrame(const PartList & aPartList, const Camera & aCamera, Storage & aStorage);
+
+    void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage);
 
     // Note: Storage cannot be const, as it might be modified to insert missing VAOs, etc
     void passOpaqueDepth(const PartList & aPartList, Storage & mStorage);
@@ -84,6 +87,9 @@ struct TheGraph
     QuadDrawer mTransparencyResolver;
     static const GLint gAccumTextureUnit{0};
     static const GLint gRevealageTextureUnit{1};
+
+    // Debug rendering
+    DebugRenderer mDebugRenderer;
 };
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -290,8 +290,8 @@ void registerGlfwCallbacks(graphics::AppInterface & aAppInterface,
 
 
 ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
-                         const std::filesystem::path & aSceneFile,
-                         const imguiui::ImguiUi & aImguiUi) :
+                                     const std::filesystem::path & aSceneFile,
+                                     const imguiui::ImguiUi & aImguiUi) :
     mGlfwAppInterface{std::move(aGlfwAppInterface)},
     // TODO How do we handle the dynamic nature of the number of instance that might be renderered?
     // At the moment, hardcode a maximum number
@@ -305,7 +305,15 @@ ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGl
     registerGlfwCallbacks(*mGlfwAppInterface, mCameraControl, EscKeyBehaviour::Close, &aImguiUi);
     registerGlfwCallbacks(*mGlfwAppInterface, mFirstPersonControl, EscKeyBehaviour::Close, &aImguiUi);
 
-    mScene = loadScene(aSceneFile, mGraph.mInstanceStream, mLoader, mStorage);
+    if(aSceneFile.extension() == ".sew")
+    {
+        mScene = loadScene(aSceneFile, mGraph.mInstanceStream, mLoader, mStorage);
+    }
+    else
+    {
+        throw std::invalid_argument{"Unsupported filetype: " + aSceneFile.extension().string()};
+    }
+
     /*const*/Node & model = mScene.mRoot.mChildren.front();
 
     // TODO Ad 2023/10/03: Sort out this bit of logic: remove hardcoded sections,
@@ -342,10 +350,10 @@ ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGl
     }
 
     // Add basic shapes to the the scene
-    Handle<Effect> simpleEffect = makeSimpleEffect(mStorage);
-    auto [triangle, cube] = loadTriangleAndCube(mStorage, simpleEffect, mGraph.mInstanceStream);
-    mScene.addToRoot(triangle);
-    mScene.addToRoot(cube);
+    //Handle<Effect> simpleEffect = makeSimpleEffect(mStorage);
+    //auto [triangle, cube] = loadTriangleAndCube(mStorage, simpleEffect, mGraph.mInstanceStream);
+    //mScene.addToRoot(triangle);
+    //mScene.addToRoot(cube);
 }
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -21,7 +21,6 @@
 #include <snac-renderer-V2/Profiling.h>
 
 // TODO #nvtx This should be handled cleanly by the profiler
-#define NOMINMAX
 #include "../../../libs/snac-renderer-V1/snac-renderer-V1/3rdparty/nvtx/include/nvtx3/nvtx3.hpp"
 
 #include <array>

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -23,6 +23,23 @@ namespace ad::renderer {
 struct PassCache;
 
 
+// TODO Ad 2024/03/07: Use an integral count of ticks?
+// This could be much better for timepoints.
+// (from rough calculations, chosing a tick of 10µs allows to represent > 150 years in 64bits)
+struct Timing
+{
+    float mDeltaDuration{0};
+    double mSimulationTimepoint{0};
+
+    Timing & advance(float aDelta)
+    {
+        mSimulationTimepoint += aDelta;
+        mDeltaDuration = aDelta;
+        return *this;
+    }
+};
+
+
 struct ViewerApplication
 {
     ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
@@ -30,7 +47,7 @@ struct ViewerApplication
                 const imguiui::ImguiUi & aImguiUi);
 
     // for camera movements, should be moved out to the simuation of course
-    void update(float aDeltaTime);
+    void update(const Timing & aTime);
     void render();
 
     void drawUi();

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -57,7 +57,7 @@ void showGui(imguiui::ImguiUi & imguiUi,
 
     ImGui::Begin("Main control");
     {
-        static bool showProfiler = true;
+        static bool showProfiler = false;
         if(imguiui::addCheckbox("Profiler", showProfiler))
         {
             ImGui::Begin("Profiler");

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -4,11 +4,16 @@
 #include <build_info.h>
 
 #include <graphics/ApplicationGlfw.h>
+
 #include <imguiui/ImguiUi.h>
 #include <imguiui/Widgets.h>
+
 #include <profiler/GlApi.h>
 #include <profiler/Profiler.h> // Internals are used to measure frame duration
+
+#include <snac-renderer-V2/Debug/DebugDrawing.h>
 #include <snac-renderer-V2/Profiling.h>
+
 #include <utilities/Time.h>
 
 #include <iostream>
@@ -98,6 +103,8 @@ void showGui(imguiui::ImguiUi & imguiUi,
 void runApplication(int argc, char * argv[])
 {
     SELOG(info)("Starting application '{}'.", gApplicationName);
+
+    renderer::initializeDebugDrawers();
 
     // Application and window initialization
     graphics::ApplicationFlag glfwFlags = graphics::ApplicationFlag::None;

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -132,6 +132,8 @@ void runApplication(int argc, char * argv[])
     };
     PROFILER_POP_SECTION(loadingSection);
 
+    renderer::Timing timing;
+
     renderer::Profiler::Values<std::uint64_t> frameDuration;
     Clock::time_point previousFrame = Clock::now();
     using FrameDurationUnit = std::chrono::microseconds;
@@ -168,7 +170,7 @@ void runApplication(int argc, char * argv[])
             }
         }
 
-        application.update(stepDuration);
+        application.update(timing.advance(stepDuration));
         application.render();
 
         // TODO Ad 2023/08/22: With this structure, it is showing the profile from previous frame

--- a/src/libs/profiler/profiler/CMakeLists.txt
+++ b/src/libs/profiler/profiler/CMakeLists.txt
@@ -50,6 +50,7 @@ if(MSVC)
     # Otherwise big object files might error with:
     # "fatal  error C1128: number of sections exceeded object file format limit: compile with /bigobj"
     target_compile_options(${TARGET_NAME} PRIVATE "/bigobj")
+    target_compile_definitions(${TARGET_NAME} PUBLIC NOMINMAX)
 endif()
 
 cmc_target_current_include_directory(${TARGET_NAME})

--- a/src/libs/profiler/profiler/GlApi.h
+++ b/src/libs/profiler/profiler/GlApi.h
@@ -40,6 +40,8 @@ public:
     void BufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
     void Clear(GLbitfield mask);
     void DrawElements(GLenum mode, GLsizei count, GLenum type, const void *indices);
+    void DrawElementsInstanced(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount);
+    void DrawElementsInstancedBaseVertex(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLint basevertex);
     void MultiDrawElementsIndirect(GLenum mode, GLenum type, const void *indirect, GLsizei drawcount, GLsizei stride);
     void TexStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
     void TexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *pixels);
@@ -114,6 +116,24 @@ inline void GlApi::DrawElements(GLenum mode, GLsizei count, GLenum type, const v
     ++v().mDrawCount;
 #endif
     return glDrawElements(mode, count, type, indices);
+}
+
+
+inline void GlApi::DrawElementsInstanced(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount)
+{
+#if defined(SE_INSTRUMENT_GL)
+    ++v().mDrawCount;
+#endif
+    return glDrawElementsInstanced(mode, count, type, indices, instancecount);
+}
+
+
+inline void GlApi::DrawElementsInstancedBaseVertex(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount, GLint basevertex)
+{
+#if defined(SE_INSTRUMENT_GL)
+    ++v().mDrawCount;
+#endif
+    return glDrawElementsInstancedBaseVertex(mode, count, type, indices, instancecount, basevertex);
 }
 
 

--- a/src/libs/profiler/profiler/GlApi.h
+++ b/src/libs/profiler/profiler/GlApi.h
@@ -39,6 +39,7 @@ public:
     void BufferData(GLenum target, GLsizeiptr size, const void *data, GLenum usage);
     void BufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, const void *data);
     void Clear(GLbitfield mask);
+    void DrawElements(GLenum mode, GLsizei count, GLenum type, const void *indices);
     void MultiDrawElementsIndirect(GLenum mode, GLenum type, const void *indirect, GLsizei drawcount, GLsizei stride);
     void TexStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
     void TexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *pixels);
@@ -104,6 +105,15 @@ inline void GlApi::BufferSubData(GLenum target, GLintptr offset, GLsizeiptr size
 inline void GlApi::Clear(GLbitfield mask)
 {
     glClear(mask);
+}
+
+
+inline void GlApi::DrawElements(GLenum mode, GLsizei count, GLenum type, const void *indices)
+{
+#if defined(SE_INSTRUMENT_GL)
+    ++v().mDrawCount;
+#endif
+    return glDrawElements(mode, count, type, indices);
 }
 
 

--- a/src/libs/profiler/profiler/ProfilerSeattle.h
+++ b/src/libs/profiler/profiler/ProfilerSeattle.h
@@ -3,7 +3,6 @@
 
 #define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN 
-#define NOMINMAX
 #include <Windows.h>
 
 

--- a/src/libs/profiler/profiler/providers/ProviderWindows.cpp
+++ b/src/libs/profiler/profiler/providers/ProviderWindows.cpp
@@ -3,7 +3,6 @@
 
 #define VC_EXTRALEAN
 #define WIN32_LEAN_AND_MEAN 
-#define NOMINMAX
 #include <Windows.h>
 
 #include <cassert>

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/Instances.h
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/Instances.h
@@ -23,7 +23,7 @@ struct PoseColor
 
 struct PoseColorSkeleton
 {
-    math::Matrix<4, 4, float> pose;
+    math::AffineMatrix<4, float> pose;
     math::sdr::Rgba albedo;
     GLuint matrixPaletteOffset; // offset to the first joint of this instance in the buffer of joints.
 };

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/Rigging.h
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/Rigging.h
@@ -64,7 +64,7 @@ struct NodeTree
 // TODO rename (clarify the fact it is not the animation of just a single node)
 struct NodeAnimation
 {
-    // TODO #anim hosting the NodeTree in the Rig instanc" is a problem,
+    // TODO #anim hosting the NodeTree in the Rig instance is a problem,
     // notably because this function mutates the node tree directly.
     // see also todo (a48c8) 
     // Maybe the Rig should host a read only hierarchy (no transformation) of joints (no whole scene)
@@ -73,6 +73,7 @@ struct NodeAnimation
 
     // The sequence of node indices that are animated.
     // (This is the order in which node pose data is provided.)
+    // Note: these are the indices of node entries in animate()'s `aNodeTree`.
     std::vector<Node::Index> mNodes;
 
     // Ideally, keyframes would be on a constant period, instead of an of time points.

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/Mesh.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/Mesh.sefx
@@ -1,9 +1,6 @@
 {
     "techniques": [
         {
-            "annotations": {
-                "pass": "forward"
-            },
             "programfile": "shaders/PhongLightingVertexColor.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/Mesh.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/Mesh.sefx
@@ -1,6 +1,9 @@
 {
     "techniques": [
         {
+            "annotations": {
+                "pass": "forward"
+            },
             "programfile": "shaders/PhongLightingVertexColor.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshRigging.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshRigging.sefx
@@ -1,6 +1,9 @@
 {
     "techniques": [
         {
+            "annotations": {
+                "pass": "forward"
+            },
             "programfile": "shaders/PhongLightingVertexColorRigging.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshRiggingTextures.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshRiggingTextures.sefx
@@ -1,6 +1,9 @@
 {
     "techniques": [
         {
+            "annotations": {
+                "pass": "forward"
+            },
             "programfile": "shaders/PhongLightingVertexColorRiggingTextures.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshRiggingTextures.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshRiggingTextures.sefx
@@ -1,9 +1,6 @@
 {
     "techniques": [
         {
-            "annotations": {
-                "pass": "forward"
-            },
             "programfile": "shaders/PhongLightingVertexColorRiggingTextures.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshTextures.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshTextures.sefx
@@ -1,9 +1,6 @@
 {
     "techniques": [
         {
-            "annotations": {
-                "pass": "forward"
-            },
             "programfile": "shaders/PhongLightingTextures.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshTextures.sefx
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/effects/MeshTextures.sefx
@@ -1,6 +1,9 @@
 {
     "techniques": [
         {
+            "annotations": {
+                "pass": "forward"
+            },
             "programfile": "shaders/PhongLightingTextures.prog"
         },
         {

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.frag
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.frag
@@ -5,7 +5,7 @@
 in vec3 ex_Position_c;
 in vec3 ex_Normal_c;
 in vec4 ex_Tangent_c;
-in vec4 ex_ColorFactor;
+in vec4 ex_BaseColorFactor;
 
 in flat uint ex_MaterialIdx;
 
@@ -13,15 +13,19 @@ in flat uint ex_MaterialIdx;
 in vec2[2] ex_TextureCoords;
 #endif
 
-in vec4 ex_Albedo;
+in vec4 ex_Color;
 
 #ifdef SHADOW
 in vec4 ex_Position_lightClip;
 #endif
 
-uniform vec3 u_LightPosition_c;
-uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8);
+// Traditionnally, a single term accounting for all lights in the scene
 uniform vec3 u_AmbientColor = vec3(0.2, 0.0, 0.2);
+
+// Per-light data
+uniform vec3 u_LightPosition_c;
+uniform vec3 u_LightColor = vec3(0.8, 0.0, 0.8); // could be split between diffuse and specular itensities
+
 #ifdef TEXTURES
 uniform uint u_BaseColorUVIndex;
 uniform uint u_NormalUVIndex;
@@ -50,9 +54,10 @@ float getShadowAttenuation(vec4 fragPosition_lightClip, float bias)
 
 struct PhongMaterial
 {
-    vec4 ambientColor;
-    vec4 diffuseColor;
-    vec4 specularColor;
+    // Notes: here, the 3 colors of the Phong material are really used as reflection factors.
+    vec4 ambientFactor;
+    vec4 diffuseFactor;
+    vec4 specularFactor;
     uint textureIndex;
     uint diffuseUvChannel;
     float specularExponent;
@@ -72,20 +77,24 @@ void main(void)
     PhongMaterial material = ub_Phong[ex_MaterialIdx];
 
     // Everything in camera space
+    const vec3 view_c = vec3(0., 0., 1.);
     vec3 light_c = normalize(u_LightPosition_c - ex_Position_c);
-    vec3 view_c = vec3(0., 0., 1.);
     vec3 h_c = normalize(view_c + light_c);
     
-    float specularExponent = 32;
-
-    vec4 color = 
-        ex_ColorFactor 
+    vec4 albedo = 
+        ex_Color
+        * ex_BaseColorFactor // Note: should probably go away
 #ifdef TEXTURES
         * texture(u_BaseColorTexture, ex_TextureCoords[u_BaseColorUVIndex])
 #endif
-        * ex_Albedo
-        // TODO #RV2 Actually port the whole material model
-        * material.diffuseColor;
+        ;
+
+    // TODO: enable alpha testing (atm)
+    // Implement "cut-out" transparency: everything below 50% opacity is discarded (i.e. no depth write).
+    //if(albedo.a < 0.5)
+    //{
+    //    discard;
+    //}
     
     //
     // Compute the fragment normal
@@ -116,23 +125,25 @@ void main(void)
     // Phong illumination
     //
     vec3 ambient = 
-        u_AmbientColor;
+        u_AmbientColor * material.ambientFactor.xyz;
     vec3 diffuse =
-        u_LightColor * max(0.f, dot(normal_c, light_c));
+        u_LightColor * max(0.f, dot(normal_c, light_c))
+        * material.diffuseFactor.xyz;
     vec3 specular = 
-        u_LightColor * pow(max(0.f, dot(normal_c, h_c)), specularExponent);
+        u_LightColor * pow(max(0.f, dot(normal_c, h_c)), material.specularExponent)
+        * material.specularFactor.xyz;
 
 #ifdef SHADOW
         float bias = max(8 * (1 - dot(normalize(ex_Normal_c), light_c)), 1) * u_ShadowBias;
     vec3 phongColor = 
-        (ambient + (diffuse + specular) * getShadowAttenuation(ex_Position_lightClip, bias)) * color.xyz;
+        (ambient + (diffuse + specular) * getShadowAttenuation(ex_Position_lightClip, bias)) * albedo.rgb;
 #else
     vec3 phongColor = 
-        (ambient + diffuse + specular) * color.xyz;
+        (ambient + diffuse + specular) * albedo.rgb;
 #endif
 
     //
     // Gamma correction
     //
-    out_Color = correctGamma(vec4(phongColor, color.w));
+    out_Color = correctGamma(vec4(phongColor, albedo.a));
 }

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
@@ -12,6 +12,7 @@ in vec2 ve_TextureCoords1;
 // We need a default value of [1, 1, 1, 1], not [0, 0, 0, 1]
 // Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
 // At the moment, export our models with a white albedo on vertices by default.
+// Note: It could either be a vertex color, or an instance color (ve_ or in_).
 in vec4 a_Color_normalized;
 
 #ifdef RIGGING
@@ -35,7 +36,7 @@ layout(std140, binding = 0) uniform ViewProjectionBlock
 uniform mat4 u_LightViewingMatrix;
 #endif
 
-// TODO #RV2 remove I guess?
+// TODO #RV2 remove I guess? This is inherited from the times of gltf PBR material
 // How do we handle per player color variations?
 uniform vec4 u_BaseColorFactor = vec4(1., 1., 1., 1.);
 
@@ -43,14 +44,14 @@ uniform vec4 u_BaseColorFactor = vec4(1., 1., 1., 1.);
 out vec3 ex_Position_c;
 out vec3 ex_Normal_c;
 out vec4 ex_Tangent_c;
-out vec4 ex_ColorFactor;
+out vec4 ex_BaseColorFactor;
 out flat uint ex_MaterialIdx;
 
 #ifdef TEXTURES
 out vec2[2] ex_TextureCoords;
 #endif
 
-out vec4 ex_Albedo;
+out vec4 ex_Color;
 
 #ifdef SHADOW
 out vec4 ex_Position_lightClip;
@@ -75,11 +76,11 @@ void main(void)
     // see: https://www.pbr-book.org/3ed-2018/Geometry_and_Transformations/Applying_Transformations
     ex_Tangent_c = vec4(mat3(localToCamera) * ve_Tangent_l.xyz, ve_Tangent_l.w);
 
-    ex_ColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;
+    ex_BaseColorFactor  = u_BaseColorFactor /* TODO multiply by vertex color, when enabled */;
 #ifdef TEXTURES
     ex_TextureCoords = vec2[](ve_TextureCoords0, ve_TextureCoords1);
 #endif
-    ex_Albedo = a_Color_normalized;
+    ex_Color = a_Color_normalized;
     ex_MaterialIdx = in_MaterialIdx;
 
 #ifdef SHADOW

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
@@ -12,7 +12,7 @@ in vec2 ve_TextureCoords1;
 // We need a default value of [1, 1, 1, 1], not [0, 0, 0, 1]
 // Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
 // At the moment, export our models with a white albedo on vertices by default.
-in vec4 in_Albedo_normalized;
+in vec4 a_Color_normalized;
 
 #ifdef RIGGING
 #include "Rigging.glsl"
@@ -21,6 +21,7 @@ in vec4 in_Albedo_normalized;
 in mat4 in_LocalToWorld;
 // Will be required to support non-uniform scaling.
 //layout(location=10) in mat4 in_LocalToWorldInverseTranspose;
+in uint in_MaterialIdx;
 
 // WARNING: for some reason, the GLSL compiler assigns the same implicit binding
 // index to both uniform blocks if we do not set it explicitly.
@@ -34,6 +35,8 @@ layout(std140, binding = 0) uniform ViewProjectionBlock
 uniform mat4 u_LightViewingMatrix;
 #endif
 
+// TODO #RV2 remove I guess?
+// How do we handle per player color variations?
 uniform vec4 u_BaseColorFactor = vec4(1., 1., 1., 1.);
 
 // TODO change _c to _cam
@@ -41,6 +44,7 @@ out vec3 ex_Position_c;
 out vec3 ex_Normal_c;
 out vec4 ex_Tangent_c;
 out vec4 ex_ColorFactor;
+out flat uint ex_MaterialIdx;
 
 #ifdef TEXTURES
 out vec2[2] ex_TextureCoords;
@@ -75,7 +79,8 @@ void main(void)
 #ifdef TEXTURES
     ex_TextureCoords = vec2[](ve_TextureCoords0, ve_TextureCoords1);
 #endif
-    ex_Albedo = in_Albedo_normalized;
+    ex_Albedo = a_Color_normalized;
+    ex_MaterialIdx = in_MaterialIdx;
 
 #ifdef SHADOW
     ex_Position_lightClip = u_LightViewingMatrix * localToWorld * vec4(ve_Position_l, 1.f);

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
@@ -12,7 +12,7 @@ in vec2 ve_TextureCoords1;
 // We need a default value of [1, 1, 1, 1], not [0, 0, 0, 1]
 // Could be addressed via: https://www.khronos.org/opengl/wiki/Vertex_Specification#Non-array_attribute_values
 // At the moment, export our models with a white albedo on vertices by default.
-in vec4 in_Albedo;
+in vec4 in_Albedo_normalized;
 
 #ifdef RIGGING
 #include "Rigging.glsl"
@@ -24,7 +24,7 @@ in mat4 in_LocalToWorld;
 
 // WARNING: for some reason, the GLSL compiler assigns the same implicit binding
 // index to both uniform blocks if we do not set it explicitly.
-layout(std140, binding = 0) uniform ViewingBlock
+layout(std140, binding = 0) uniform ViewProjectionBlock
 {
     mat4 u_WorldToCamera;
     mat4 u_Projection;
@@ -55,8 +55,7 @@ out vec4 ex_Position_lightClip;
 void main(void)
 {
     mat4 localToWorld =
-        mat4(1.0)
-        //in_LocalToWorld
+        in_LocalToWorld
 #ifdef RIGGING
         * assembleSkinningMatrix()
 #endif
@@ -76,7 +75,7 @@ void main(void)
 #ifdef TEXTURES
     ex_TextureCoords = vec2[](ve_TextureCoords0, ve_TextureCoords1);
 #endif
-    ex_Albedo = in_Albedo;
+    ex_Albedo = in_Albedo_normalized;
 
 #ifdef SHADOW
     ex_Position_lightClip = u_LightViewingMatrix * localToWorld * vec4(ve_Position_l, 1.f);

--- a/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
+++ b/src/libs/snac-renderer-V1/snac-renderer-V1/shaders/PhongLighting.vert
@@ -54,8 +54,9 @@ out vec4 ex_Position_lightClip;
 
 void main(void)
 {
-    mat4 localToWorld = 
-        in_LocalToWorld
+    mat4 localToWorld =
+        mat4(1.0)
+        //in_LocalToWorld
 #ifdef RIGGING
         * assembleSkinningMatrix()
 #endif

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
@@ -30,6 +30,7 @@ set(${TARGET_NAME}_SOURCES
     Camera.cpp
     IntrospectProgram.cpp
     Logging-init.cpp
+    Model.cpp
     Pass.cpp
     Profiling.cpp
     Rigging.cpp

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
@@ -18,6 +18,9 @@ set(${TARGET_NAME}_HEADERS
     Semantics.h
     SetupDrawing.h
 
+    debug/DebugDrawing.h
+    debug/DebugRenderer.h
+
     files/Flags.h
     files/BinaryArchive.h
     files/Loader.h
@@ -31,6 +34,9 @@ set(${TARGET_NAME}_SOURCES
     Profiling.cpp
     Rigging.cpp
     SetupDrawing.cpp
+
+    debug/DebugDrawing.cpp
+    debug/DebugRenderer.cpp
 
     files/Loader.cpp
 )
@@ -76,6 +82,9 @@ cmc_cpp_sanitizer(${TARGET_NAME} ${BUILD_CONF_Sanitizer})
 target_link_libraries(${TARGET_NAME}
     PUBLIC
         ad::resource
+
+        #TODO Remove this! Currently needed for the debug drawer
+        ad::snac-renderer-V1
     PRIVATE
         ad::graphics
         ad::math

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
@@ -17,6 +17,7 @@ set(${TARGET_NAME}_HEADERS
     Semantics.h
     SetupDrawing.h
 
+    files/Flags.h
     files/BinaryArchive.h
     files/Loader.h
 )

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/CMakeLists.txt
@@ -14,6 +14,7 @@ set(${TARGET_NAME}_HEADERS
     Profiling.h
     RendererReimplement.h
     Repositories.h
+    Rigging.h
     Semantics.h
     SetupDrawing.h
 
@@ -28,6 +29,7 @@ set(${TARGET_NAME}_SOURCES
     Logging-init.cpp
     Pass.cpp
     Profiling.cpp
+    Rigging.cpp
     SetupDrawing.cpp
 
     files/Loader.cpp

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Camera.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Camera.h
@@ -74,7 +74,8 @@ std::pair<float/*near*/, float/*far*/> getNearFarPlanes(const Camera & aCamera);
 /// and looking toward the orbit origin.
 struct Orbital
 {
-    Orbital(float aRadius, math::Radian<float> aPolar = math::Degree<float>{90.f},
+    Orbital(float aRadius,
+            math::Radian<float> aPolar = math::Degree<float>{90.f},
             math::Radian<float> aAzimuthal = math::Radian<float>{0.f},
             math::Position<3, float> aPosition = {0.f, 0.f, 0.f}) :
         mSpherical{aRadius, aPolar, aAzimuthal}
@@ -100,6 +101,9 @@ struct Orbital
 //TODO Ad 2023/07/27: 
 // This should be abstracted away from being used purely for rendering cameras, removing
 // knowledge of window size and vertical FOV. Yet this cause au complication for _panning_ movements.
+
+// TODO Ad 2024/02/16:
+// OrbitalControl should be renamed and become a glfw-callback wrapper around some "OrbitalControl_raw".
 
 /// @brief Controls an Orbital position with mouse movements (movements of an usual orbital camera).
 struct OrbitalControl

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/IntrospectProgram.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/IntrospectProgram.cpp
@@ -275,6 +275,9 @@ IntrospectProgram::IntrospectProgram(graphics::Program aProgram, std::string aNa
         // there tends to be a lot of collisions.
         // TODO Understand why, unlike for generic vertex attributes, automatic indices
         // are not working for uniform blocks.
+        // TODO Ad 2024/02/22: Anyway, it seems what we might do is algorithmically
+        // assign distinct indices to the blocks, instead of hardcoding values.
+        // (and by being clever, we could minimize the need to change the buffer binding indices client side)
         
         [[maybe_unused]] // Otherwise clang complains that this variable is unused in release builds
         auto checkDuplicateIndex = [](const std::vector<UniformBlock> & aBlocks) -> bool

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/IntrospectProgram.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/IntrospectProgram.cpp
@@ -167,7 +167,7 @@ namespace {
         std::string_view prefix, body, suffix;
         std::tie(prefix, body) = lsplit(aResourceName, delimiter);
         std::tie(body, suffix) = lsplit(body, delimiter);
-        return suffix.starts_with("_normalized");
+        return suffix.starts_with("normalized");
     }
 
 } // anonymous

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Material.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Material.h
@@ -11,7 +11,11 @@ struct TextureInput
     using Index = unsigned int;
     inline static constexpr Index gNoEntry = std::numeric_limits<Index>::max();
 
-    Index mTextureIndex = gNoEntry; // Index of the texture in storage. Maybe could be the texture name directly.
+    // NOTE Ad 2024/02/21: If one day we go with bindless textures, this should probably become
+    //   the "address" of a plain TEXTURE_2D 
+    //   (since we would not have to assemble several logical textures in a common TEXTURE_2D_ARRAY)
+    Index mTextureIndex = gNoEntry; // Index of the texture in the TEXTURE_2D_ARRAY.
+
     Index mUVAttributeIndex = gNoEntry;
 };
 
@@ -25,6 +29,7 @@ struct alignas(16) PhongMaterial
     math::hdr::Rgba<float> mDiffuseColor  = math::hdr::gWhite<float>;
     math::hdr::Rgba<float> mSpecularColor = math::hdr::gWhite<float>;
     TextureInput mDiffuseMap; 
+    TextureInput mNormalMap; 
     float mSpecularExponent = 1.f;
 };
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.cpp
@@ -1,0 +1,15 @@
+#include "Model.h"
+
+#include <math/Transformations.h>
+
+
+namespace ad::renderer {
+
+
+Pose::operator math::AffineMatrix<4, float> () const
+{
+    return math::trans3d::scaleUniform(mUniformScale) * math::trans3d::translate(mPosition);
+}
+
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -5,6 +5,7 @@
 #include "IntrospectProgram.h" 
 #include "Material.h"
 #include "Repositories.h"
+#include "Rigging.h"
 
 #include <renderer/Texture.h>
 #include <renderer/UniformBuffer.h>
@@ -213,6 +214,9 @@ struct Object
 {
     std::vector<Part> mParts;
     math::Box<GLfloat> mAabb;
+    // TODO #RV2 animation should actually store rigs
+    //Handle<Rig> mRig = gNullHandle;
+    Handle<NodeTree<Rig::Pose>> mRigTree = gNullHandle;
 };
 
 
@@ -281,6 +285,8 @@ struct Storage
     std::list<MaterialContext> mMaterialContexts;
     // Used for random access (DOD)
     std::vector<Name> mMaterialNames{"<no-material>",}; // This is a hack, so the name at index zero can be used when there are no material parameters
+    // TODO #RV2 animation should actually store rigs
+    std::list<NodeTree<Rig::Pose>> mRigs;
 };
 
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -252,6 +252,8 @@ struct Pose
         aNested.mUniformScale *= mUniformScale;
         return aNested;
     }
+
+    explicit operator math::AffineMatrix<4, float> () const;
 };
 
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -50,6 +50,7 @@ static constexpr auto gNullHandle = nullptr;
 // This offset in implemented by the Part m*First and m*Count members.
 struct BufferView
 {
+    // TODO Ad 2024/03/05: This should probably be a direct GL name (probably via a Handle), not a pointer.
     graphics::BufferAny * mGLBuffer;
     // The stride is at the view level (not buffer).
     // This way the buffer can store heterogeneous sections, accessed by distinct views.
@@ -232,9 +233,7 @@ struct Object
 {
     std::vector<Part> mParts;
     math::Box<GLfloat> mAabb;
-    // TODO #RV2 animation should actually store rigs
-    //Handle<Rig> mRig = gNullHandle;
-    Handle<NodeTree<Rig::Pose>> mRigTree = gNullHandle;
+    Handle<Rig> mRig = gNullHandle;
 };
 
 
@@ -303,8 +302,7 @@ struct Storage
     std::list<MaterialContext> mMaterialContexts;
     // Used for random access (DOD)
     std::vector<Name> mMaterialNames{"<no-material>",}; // This is a hack, so the name at index zero can be used when there are no material parameters
-    // TODO #RV2 animation should actually store rigs
-    std::list<NodeTree<Rig::Pose>> mRigs;
+    std::list<Rig> mRigs;
 };
 
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -81,8 +81,8 @@ struct ProgramConfig
         // TODO: When moving to VAB (separate format), reuse the VAO for distinct buffers
         // all buffer sets with the same format (attribute size, component type, relative offset) can share a VAO.
         // (and the buffer would be bound to the VAO)
-        Handle<const VertexStream> mVertexStream;
-        Handle<graphics::VertexArrayObject> mVao;
+        Handle<const VertexStream> mVertexStream; // The lookup key
+        Handle<graphics::VertexArrayObject> mVao; // The cached VAO
     };
     // Note: The cache is implemented as a vector, lookup is made by visiting elements and comparing VertexStream handles.
     std::vector<Entry> mEntries;
@@ -125,6 +125,9 @@ struct Effect
 struct MaterialContext
 {
     RepositoryUbo mUboRepo;
+
+    // Probably would become useless if we went down the bindless-textures route.
+    // (i.e. the variance in MaterialContext would get lower, which means less context changes == better at AZDO)
     RepositoryTexture mTextureRepo;
 };
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -233,7 +233,7 @@ struct Object
 {
     std::vector<Part> mParts;
     math::Box<GLfloat> mAabb;
-    Handle<Rig> mRig = gNullHandle;
+    Handle<AnimatedRig> mAnimatedRig = gNullHandle;
 };
 
 
@@ -304,7 +304,7 @@ struct Storage
     std::list<MaterialContext> mMaterialContexts;
     // Used for random access (DOD)
     std::vector<Name> mMaterialNames{"<no-material>",}; // This is a hack, so the name at index zero can be used when there are no material parameters
-    std::list<Rig> mRigs;
+    std::list<AnimatedRig> mAnimatedRigs;
 };
 
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -138,6 +138,9 @@ struct Material
     // later on, it should allow for different types of parameters (that will have to match the different shader program expectations)
     // TODO Ad 2023/10/12: Review how this index is passed: we should make that generic so materials can index into
     // user defined buffers easily, not hardcoding Phong model. 
+    //   Note: The MaterialContext could be used to point to the "SurfaceProperties" array (UBO) applied to this material
+    //         (each array might be of a different type of SurfaceProperty)
+    //          Then the index would index into this array.
     // (The material context is already generic, so complete the job)
     std::size_t mPhongMaterialIdx = (std::size_t)-1;
 
@@ -243,6 +246,11 @@ struct Instance
 };
 
 
+// Note: (#flaw_593) A complication with this design is in the presence of a Node which has geometry 
+//       (i.e. non null Object*) and also children.
+//       If clients are expected to provide a list of Instances, it means they need to 
+//       visit the hierarchy to provide the distinct Instances-with-Object in the sub-tree.
+//       It also potentially means that distinct "nested" objects could use the same rig / animation state.
 struct Node
 {
     Instance mInstance;

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Model.h
@@ -186,6 +186,24 @@ struct VertexStream /*: public SemanticBufferViews*/
 
 #undef SEMANTIC_BUFFER_MEMBERS
 
+/// @brief Helper to retrieve the `BufferView` associated to a `Semantic`
+/// @attention I am not convinced this is a good idea to provide such methods,
+/// since clients should probably cache this info (not really on calling this each frame).
+inline const renderer::BufferView & getBufferView(const VertexStream & aVertexStream,
+                                                  Semantic aSemantic)
+{
+    return aVertexStream.mVertexBufferViews[
+        aVertexStream.mSemanticToAttribute.at(aSemantic).mBufferViewIndex];
+}
+
+
+inline const renderer::BufferView & getBufferView(const GenericStream & aStream,
+                                                  Semantic aSemantic)
+{
+    return aStream.mVertexBufferViews[
+        aStream.mSemanticToAttribute.at(aSemantic).mBufferViewIndex];
+}
+
 //// TODO might be better as a binary flag, but this still should allow for user extension
 //// (anyway, feature order should not be important)
 //using FeatureSet = std::set<Feature>;

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Pass.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Pass.h
@@ -70,9 +70,21 @@ struct PassCache
 };
 
 
+// 
+// High level API
+//
 PassCache preparePass(StringKey aPass,
                       const PartList & aPartList,
                       Storage & aStorage);
 
+
+//
+// Low level API
+//
+Handle<ConfiguredProgram> getProgramForPass(const Effect & aEffect, StringKey aPassName);
+
+Handle<graphics::VertexArrayObject> getVao(const ConfiguredProgram & aProgram,
+                                           const Part & aPart,
+                                           Storage & aStorage);
 
 } // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.cpp
@@ -1,10 +1,105 @@
 #include "Rigging.h"
 
+#include <math/Transformations.h>
+#include <math/Interpolation/QuaternionInterpolation.h>
+
 
 namespace ad::renderer {
 
 
+namespace {
 
+    math::AffineMatrix<4, float> computeInterpolatedMatrix(
+        const RigAnimation::NodeKeyframes & aKeyframes,
+        std::size_t aPreviousStep, std::size_t aNextStep,
+        float aInterpolant)
+    {
+        return 
+            math::trans3d::scale(
+                math::lerp(aKeyframes.mScales[aPreviousStep].as<math::Size>(),
+                           aKeyframes.mScales[aNextStep].as<math::Size>(),
+                           aInterpolant))
+            * math::slerp(aKeyframes.mRotations[aPreviousStep],
+                          aKeyframes.mRotations[aNextStep],
+                          aInterpolant).toRotationMatrix()
+            * math::trans3d::translate(
+                math::lerp(aKeyframes.mTranslations[aPreviousStep],
+                           aKeyframes.mTranslations[aNextStep],
+                           aInterpolant))
+            ;
+    }
+
+} // unnamed namespace
+
+
+void animate(const RigAnimation & aAnimation, float aTimepoint, NodeTree<Rig::Pose> & aAnimatedTree)
+{
+    using Node = NodeTree<Rig::Pose>::Node;
+
+    const auto & timepoints = aAnimation.mTimepoints;
+    assert(!timepoints.empty());
+
+    //
+    // Find the indices of the timepoints around the current time,
+    // and the interpolation value.
+    //
+    auto timepointAfter =
+        std::find_if(timepoints.begin(), timepoints.end(),
+                     [aTimepoint](float aTime){return aTime > aTimepoint;});
+    
+    std::size_t previousIdx, nextIdx;
+    float interpolant = 0.f;
+    if (timepointAfter == timepoints.begin())
+    {
+        previousIdx = nextIdx = 0;
+    }
+    else if(timepointAfter == timepoints.end())
+    {
+        previousIdx = nextIdx = timepoints.size() - 1;
+    }
+    else
+    {
+        nextIdx = timepointAfter - timepoints.begin();
+        previousIdx = nextIdx - 1;
+        interpolant = (aTimepoint - timepoints[previousIdx]) 
+                       / (*timepointAfter - timepoints[previousIdx]);
+    }
+
+    //
+    // Compute the new local pose of each animated node
+    // (Important: This might only touch a subset of the bone hierarchy,
+    //  since an animation does not have to touch all bones)
+    //
+    const auto & nodes = aAnimation.mNodes;
+    // Note: The joint index is the index in the RigAnimation list of joints.
+    // This will be different from the node index in the NodeTree hierarchy, 
+    // this hierarchy index is looked up in RigAnimation.mNodes.
+    for(std::size_t jointIdx = 0; jointIdx != nodes.size(); ++jointIdx)
+    {
+        Node::Index hierarchyIdx = nodes[jointIdx];
+        const RigAnimation::NodeKeyframes & keyframes = aAnimation.mKeyframes[jointIdx];
+
+        aAnimatedTree.mLocalPose[hierarchyIdx] = 
+            computeInterpolatedMatrix(keyframes, previousIdx, nextIdx, interpolant);
+    }
+
+    //
+    // Traverse the *whole* node tree hierarchy to compute the global pose of each node
+    //
+    for(Node::Index hierarchyIdx = 0; hierarchyIdx != aAnimatedTree.mHierarchy.size(); ++hierarchyIdx)
+    {
+        if(Node::Index parentIdx = aAnimatedTree.mHierarchy[hierarchyIdx].mParent;
+           parentIdx != Node::gInvalidIndex)
+        {
+            aAnimatedTree.mGlobalPose[hierarchyIdx] =
+                aAnimatedTree.mLocalPose[hierarchyIdx] * aAnimatedTree.mGlobalPose[parentIdx];
+        }
+        else
+        {
+            aAnimatedTree.mGlobalPose[hierarchyIdx] = aAnimatedTree.mLocalPose[hierarchyIdx];
+        }
+    }
+}
 
 
 } // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.cpp
@@ -102,4 +102,22 @@ void animate(const RigAnimation & aAnimation, float aTimepoint, NodeTree<Rig::Po
 }
 
 
+std::vector<Rig::Pose> Rig::computeJointMatrices() const
+{
+    assert(mJoints.mIndices.size() == mJoints.mInverseBindMatrices.size());
+
+    std::vector<math::AffineMatrix<4, float>> result;
+    result.reserve(mJoints.mIndices.size());
+
+    for(std::size_t jointIdx = 0; jointIdx != mJoints.mIndices.size(); ++jointIdx)
+    {
+        result.push_back(
+            mJoints.mInverseBindMatrices[jointIdx] 
+            * mJointTree.mGlobalPose[mJoints.mIndices[jointIdx]]);
+    }
+
+    return result;
+}
+
+
 } // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.cpp
@@ -1,0 +1,10 @@
+#include "Rigging.h"
+
+
+namespace ad::renderer {
+
+
+
+
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
@@ -72,15 +72,18 @@ struct Rig
 
     NodeTree<Pose> mJointTree;
 
-    // Maps a bone index in aiMesh.mBones[] (the index into mJoints array) 
-    // to a Node index in mJointTree (the value)
-    // TODO #anim Ideally, mJointsTree nodes would be "bones" only,
-    // indexed in the same order as bone indices provided as a vertex attribute,
-    // so this member could be removed (getting rid of one indirection)
-    std::vector<NodeTree<Pose>::Node::Index> mJoints;
+    struct JointData
+    {
+        // Maps a bone index in aiMesh.mBones[] (the index into mJoints array) 
+        // to a Node index in mJointTree (the value)
+        // TODO #anim Ideally, mJointsTree nodes would be "bones" only,
+        // indexed in the same order as bone indices provided as a vertex attribute,
+        // so this member could be removed (getting rid of one indirection)
+        std::vector<NodeTree<Pose>::Node::Index> mIndices;
 
-    // Directly given in the order of bones in aiMesh.mBones.
-    std::vector<math::AffineMatrix<4, float>> mInverseBindMatrices;
+        // Directly given in the order of bones in aiMesh.mBones.
+        std::vector<math::AffineMatrix<4, float>> mInverseBindMatrices;
+    } mJoints;
 
     // With Assimp, I do not know any better name for the rig as a whole than its armature
     std::string mArmatureName;
@@ -91,12 +94,13 @@ struct Rig
 struct VertexJointData
 {
     static constexpr std::size_t gMaxBones = 4;
+    using BoneIndex_t = unsigned int; // TODO #perf use a more compact type than uint
 
     // Would require attribute interleaving, and VertexJointData would be per-vertex 
     // (instead of containing all vertices)
     //math::Vec<gMaxBones, unsigned int> mBoneIndices{math::Vec<gMaxBones, unsigned int>::Zero()};
     //math::Vec<gMaxBones, float> mBoneWeights{math::Vec<gMaxBones, float>::Zero()};
-    std::vector<math::Vec<gMaxBones, unsigned int>> mBoneIndices; // TODO use a more compact type than uint
+    std::vector<math::Vec<gMaxBones, BoneIndex_t>> mBoneIndices; 
     std::vector<math::Vec<gMaxBones, float>> mBoneWeights;
 };
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
@@ -112,6 +112,10 @@ struct Rig
     using Pose = math::AffineMatrix<4, float>;
     using Ibm = math::AffineMatrix<4, float>;
 
+    /// @brief Return the joint matrix palette, used by shaders to compute vertex deplacement
+    /// from skeletal animation.
+    std::vector<Rig::Pose> computeJointMatrices() const;
+
     // Note: currently usually represents a hierarchy larger than the skeleton.
     // The entries of this tree that are used as actual bones are given by mJoints.mIndices.
     NodeTree<Pose> mJointTree;

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
@@ -69,6 +69,7 @@ struct NodeTree
 struct Rig
 {
     using Pose = math::AffineMatrix<4, float>;
+    using Ibm = math::AffineMatrix<4, float>;
 
     NodeTree<Pose> mJointTree;
 
@@ -82,7 +83,7 @@ struct Rig
         std::vector<NodeTree<Pose>::Node::Index> mIndices;
 
         // Directly given in the order of bones in aiMesh.mBones.
-        std::vector<math::AffineMatrix<4, float>> mInverseBindMatrices;
+        std::vector<Ibm> mInverseBindMatrices;
     } mJoints;
 
     // With Assimp, I do not know any better name for the rig as a whole than its armature

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Rigging.h
@@ -1,0 +1,209 @@
+#pragma once
+
+
+#include <math/Homogeneous.h>
+
+#include <functional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <cassert>
+
+
+namespace ad::renderer {
+
+
+template <class T_Pose>
+struct NodeTree
+{
+
+    struct Node
+    {   
+        using Index = std::size_t;
+        static constexpr Index gInvalidIndex = std::numeric_limits<Index>::max();
+
+        Index mParent      = gInvalidIndex;
+        Index mFirstChild  = gInvalidIndex;
+        Index mNextSibling = gInvalidIndex;
+        Index mLastSibling = gInvalidIndex; // WARNING: this is an inconsistent internal value, not an invariant.
+        unsigned int mLevel = 0;
+    };
+
+
+    /// @param aParent if set to invalid index, the call adds a root node.
+    Node::Index addNode(Node::Index aParent, T_Pose aPose);
+
+    bool hasParent(Node::Index aNode) const
+    { return mHierarchy[aNode].mParent != Node::gInvalidIndex; }
+
+    bool hasChild(Node::Index aNode) const
+    { return mHierarchy[aNode].mFirstChild != Node::gInvalidIndex; }
+
+    bool hasName(Node::Index aNode) const
+    { return mNodeNames.find(aNode) != mNodeNames.end(); }
+
+    void reserve(std::size_t aCapacity)
+    {
+        mHierarchy.reserve(aCapacity);
+        mLocalPose.reserve(aCapacity);
+        mGlobalPose.reserve(aCapacity);
+    }
+
+    std::vector<Node> mHierarchy;
+    Node::Index mFirstRoot = Node::gInvalidIndex;
+
+    // TODO can we do without storing the local pose for skeletal animation?
+    // (might not be the case when interpolating between several animations)
+    std::vector<T_Pose> mLocalPose;
+    std::vector<T_Pose> mGlobalPose;
+
+    std::unordered_map<typename Node::Index, std::string> mNodeNames;
+};
+
+
+
+/// @brief 
+/// @note A single Rig might be used for several Parts of a given Object.
+struct Rig
+{
+    using Pose = math::AffineMatrix<4, float>;
+
+    NodeTree<Pose> mJointTree;
+
+    // Maps a bone index in aiMesh.mBones[] (the index into mJoints array) 
+    // to a Node index in mJointTree (the value)
+    // TODO #anim Ideally, mJointsTree nodes would be "bones" only,
+    // indexed in the same order as bone indices provided as a vertex attribute,
+    // so this member could be removed (getting rid of one indirection)
+    std::vector<NodeTree<Pose>::Node::Index> mJoints;
+
+    // Directly given in the order of bones in aiMesh.mBones.
+    std::vector<math::AffineMatrix<4, float>> mInverseBindMatrices;
+
+    // With Assimp, I do not know any better name for the rig as a whole than its armature
+    std::string mArmatureName;
+};
+
+
+/// @brief Per-vertex data required for skeletal animation.
+struct VertexJointData
+{
+    static constexpr std::size_t gMaxBones = 4;
+
+    // Would require attribute interleaving, and VertexJointData would be per-vertex 
+    // (instead of containing all vertices)
+    //math::Vec<gMaxBones, unsigned int> mBoneIndices{math::Vec<gMaxBones, unsigned int>::Zero()};
+    //math::Vec<gMaxBones, float> mBoneWeights{math::Vec<gMaxBones, float>::Zero()};
+    std::vector<math::Vec<gMaxBones, unsigned int>> mBoneIndices; // TODO use a more compact type than uint
+    std::vector<math::Vec<gMaxBones, float>> mBoneWeights;
+};
+
+
+//
+// Implementation
+//
+template <class T_Pose>
+std::ostream & operator<<(std::ostream & aOut, const NodeTree<T_Pose> & aTree)
+{
+    using Node = NodeTree<T_Pose>::Node;
+
+    std::function<void(typename Node::Index)> dump = [&aOut, &aTree, &dump](Node::Index aIdx)
+    {
+        static const std::string gDefaultName{"<UNNAMED>"};
+
+        const Node & node = aTree.mHierarchy[aIdx];
+        std::fill_n(std::ostreambuf_iterator<char>{aOut}, 2*node.mLevel, ' ');
+        
+        aOut << "(idx: " << aIdx << ")"
+             << (aTree.mNodeNames.count(aIdx) == 1 ? aTree.mNodeNames.at(aIdx) : gDefaultName)
+             ;
+
+        for(typename Node::Index childIdx = node.mFirstChild;
+            childIdx != Node::gInvalidIndex;
+            childIdx = aTree.mHierarchy[childIdx].mNextSibling)
+        {
+            aOut << "\n";
+            dump(childIdx);
+        }
+    };
+
+    // Do **not** prepend the very first output with a '\n', but do prepend each following print.
+    // This implements the "join" behaviour, '\n' only being present between elements.
+    dump(aTree.mFirstRoot);
+    for(typename Node::Index rootIdx = aTree.mHierarchy[aTree.mFirstRoot].mNextSibling;
+        rootIdx != Node::gInvalidIndex;
+        rootIdx = aTree.mHierarchy[rootIdx].mNextSibling)
+    {
+        aOut << "\n";
+        dump(rootIdx);
+    }
+
+    return aOut;
+}
+
+template <class T_Pose>
+NodeTree<T_Pose>::Node::Index NodeTree<T_Pose>::addNode(Node::Index aParent, T_Pose aPose)
+{
+    typename Node::Index thisIndex = mHierarchy.size();
+
+    mHierarchy.push_back(Node{
+        .mParent = aParent,
+    });
+
+    mLocalPose.push_back(std::move(aPose));
+
+    Node & node = mHierarchy[thisIndex];
+
+    if(aParent != Node::gInvalidIndex) // This node has a parent
+    {
+        Node & parent = mHierarchy[aParent];
+        node.mLevel = parent.mLevel + 1;
+        mGlobalPose.push_back(mLocalPose[thisIndex] * mGlobalPose[aParent]);
+
+        if (parent.mFirstChild == Node::gInvalidIndex) // The parent has no child
+        {
+            parent.mFirstChild = thisIndex;
+            node.mLastSibling = thisIndex;
+        }
+        else // The parent has children
+        {
+            Node & firstSibling = mHierarchy[parent.mFirstChild];
+            typename Node::Index currentLastIdx = firstSibling.mLastSibling;
+            // If the first sibling does not have its last sibling value set,
+            // find the last sibling by traversing the siblings.
+            if(currentLastIdx == Node::gInvalidIndex)
+            {
+                for(currentLastIdx = parent.mFirstChild;
+                    mHierarchy[currentLastIdx].mNextSibling != Node::gInvalidIndex;
+                    currentLastIdx = mHierarchy[currentLastIdx].mNextSibling)    
+                {}
+            }
+            mHierarchy[currentLastIdx].mNextSibling = thisIndex;
+            firstSibling.mLastSibling = thisIndex;
+        }
+    }
+    else // This is a root node
+    {
+        mGlobalPose.push_back(mLocalPose[thisIndex]);
+
+        if (mFirstRoot != Node::gInvalidIndex) // This is not the first root node
+        {
+            assert(mHierarchy[mFirstRoot].mLastSibling != Node::gInvalidIndex);
+            typename Node::Index currentLastIdx = mHierarchy[mFirstRoot].mLastSibling;
+
+            mHierarchy[currentLastIdx].mNextSibling = thisIndex;
+        }
+        else // This is the first root node
+        {
+            mFirstRoot = thisIndex;
+        }
+        mHierarchy[mFirstRoot].mLastSibling = thisIndex;
+    }
+
+    return thisIndex;
+}
+
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Semantics.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Semantics.h
@@ -6,20 +6,32 @@ namespace ad::renderer {
 
 namespace semantic
 {
+    #define SEM(s) const Semantic g ## s{#s}
+
     const Semantic gPosition{"Position"};
     const Semantic gNormal{"Normal"};
     const Semantic gTangent{"Tangent"};
     const Semantic gColor{"Color"};
     const Semantic gUv{"Uv"};
+    SEM(Joints0);
+    SEM(Weights0);
     const Semantic gDiffuseTexture{"DiffuseTexture"};
     const Semantic gNormalTexture{"NormalTexture"};
     const Semantic gModelTransformIdx{"ModelTransformIdx"};
     const Semantic gMaterialIdx{"MaterialIdx"};
 
+    #undef SEM
+
+    #define BLOCK_SEM(s) const BlockSemantic g ## s{#s}
+
     const BlockSemantic gFrame{"Frame"};
     const BlockSemantic gView{"View"};
     const BlockSemantic gMaterials{"Materials"};
     const BlockSemantic gLocalToWorld{"LocalToWorld"};
+    BLOCK_SEM(JointMatrices);
+
+    #undef BLOCK_SEM
+
 } // namespace semantic
 
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Semantics.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Semantics.h
@@ -11,6 +11,7 @@ namespace semantic
     const Semantic gColor{"Color"};
     const Semantic gUv{"Uv"};
     const Semantic gDiffuseTexture{"DiffuseTexture"};
+    const Semantic gNormalsTexture{"NormalsTexture"};
     const Semantic gModelTransformIdx{"ModelTransformIdx"};
     const Semantic gMaterialIdx{"MaterialIdx"};
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/Semantics.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/Semantics.h
@@ -8,10 +8,11 @@ namespace semantic
 {
     const Semantic gPosition{"Position"};
     const Semantic gNormal{"Normal"};
+    const Semantic gTangent{"Tangent"};
     const Semantic gColor{"Color"};
     const Semantic gUv{"Uv"};
     const Semantic gDiffuseTexture{"DiffuseTexture"};
-    const Semantic gNormalsTexture{"NormalsTexture"};
+    const Semantic gNormalTexture{"NormalTexture"};
     const Semantic gModelTransformIdx{"ModelTransformIdx"};
     const Semantic gMaterialIdx{"MaterialIdx"};
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.cpp
@@ -1,0 +1,26 @@
+#include "DebugDrawing.h"
+
+#include <mutex> // for once_flag
+
+namespace ad::renderer {
+
+
+namespace {
+
+    std::once_flag debugDrawersInitializationOnce;
+
+    void initializeDebugDrawers_impl()
+    {
+        snac::DebugDrawer::AddDrawer(drawer::gRig);
+    }
+
+} // unnamed namespace
+
+
+void initializeDebugDrawers()
+{
+    std::call_once(debugDrawersInitializationOnce, &initializeDebugDrawers_impl);
+}
+
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.h
@@ -1,0 +1,16 @@
+// TODO #debugdraw There should be a debug drawer direclty in this lib
+#include <snac-renderer-V1/DebugDrawer.h>
+
+
+namespace ad::renderer {
+
+
+namespace drawer
+{
+    constexpr const char * gRig = "rig";
+}
+
+void initializeDebugDrawers();
+
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugRenderer.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugRenderer.cpp
@@ -1,0 +1,88 @@
+#include "DebugRenderer.h"
+
+#include "../Pass.h"
+#include "../Semantics.h"
+#include "../SetupDrawing.h"
+
+#include "../files/Loader.h"
+
+namespace ad::renderer {
+
+
+namespace {
+
+    static const std::array<AttributeDescription, 2> gLineAttributes {
+        AttributeDescription{
+            .mSemantic = semantic::gPosition,
+            .mDimension = 3,
+            .mComponentType = GL_FLOAT,
+        },
+        AttributeDescription{
+            .mSemantic = semantic::gColor,
+            .mDimension = 4,
+            .mComponentType = GL_FLOAT,
+        },
+    };
+
+} // unnamed namespace
+
+
+DebugRenderer::DebugRenderer(Storage & aStorage, const Loader & aLoader) :
+    mLines{
+        .mName = "DebugLines",
+        // TODO It would be more semantically correct to host the "mLineBuffer" ourselves,
+        // and use a (to be implemented) function that would create the vertex stream *around* 
+        // this buffer we are explicitly responsible for.
+        .mVertexStream = makeVertexStream(0, 0, gLineAttributes, aStorage, {}),
+        .mPrimitiveMode = GL_LINES,
+    },
+    mLinePositionBuffer{getBufferView(*mLines.mVertexStream, semantic::gPosition).mGLBuffer},
+    mLineColorBuffer{getBufferView(*mLines.mVertexStream, semantic::gColor).mGLBuffer},
+    mLineProgram{storeConfiguredProgram(aLoader.loadProgram("shaders/DebugDraw.prog"), aStorage)}
+{}
+
+void DebugRenderer::render(snac::DebugDrawer::DrawList aDrawList,
+                           const RepositoryUbo & aUboRepository,
+                           Storage & aStorage)
+{
+    drawLines(aDrawList.mCommands->mLineVertices, aUboRepository, aStorage);
+}
+
+
+void DebugRenderer::drawLines(std::span<snac::DebugDrawer::LineVertex> aLines,
+                              const RepositoryUbo & aUboRepository,
+                              Storage & aStorage)
+{
+    // TODO enable interleaving so we can use the aLines span directly
+    std::vector<math::Position<3, float>> positions;
+    std::vector<math::hdr::Rgba<float>> colors;
+    for(const auto & lineVertex : aLines)
+    {
+        positions.push_back(lineVertex.mPosition);
+        colors.push_back(lineVertex.mColor);
+    }
+
+    {
+        std::span lineData{positions};
+        glBindBuffer(GL_ARRAY_BUFFER, *mLinePositionBuffer);
+        glBufferData(GL_ARRAY_BUFFER, lineData.size_bytes(), lineData.data(), GL_STREAM_DRAW);
+    }
+    {
+        std::span lineData{colors};
+        glBindBuffer(GL_ARRAY_BUFFER, *mLineColorBuffer);
+        glBufferData(GL_ARRAY_BUFFER, lineData.size_bytes(), lineData.data(), GL_STREAM_DRAW);
+    }
+
+    // The VAO might actually be cached as a data member, since it will be constant during runtime
+    Handle<graphics::VertexArrayObject> vao = getVao(*mLineProgram, mLines, aStorage);
+    graphics::ScopedBind vaoScope{*vao};
+    graphics::ScopedBind programScope{mLineProgram->mProgram};
+
+    setBufferBackedBlocks(mLineProgram->mProgram, aUboRepository);
+
+    glDisable(GL_DEPTH_TEST);
+    glDrawArrays(mLines.mPrimitiveMode, 0, (GLsizei)aLines.size());
+}
+
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugRenderer.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugRenderer.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "../Model.h"
+
+// TODO #debugdraw There should be a debug drawer direclty in this lib
+#include <snac-renderer-V1/DebugDrawer.h>
+
+
+namespace ad::renderer {
+
+
+struct Loader;
+
+
+// IMPORTANT: This is a Q&D (probably incomplete) implementation aimed at the V1 DebugDrawer.
+
+/// @brief Used to render on screen the debug DrawList.
+class DebugRenderer
+{
+public:
+    DebugRenderer(Storage & aStorage, const Loader & aLoader);
+
+    void render(snac::DebugDrawer::DrawList aDrawList,
+                const RepositoryUbo & aUboRepository,
+                Storage & aStorage);
+
+private:
+    void drawLines(std::span<snac::DebugDrawer::LineVertex> aLines,
+                   const RepositoryUbo & aUboRepository,
+                   Storage & aStorage);
+
+    Part mLines;
+    graphics::BufferAny * mLinePositionBuffer;
+    graphics::BufferAny * mLineColorBuffer;
+    Handle<ConfiguredProgram> mLineProgram;
+};
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/BinaryArchive.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/BinaryArchive.h
@@ -68,6 +68,18 @@ struct BinaryOutArchive
         return write(std::span{aString});
     }
 
+    template <class T_key, class T_value>
+    BinaryOutArchive & write(const std::unordered_map<T_key, T_value> & aMap)
+    {
+        write((unsigned int)aMap.size());
+        for(const auto & [key, value] : aMap)
+        {
+            write(key);
+            write(value);
+        }
+        return *this;
+    }
+
     std::ofstream mOut;
     std::filesystem::path mParentPath;
 };
@@ -96,6 +108,12 @@ struct BinaryInArchive
         std::string buffer(stringSize, '\0');
         mIn.read(buffer.data(), stringSize);
         return buffer;
+    }
+
+    BinaryInArchive & read(std::string & aString)
+    {
+        aString = readString();
+        return *this;
     }
 
     template <class T>
@@ -129,6 +147,21 @@ struct BinaryInArchive
         return *this;
     }
 
+    template <class T_key, class T_value>
+    BinaryInArchive & read(std::unordered_map<T_key, T_value> & aMap)
+    {
+        unsigned int mapSize;
+        read(mapSize);
+        T_key key;
+        T_value value;
+        for(unsigned int i = 0; i != mapSize; ++i)
+        {
+            read(key);
+            read(value);
+            aMap.emplace(key, value);
+        }
+        return *this;
+    }
 
     std::ifstream mIn;
     std::filesystem::path mParentPath;

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Flags.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Flags.h
@@ -1,0 +1,16 @@
+#pragma once
+
+
+namespace ad::renderer {
+
+
+constexpr unsigned int gVertexPosition = 0b1;
+constexpr unsigned int gVertexNormal = gVertexPosition << 1;
+constexpr unsigned int gVertexTangent = gVertexPosition << 2;
+
+bool has(unsigned int aFlags, unsigned int aTag)
+{
+    return (aFlags & aTag) == aTag;
+}
+
+} // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.cpp
@@ -775,7 +775,7 @@ Effect * Loader::loadEffect(const std::filesystem::path & aEffectFile,
 
 
 IntrospectProgram Loader::loadProgram(const filesystem::path & aProgFile,
-                                      const std::vector<std::string> & aDefines_temp)
+                                      std::vector<std::string> aDefines_temp)
 {
     std::vector<std::pair<const GLenum, graphics::ShaderSource>> shaders;
 
@@ -800,9 +800,14 @@ IntrospectProgram Loader::loadProgram(const filesystem::path & aProgFile,
     for (auto [shaderStage, shaderFile] : program.items())
     {
         GLenum stageEnumerator;
-        if(shaderStage == "features")
+        if(shaderStage == "defines")
         {
             // Special case, not a shader stage
+            for (std::string macro : shaderFile)
+            {
+                aDefines_temp.push_back(std::move(macro));
+            }
+            SELOG(warn)("'{}' program has 'defines', which are not recommended with V2.", aProgFile.string());
             continue;
         }
         else if(shaderStage == "vertex")

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.cpp
@@ -7,6 +7,7 @@
 #include "../Json.h"
 #include "../Logging.h"
 #include "../RendererReimplement.h"
+#include "../Rigging.h"
 #include "../Semantics.h"
 
 #include <arte/Image.h>
@@ -105,6 +106,8 @@ namespace {
     constexpr auto gUvSize = 2 * sizeof(float);
     constexpr auto gColorSize = 4 * sizeof(float);
     constexpr auto gIndexSize = sizeof(unsigned int);
+    constexpr auto gBoneIndicesSize = VertexJointData::gMaxBones * sizeof(unsigned int);
+    constexpr auto gBoneWeightsSize = VertexJointData::gMaxBones * sizeof(float);
 
     struct AttributeDescription
     {
@@ -176,6 +179,7 @@ namespace {
                 }
             }();
 
+            // TODO allow interleaving of vertex attributes
             vertexStream.mSemanticToAttribute.emplace(
                 attribute.mSemantic,
                 AttributeAccessor{
@@ -217,11 +221,13 @@ namespace {
             };
 
         // TODO #loader Those hardcoded indices are smelly, hard-coupled to the attribute streams structure in the binary.
-        graphics::BufferAny & positionBuffer = *(aVertexStream.mVertexBufferViews.end() - 5)->mGLBuffer;
-        graphics::BufferAny & normalBuffer   = *(aVertexStream.mVertexBufferViews.end() - 4)->mGLBuffer;
-        graphics::BufferAny & tangentBuffer  = *(aVertexStream.mVertexBufferViews.end() - 3)->mGLBuffer;
-        graphics::BufferAny & colorBuffer = *(aVertexStream.mVertexBufferViews.end() - 2)->mGLBuffer;
-        graphics::BufferAny & uvBuffer = *(aVertexStream.mVertexBufferViews.end() - 1)->mGLBuffer;
+        graphics::BufferAny & positionBuffer = *(aVertexStream.mVertexBufferViews.end() - 7)->mGLBuffer;
+        graphics::BufferAny & normalBuffer   = *(aVertexStream.mVertexBufferViews.end() - 6)->mGLBuffer;
+        graphics::BufferAny & tangentBuffer  = *(aVertexStream.mVertexBufferViews.end() - 5)->mGLBuffer;
+        graphics::BufferAny & colorBuffer = *(aVertexStream.mVertexBufferViews.end() - 4)->mGLBuffer;
+        graphics::BufferAny & uvBuffer = *(aVertexStream.mVertexBufferViews.end() - 3)->mGLBuffer;
+        graphics::BufferAny & boneIndicesBuffer = *(aVertexStream.mVertexBufferViews.end() - 2)->mGLBuffer;
+        graphics::BufferAny & boneWeightsBuffer = *(aVertexStream.mVertexBufferViews.end() - 1)->mGLBuffer;
         graphics::BufferAny & indexBuffer = *(aVertexStream.mIndexBufferView.mGLBuffer);
 
         const std::string meshName = aIn.readString();
@@ -274,6 +280,17 @@ namespace {
         aIn.read(primitiveCount);
         const unsigned int indicesCount = 3 * primitiveCount;
         loadBufferFromArchive(indexBuffer, aIndexFirst, gIndexSize, indicesCount);
+
+        {
+            unsigned int bonesCount;
+            aIn.read(bonesCount);
+
+            if(bonesCount != 0)
+            {
+                loadBufferFromArchive(boneIndicesBuffer, aVertexFirst, gBoneIndicesSize, verticesCount);
+                loadBufferFromArchive(boneWeightsBuffer, aVertexFirst, gBoneWeightsSize, verticesCount);
+            }
+        }
 
         // Assign the part material index to the otherwise common material
         aPartsMaterial.mPhongMaterialIdx = materialIndex;
@@ -710,7 +727,7 @@ Node loadBinary(const std::filesystem::path & aBinaryFile,
 
     // Binary attributes descriptions
     // TODO Ad 2023/10/11: #loader Support dynamic set of attributes in the binary
-    static const std::array<AttributeDescription, 5> gAttributeStreamsInBinary {
+    static const std::array<AttributeDescription, 7> gAttributeStreamsInBinary {
         AttributeDescription{
             .mSemantic = semantic::gPosition,
             .mDimension = 3,
@@ -734,6 +751,16 @@ Node loadBinary(const std::filesystem::path & aBinaryFile,
         AttributeDescription{
             .mSemantic = semantic::gUv,
             .mDimension = 2,
+            .mComponentType = GL_FLOAT,
+        },
+        AttributeDescription{
+            .mSemantic = semantic::gJoints0,
+            .mDimension = VertexJointData::gMaxBones,
+            .mComponentType = GL_UNSIGNED_INT,
+        },
+        AttributeDescription{
+            .mSemantic = semantic::gWeights0,
+            .mDimension = VertexJointData::gMaxBones,
             .mComponentType = GL_FLOAT,
         },
     };

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.cpp
@@ -52,13 +52,10 @@ namespace {
             rows[2].getNorm(),
         };
 
-        // TODO we will need to introduce some tolerance here
-        assert(isWithinTolerance(scale[0], 1.f, 1E-6f));
-        assert(isWithinTolerance(scale[1], 1.f, 1E-6f));
-        assert(isWithinTolerance(scale[2], 1.f, 1E-6f));
-        result.mUniformScale = 1;
+        assert(isWithinTolerance(scale[1], scale[0], 1E-6f));
+        assert(isWithinTolerance(scale[2], scale[0], 1E-6f));
         //assert(scale[0] == scale[1] && scale[0] == scale[2]);
-        //result.mUniformScale = scale[0];
+        result.mUniformScale = scale[0];
 
         return result;
     }

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.h
@@ -47,7 +47,7 @@ struct Loader
     /// @brief Load a `.prog` file as an IntrospectProgram.
     IntrospectProgram loadProgram(const filesystem::path & aProgFile,
                                   // TODO Ad 2023/10/03: #shader-system Remove this temporary.
-                                  const std::vector<std::string> & aDefines_temp);
+                                  std::vector<std::string> aDefines_temp);
 
     graphics::ShaderSource loadShader(const filesystem::path & aShaderFile) const;
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.h
@@ -20,6 +20,32 @@ struct InstanceData
 };
 
 
+// TODO move to a more generic header
+// TODO review the usefulness of aVertexStream last argument
+// alongside makeVertexStream
+struct AttributeDescription
+{
+    Semantic mSemantic;
+    // To replace wih graphics::ClientAttribute if we support interleaved buffers (i.e. with offset)
+    graphics::AttributeDimension mDimension;
+    GLenum mComponentType;   // data individual components' type.
+};
+
+
+// TODO move to a more generic header, review the usefulness of aVertexStream last argument
+/// @note Provide a distinct buffer for each attribute stream at the moment (i.e. no interleaving).
+/// @param aVertexStream If not nullptr, create views into this vertex stream buffers instead of creating
+/// new buffers.
+Handle<VertexStream> makeVertexStream(unsigned int aVerticesCount,
+                                      unsigned int aIndicesCount,
+                                      std::span<const AttributeDescription> aBufferedStreams,
+                                      Storage & aStorage,
+                                      const GenericStream & aStream,
+                                      // This is probably only useful to create debug data buffers
+                                      // (as there is little sense to not reuse the existing views)
+                                      const VertexStream * aVertexStream = nullptr);
+
+
 // IMPORTANT: for the moment, just load the first vertex stream in the file
 // has to be extended to actually load complex models.
 Node loadBinary(const std::filesystem::path & aBinaryFile,
@@ -36,24 +62,6 @@ std::pair<Node, Node> loadTriangleAndCube(Storage & aStorage,
                                           const GenericStream & aStream);
 
 
-struct Loader
-{
-    /// @brief Load an effect file (.sefx), store it in `aStorage` and return its handle.
-    Effect * loadEffect(const std::filesystem::path & aEffectFile,
-                        Storage & aStorage,
-                        // TODO Ad 2023/10/03: #shader-system Remove this temporary.
-                        const std::vector<std::string> & aDefines_temp = {});
-
-    /// @brief Load a `.prog` file as an IntrospectProgram.
-    IntrospectProgram loadProgram(const filesystem::path & aProgFile,
-                                  // TODO Ad 2023/10/03: #shader-system Remove this temporary.
-                                  std::vector<std::string> aDefines_temp);
-
-    graphics::ShaderSource loadShader(const filesystem::path & aShaderFile) const;
-
-    resource::ResourceFinder mFinder;
-};
-
 // TODO Ad 2024/02/15: Those free functins should be relocated
 // (not even sure we want the library to propose an instance stream format at all)
 GenericStream makeInstanceStream(Storage & aStorage, std::size_t aInstanceCount);
@@ -65,6 +73,28 @@ BufferView createBuffer(GLsizei aElementSize,
                         GLuint aInstanceDivisor,
                         GLenum aHint,
                         Storage & aStorage);
+
+
+Handle<ConfiguredProgram> storeConfiguredProgram(IntrospectProgram aProgram, Storage & aStorage);
+
+
+struct Loader
+{
+    /// @brief Load an effect file (.sefx), store it in `aStorage` and return its handle.
+    Effect * loadEffect(const std::filesystem::path & aEffectFile,
+                        Storage & aStorage,
+                        // TODO Ad 2023/10/03: #shader-system Remove this temporary.
+                        const std::vector<std::string> & aDefines_temp = {}) const;
+
+    /// @brief Load a `.prog` file as an IntrospectProgram.
+    IntrospectProgram loadProgram(const filesystem::path & aProgFile,
+                                  // TODO Ad 2023/10/03: #shader-system Remove this temporary.
+                                  std::vector<std::string> aDefines_temp = {}) const;
+
+    graphics::ShaderSource loadShader(const filesystem::path & aShaderFile) const;
+
+    resource::ResourceFinder mFinder;
+};
 
 
 } // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/files/Loader.h
@@ -54,7 +54,17 @@ struct Loader
     resource::ResourceFinder mFinder;
 };
 
+// TODO Ad 2024/02/15: Those free functins should be relocated
+// (not even sure we want the library to propose an instance stream format at all)
 GenericStream makeInstanceStream(Storage & aStorage, std::size_t aInstanceCount);
+
+/// @brief Create a GL buffer of specified size (without loading data into it).
+/// @return Buffer view to the buffer.
+BufferView createBuffer(GLsizei aElementSize,
+                        GLsizeiptr aElementCount,
+                        GLuint aInstanceDivisor,
+                        GLenum aHint,
+                        Storage & aStorage);
 
 
 } // namespace ad::renderer

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/DebugDraw.prog
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/DebugDraw.prog
@@ -1,0 +1,4 @@
+{
+    "vertex": "SimplePositionTransform.vert",
+    "fragment": "Solid.frag"
+}

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/PhongLighting.frag
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/PhongLighting.frag
@@ -22,8 +22,10 @@ struct PhongMaterial
     vec4 ambientColor;
     vec4 diffuseColor;
     vec4 specularColor;
-    uint textureIndex;
+    uint diffuseTextureIndex;
     uint diffuseUvChannel;
+    uint normalTextureIndex;
+    uint normalUvChannel;
     float specularExponent;
 };
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/PhongLighting.vert
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/PhongLighting.vert
@@ -5,8 +5,6 @@ in vec3 ve_Normal_local;
 in vec4 ve_Color;
 in vec2 ve_Uv;
 
-// Will be required to support non-uniform scaling.
-//in mat4 in_LocalToWorldInverseTranspose;
 in uint in_ModelTransformIdx;
 in uint in_MaterialIdx;
 
@@ -22,7 +20,7 @@ layout(std140, binding = 0) uniform ViewBlock
 // TODO #ssbo Use a shader storage block, due to the unbounded nature of the number of instances
 layout(std140, binding = 1) uniform LocalToWorldBlock
 {
-    mat4 localToWorld[512];
+    mat4 modelTransforms[512];
 };
 
 out vec3 ex_Position_cam;
@@ -31,16 +29,22 @@ out vec4 ex_Color;
 out vec2[4] ex_Uv; // simulates 4 UV channels, not implement atm
 out flat uint ex_MaterialIdx;
 
+
+#ifdef RIGGING
+#include "Rigging.glsl"
+#endif
+
+
 void main(void)
 {
-//    mat4 localToWorld = 
-//        in_LocalToWorld
-//#ifdef RIGGING
-//        * assembleSkinningMatrix()
-//#endif
+    mat4 localToWorld = 
+        modelTransforms[in_ModelTransformIdx]
+#ifdef RIGGING
+        * assembleSkinningMatrix()
+#endif
     ;
 
-    mat4 localToCamera = worldToCamera * localToWorld[in_ModelTransformIdx];
+    mat4 localToCamera = worldToCamera * localToWorld;
     vec4 position_cam = localToCamera * vec4(ve_Position_local, 1.f);
     gl_Position = projection * position_cam;
     ex_Position_cam = vec3(position_cam);

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/PhongLighting_transparent.frag
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/PhongLighting_transparent.frag
@@ -22,8 +22,10 @@ struct PhongMaterial
     vec4 ambientColor;
     vec4 diffuseColor;
     vec4 specularColor;
-    uint textureIndex;
+    uint diffuseTextureIndex;
     uint diffuseUvChannel;
+    uint normalTextureIndex;
+    uint normalUvChannel;
     float specularExponent;
 };
 

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/Rigging.glsl
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/Rigging.glsl
@@ -1,0 +1,21 @@
+in uvec4 ve_Joints0;
+in vec4  ve_Weights0;
+
+in uint in_MatrixPaletteOffset; // default value of 0 is what we need when a single palette is provided.
+
+// Having a fixed binding value in an included file is dangerous.
+// Yet this seems to be required to avoid collisions with other uniform blocks.
+layout(std140, binding = 3) uniform JointMatricesBlock
+{
+    mat4 joints[512];
+};
+
+mat4 assembleSkinningMatrix()
+{
+    return 
+          ve_Weights0[0] * joints[in_MatrixPaletteOffset + ve_Joints0[0]]
+        + ve_Weights0[1] * joints[in_MatrixPaletteOffset + ve_Joints0[1]]
+        + ve_Weights0[2] * joints[in_MatrixPaletteOffset + ve_Joints0[2]]
+        + ve_Weights0[3] * joints[in_MatrixPaletteOffset + ve_Joints0[3]]
+    ;
+}

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/SimplePositionTransform.vert
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/SimplePositionTransform.vert
@@ -1,0 +1,40 @@
+#version 420
+
+in vec3 ve_Position_l;
+in vec4 ve_Color;
+in vec2 ve_TextureCoords0;
+
+#ifdef MODEL_MATRIX
+in mat4 in_LocalToWorld;
+#endif
+
+#ifdef RIGGING
+#include "Rigging.glsl"
+#endif
+
+layout(std140, binding = 0) uniform ViewBlock
+{
+    mat4 worldToCamera;
+    mat4 projection;
+    mat4 viewingProjection;
+};
+
+out vec4 ex_Color;
+out vec2 ex_TextureCoords;
+
+void main(void)
+{
+    gl_Position = 
+        viewingProjection  
+#ifdef MODEL_MATRIX
+        * in_LocalToWorld
+#endif
+#ifdef RIGGING
+        * assembleSkinningMatrix()
+#endif
+        * vec4(ve_Position_l, 1.f)
+        ;
+
+    ex_Color = ve_Color;
+    ex_TextureCoords = ve_TextureCoords0;
+}

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/Solid.frag
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/resources/shaders/Solid.frag
@@ -1,0 +1,12 @@
+#version 420
+
+#include "Gamma.glsl"
+
+in vec4 ex_Color;
+
+out vec4 out_Color;
+
+void main(void)
+{
+    out_Color = correctGamma(ex_Color);
+}


### PR DESCRIPTION
closes #121.
- Prepare migration work, by duplicating current Renderer.
- Port code for Model (Node) loading.
- WIP porting the mesh rendering: first results.
- Fix model rendering, render all instances.
- Fix "normalized" suffix handling for vertex attributes.
- Implement a "ModelLoader" sandbox simulation.
- Implement indexing into the phong material for renderer v2.
- Complete the material interaction with the Phong reflection model.
- Copy resources, revert changes made to renderer_V1 resources.
- Restore (diffuse) color texturing.
- Fix an issue with empty "upsampled" dirs, use relative paths.
- Dump more information when running "asset_processor".
- Implement a value correction for specular exponent.
- Fixup texture upsample folder.
- Revert "Implement a value correction for specular exponent."
- Implement a value correction for specular exponent.
- Factorize texture parameters reading.
- Store and read normal maps from binary files.
- Add vertex tangents to the binary file, use them for normal mapping.
- Make the assimp importer more verbose, to diagnose issues.
- f
- Make `dumpTextures()` even more complex...
- Adapt snacgame to work with the current partial port to renderer V2.
- Fix shaders for Viewer app.
- Handle filetype better in Viewer app, disable default cube and triangle.
- Intoduce rigging in Viewer's shaders, and review a bit Rigging.h
- Start handling Assimp bone data, dump vertex joints/weights attributes.
- Dump the Rig on Nodes when present, display bone name in Viewer gui.
- Handle "NOMINMAX" macro via the CMake scripts.
- Implement a DebugRenderer (in V2) for DebugDrawer V1.
- Write joint information in the .seum file.
- Transform debug skeleton so it aligns with the model.
- Handle Animations in seum file, animate skeletons in Viewer.
- Refactor dumpAnimations() to handle 1 key animations (static poses).
- Get a first iteration of skeletal animation in the Viewer.
