### PR TITLE
topic/snacman#136 secondary window

### DIFF
--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,7 +23,7 @@ class SnacmanConan(ConanFile):
 
     requires = (
         ("entity/38ecfecf59@adnn/develop"),
-        ("graphics/24de18f6a4@adnn/develop"),
+        ("graphics/65f225f279@adnn/develop"),
         ("handy/15a1bb8eaa@adnn/develop"),
         ("math/93cb736b19@adnn/develop"),
         ("MarkovJunior.cpp/c6fb4e32d1@adnn/develop"),

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,7 +23,7 @@ class SnacmanConan(ConanFile):
 
     requires = (
         ("entity/38ecfecf59@adnn/develop"),
-        ("graphics/65f225f279@adnn/develop"),
+        ("graphics/a494da01c2@adnn/develop"),
         ("handy/15a1bb8eaa@adnn/develop"),
         ("math/93cb736b19@adnn/develop"),
         ("MarkovJunior.cpp/c6fb4e32d1@adnn/develop"),

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -23,10 +23,10 @@ class SnacmanConan(ConanFile):
 
     requires = (
         ("entity/38ecfecf59@adnn/develop"),
-        ("graphics/9553555490@adnn/develop"),
+        ("graphics/24de18f6a4@adnn/develop"),
         ("handy/15a1bb8eaa@adnn/develop"),
-        ("math/4173650c1e@adnn/develop"),
-        ("MarkovJunior.cpp/86f542db56@adnn/develop"),
+        ("math/93cb736b19@adnn/develop"),
+        ("MarkovJunior.cpp/c6fb4e32d1@adnn/develop"),
 
         # Waiting for my PR on conan-center for assimp to get merged in
         # see: https://github.com/conan-io/conan-center-index/pull/20185

--- a/conan/workspaces/complete.yml
+++ b/conan/workspaces/complete.yml
@@ -1,13 +1,13 @@
 editables:
-    MarkovJunior.cpp/86f542db56@adnn/develop:
+    MarkovJunior.cpp/c6fb4e32d1@adnn/develop:
         path: ../../../MarkovJunior.cpp/conan
     entity/38ecfecf59@adnn/develop:
         path: ../../../entity/conan
-    graphics/9553555490@adnn/develop:
+    graphics/24de18f6a4@adnn/develop:
         path: ../../../graphics/conan
     handy/15a1bb8eaa@adnn/develop:
         path: ../../../handy/conan
-    math/4173650c1e@adnn/develop:
+    math/93cb736b19@adnn/develop:
         path: ../../../math/conan
     snacman/local:
         path: ../../conan

--- a/src/apps/viewer/viewer/CMakeLists.txt
+++ b/src/apps/viewer/viewer/CMakeLists.txt
@@ -12,7 +12,8 @@ set(${TARGET_NAME}_HEADERS
     Json.h
     Lights.h
     Logging.h
-    PassViewer.cpp
+    PassViewer.h
+    SecondaryView.h
     Scene.h
     SceneGui.h
     TheGraph.h
@@ -31,6 +32,7 @@ set(${TARGET_NAME}_SOURCES
     GraphGui.cpp
     Logging.cpp
     PassViewer.cpp
+    SecondaryView.cpp
     Scene.cpp
     SceneGui.cpp
     TheGraph.cpp

--- a/src/apps/viewer/viewer/CameraSystem.cpp
+++ b/src/apps/viewer/viewer/CameraSystem.cpp
@@ -299,14 +299,19 @@ void CameraSystemGui::presentSection(CameraSystem & aCameraSystem)
             };
             int projectionId = std::holds_alternative<graphics::OrthographicParameters>(projectionParams) ?
                 Orthographic : Perspective;
+            const int previousProjectionId = projectionId;
 
-            bool changed = ImGui::RadioButton("Orthographic",
-                                              &projectionId,
-                                              Orthographic);
+            ImGui::RadioButton("Orthographic",
+                               &projectionId,
+                               Orthographic);
             ImGui::SameLine();
-            changed |= ImGui::RadioButton("Perspective",
-                                          &projectionId,
-                                          Perspective);
+            ImGui::RadioButton("Perspective",
+                               &projectionId,
+                               Perspective);
+
+            // Note: initially, we used the return value from ImGui::RadioButton to detect change
+            // but clicking the already selected button would also return true.
+            bool changed = (projectionId != previousProjectionId);
 
             // If a change occured, convert from one projection parameter type to the other
             if(changed)

--- a/src/apps/viewer/viewer/CameraSystem.cpp
+++ b/src/apps/viewer/viewer/CameraSystem.cpp
@@ -9,7 +9,6 @@ namespace ad::renderer {
 namespace {
 
     constexpr math::Degree<float> gInitialVFov{50.f};
-    constexpr float gInitialRadius{2.f};
     constexpr float gNearZ{-0.1f};
     constexpr float gMinFarZ{-25.f};
 
@@ -33,16 +32,17 @@ constexpr float gDepthFactor{20.f};
 
 CameraSystem::CameraSystem(std::shared_ptr<graphics::AppInterface> aAppInterface,
                            const imguiui::ImguiUi * aImguiUi,
-                           Control aMode) :
+                           Control aMode,
+                           Orbital aInitialOrbitalPose) :
     mAppInterface{std::move(aAppInterface)},
     mImguiUi{aImguiUi},
     mActive{aMode},
-    mOrbitalHome{gInitialRadius},
+    mOrbitalHome{aInitialOrbitalPose},
     mOrbitalControl{mOrbitalHome},
     mFramebufferSizeListener{mAppInterface->listenFramebufferResize(
         std::bind(&CameraSystem::onFramebufferResize, this, std::placeholders::_1))
     },
-    mPreviousRadius{gInitialRadius}
+    mPreviousRadius{aInitialOrbitalPose.mSpherical.radius()}
 {
         setControlMode(mActive);
 

--- a/src/apps/viewer/viewer/CameraSystem.h
+++ b/src/apps/viewer/viewer/CameraSystem.h
@@ -23,7 +23,8 @@ struct CameraSystem
 
     CameraSystem(std::shared_ptr<graphics::AppInterface> aAppInterface,
                  const imguiui::ImguiUi * aImguiUi,
-                 Control aMode);
+                 Control aMode,
+                 Orbital aInitialOrbitalPose = {gInitialOrbitalRadius});
 
     
     /// \brief High-level function configuring the CameraSystem to view a model
@@ -54,6 +55,8 @@ struct CameraSystem
     std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
     // Hackish member, saving the last orbital radius to be able to recompute equivalent FOV for orthographic zoom.
     float mPreviousRadius;
+
+    inline static constexpr float gInitialOrbitalRadius{2.f};
 };
 
 

--- a/src/apps/viewer/viewer/EnvironmentUtilities.cpp
+++ b/src/apps/viewer/viewer/EnvironmentUtilities.cpp
@@ -29,6 +29,7 @@ namespace {
 } // unnamed namespace
 
 
+// TODO Ad 2024/08/02: #graph remove dependency to TheGraph from those utilities
 void dumpEnvironmentCubemap(const Environment & aEnvironment, 
                             const TheGraph & aGraph,
                             Storage & aStorage,

--- a/src/apps/viewer/viewer/EnvironmentUtilities.cpp
+++ b/src/apps/viewer/viewer/EnvironmentUtilities.cpp
@@ -124,7 +124,7 @@ namespace {
         // Get the internal format of the provided environment texture
         GLint environmentInternalFormat = 0;
         {
-            graphics::ScopedBind boundEnvironment{*aEnvironment.mMap};
+            graphics::ScopedBind boundEnvironment{*aEnvironment.getEnvMap()};
             glGetTexLevelParameteriv(GL_TEXTURE_CUBE_MAP_POSITIVE_X,
                                      0,
                                      GL_TEXTURE_INTERNAL_FORMAT,
@@ -136,7 +136,7 @@ namespace {
                 default:
                 {
                     GLint isCompressed = GL_TRUE;
-                    glGetInternalformativ(aEnvironment.mMap->mTarget, environmentInternalFormat, 
+                    glGetInternalformativ(aEnvironment.getEnvMap()->mTarget, environmentInternalFormat, 
                                           GL_TEXTURE_COMPRESSED, 1, &isCompressed);
                     if(isCompressed)
                     {
@@ -253,6 +253,7 @@ Handle<graphics::Texture> filterEnvironmentMapSpecular(const Environment & aEnvi
         //glTexParameterf(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAX_ANISOTROPY, 16.f);
     }
 
+    glObjectLabel(GL_TEXTURE, filteredCubemap, -1, "filtered_radiance_specular_env");
     return &aStorage.mTextures.emplace_back(std::move(filteredCubemap));
 }
 
@@ -288,6 +289,7 @@ Handle<graphics::Texture> filterEnvironmentMapDiffuse(const Environment & aEnvir
         glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     }
 
+    glObjectLabel(GL_TEXTURE, filteredCubemap, -1, "filtered_irradiance_diffuse_env");
     return &aStorage.mTextures.emplace_back(std::move(filteredCubemap));
 }
 
@@ -344,6 +346,7 @@ Handle<graphics::Texture> integrateEnvironmentBrdf(Storage & aStorage,
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     }
 
+    glObjectLabel(GL_TEXTURE, result, -1, "integrated_env_brdf");
     return &aStorage.mTextures.emplace_back(std::move(result));
 }
 
@@ -362,7 +365,7 @@ graphics::Texture highLightSamples(const Environment & aEnvironment,
     GLint environmentInternalFormat = 0;
     GLint environmentSideSize = 0;
     {
-        graphics::ScopedBind boundEnvironment{*aEnvironment.mMap};
+        graphics::ScopedBind boundEnvironment{*aEnvironment.getEnvMap()};
         glGetTexLevelParameteriv(GL_TEXTURE_CUBE_MAP_POSITIVE_X,
                                  0,
                                  GL_TEXTURE_INTERNAL_FORMAT,

--- a/src/apps/viewer/viewer/Scene.h
+++ b/src/apps/viewer/viewer/Scene.h
@@ -50,6 +50,8 @@ inline std::string to_string(Environment::Type aEnvironment)
 }
 
 
+/// @note The Scene does not contain the camera: this way the same logical scene 
+/// can be rendered from multiple views.
 struct Scene
 {
     Scene & addToRoot(Node aNode)

--- a/src/apps/viewer/viewer/Scene.h
+++ b/src/apps/viewer/viewer/Scene.h
@@ -3,6 +3,7 @@
 #include "Lights.h"
 
 #include <snac-renderer-V2/Model.h>
+#include <snac-renderer-V2/Semantics.h>
 
 
 namespace ad::renderer {
@@ -19,12 +20,19 @@ struct Environment
         Cubemap,
         Equirectangular,
     };
+
+    Handle<const graphics::Texture> getEnvMap() const
+    { return mTextureRepository.at(semantic::gEnvironmentTexture); }
+
+    Handle<const graphics::Texture> getFilteredRadiance() const
+    { return mTextureRepository.at(semantic::gFilteredRadianceEnvironmentTexture); }
+
+    Handle<const graphics::Texture> getFilteredIrradiance() const
+    { return mTextureRepository.at(semantic::gFilteredIrradianceEnvironmentTexture); }
+
     Type mType;
-    Handle<const graphics::Texture> mMap;
+    RepositoryTexture mTextureRepository;
     std::filesystem::path mMapFile; // notably used when dumping the cubemap, to derive a destination
-    Handle<const graphics::Texture> mFilteredRadiance;
-    Handle<const graphics::Texture> mIntegratedBrdf;
-    Handle<const graphics::Texture> mFilteredIrradiance;
 };
 
 

--- a/src/apps/viewer/viewer/SceneGui.h
+++ b/src/apps/viewer/viewer/SceneGui.h
@@ -15,9 +15,16 @@ struct Scene;
 
 class SceneGui
 {
-    friend struct ViewerApplication;
-
 public:
+    struct Options
+    {
+        bool mHighlightObjects = false;
+        // Not sure it should be located here: the scene gui will offer the checkbox,
+        // but it is unlikely to handle the actual rendering of light positions.
+        bool mShowPointLights = true;
+        bool mAreDirectionalLightsCameraSpace = false;
+    };
+    
     SceneGui(Handle<Effect> aHighlight, const Storage & aStorage) :
         mHighlightMaterial{
             .mNameArrayOffset = 1, // hack to index the name at 0
@@ -26,6 +33,11 @@ public:
     {}
 
     void presentSection(Scene & aScene, const Timing & aTime);
+
+    const Options & getOptions() const
+    {
+        return mOptions;
+    }
 
 private:
     /// @return Hovered node
@@ -50,15 +62,6 @@ private:
     static const int gLeafFlags;
     static const int gPartFlags;
 
-    struct Options
-    {
-        bool mHighlightObjects = false;
-        // Not sure it should be located here: the scene gui will offer the checkbox,
-        // but it is unlikely to handle the actual rendering of light positions.
-        bool mShowPointLights = true;
-        bool mAreDirectionalLightsCameraSpace = false;
-    };
-    
     Options mOptions;
 
     Handle<const Part> mSelectedPart = gNullHandle;

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -12,12 +12,13 @@ namespace ad::renderer {
 
 
 SecondaryView::SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+                             const imguiui::ImguiUi & aImguiUi,
                              Storage & aStorage,
                              const Loader & aLoader) : 
     mAppInterface{std::move(aGlfwAppInterface)},
     mCameraSystem{
         mAppInterface,
-        nullptr /* no inhibiter*/,
+        &aImguiUi,
         CameraSystem::Control::Orbital,
         Orbital{
             5.f,

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -22,7 +22,7 @@ SecondaryView::SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInt
         CameraSystem::Control::Orbital,
         Orbital{
             5.f,
-            math::Degree{0.f}
+            math::Degree<float>{0.f}
         }},
     mRenderSize{mAppInterface->getFramebufferSize()},
     mGraph{mRenderSize, aStorage, aLoader},

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -12,10 +12,11 @@ namespace ad::renderer {
 
 SecondaryView::SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface) :
     mAppInterface{std::move(aGlfwAppInterface)},
-    mCameraSystem{mAppInterface, nullptr /* no inhibiter*/, CameraSystem::Control::FirstPerson}
+    mCameraSystem{mAppInterface, nullptr /* no inhibiter*/, CameraSystem::Control::FirstPerson},
+    mRenderSize{mAppInterface->getFramebufferSize()}
 {
     mCameraSystem.mCamera.setupOrthographicProjection(Camera::OrthographicParameters{
-        .mAspectRatio = 1,
+        .mAspectRatio = math::getRatio<float>(mRenderSize.as<math::Size, float>()),
         .mViewHeight = 2,
         .mNearZ = 0,
         .mFarZ = -100,
@@ -30,11 +31,69 @@ void SecondaryView::render(ViewerApplication & aViewerApp)
 {
     PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "SecondaryView::render()", CpuTime, GpuTime, BufferMemoryWritten);
 
+    // TODO handle resizing
+
+    // TODO handle initializing only once...
+    graphics::ScopedBind boundFbo{mDrawFramebuffer, graphics::FrameBufferTarget::Draw};
+
+    {
+        graphics::ScopedBind boundRenderbuffer{mColorBuffer};
+        glRenderbufferStorage(
+            GL_RENDERBUFFER, 
+            GL_RGBA8,
+            mRenderSize.width(), mRenderSize.height());
+    }
+    glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER,
+                            GL_COLOR_ATTACHMENT0 + gColorAttachment,
+                            GL_RENDERBUFFER,
+                            mColorBuffer);
+
+    {
+        graphics::ScopedBind boundRenderbuffer{mDepthBuffer};
+        glRenderbufferStorage(
+            GL_RENDERBUFFER, 
+            GL_DEPTH_COMPONENT32,
+            mRenderSize.width(), mRenderSize.height());
+    }
+    glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER,
+                            GL_DEPTH_ATTACHMENT,
+                            GL_RENDERBUFFER,
+                            mDepthBuffer);
+
+
+    // TODO clear the buffers!
     aViewerApp.mGraph.renderFrame(aViewerApp.mScene,
                                   mCameraSystem.mCamera,
                                   aViewerApp.mScene.getLightsInCamera(mCameraSystem.mCamera,
                                                                       !aViewerApp.mSceneGui.getOptions().mAreDirectionalLightsCameraSpace),
-                                  aViewerApp.mStorage);
+                                  aViewerApp.mStorage,
+                                  false,
+                                  mDrawFramebuffer);
+                                  //false);
+}
+
+
+void SecondaryView::blitIt(const graphics::FrameBuffer & aDestination)
+{
+    graphics::ScopedBind boundReadFbo{mReadFramebuffer, graphics::FrameBufferTarget::Read};
+    graphics::ScopedBind boundRenderbuffer{mColorBuffer};
+    glFramebufferRenderbuffer(GL_READ_FRAMEBUFFER,
+                              GL_COLOR_ATTACHMENT0 + gColorAttachment,
+                              GL_RENDERBUFFER,
+                              mColorBuffer);
+    glReadBuffer(GL_COLOR_ATTACHMENT0 + gColorAttachment);
+
+    // We expect the size of the read renderbuffer to exactly match that of the output draw buffer.
+    graphics::ScopedBind boundDrawFbo{aDestination, graphics::FrameBufferTarget::Draw};
+    //glDrawBuffer(GL_BACK);
+    
+    assert(glCheckFramebufferStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+    assert(glCheckFramebufferStatus(GL_READ_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
+
+    glBlitFramebuffer(0, 0, mRenderSize.width(), mRenderSize.height(),
+                      0, 0, mRenderSize.width(), mRenderSize.height(),
+                      GL_COLOR_BUFFER_BIT,
+                      GL_NEAREST);
 }
 
 

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -15,7 +15,14 @@ SecondaryView::SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInt
                              Storage & aStorage,
                              const Loader & aLoader) : 
     mAppInterface{std::move(aGlfwAppInterface)},
-    mCameraSystem{mAppInterface, nullptr /* no inhibiter*/, CameraSystem::Control::FirstPerson},
+    mCameraSystem{
+        mAppInterface,
+        nullptr /* no inhibiter*/,
+        CameraSystem::Control::Orbital,
+        Orbital{
+            5.f,
+            math::Degree{0.f}
+        }},
     mRenderSize{mAppInterface->getFramebufferSize()},
     mGraph{mRenderSize, aStorage, aLoader},
     mFramebufferSizeListener{mAppInterface->listenFramebufferResize(
@@ -29,10 +36,6 @@ SecondaryView::SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInt
         .mNearZ = 0,
         .mFarZ = -100,
     });
-    mCameraSystem.mCamera.setPose(
-        graphics::getCameraTransform<GLfloat>({0.f, 5.f, 0.f},
-                                              {0.f, -1.f, 0.f},
-                                              {0.f, 0.f, -1.f}));
 
     // Attach the render buffers to FBO
     graphics::ScopedBind boundFbo{mDrawFramebuffer, graphics::FrameBufferTarget::Draw};
@@ -74,6 +77,14 @@ void SecondaryView::allocateBuffers()
             GL_DEPTH_COMPONENT32,
             mRenderSize.width(), mRenderSize.height());
     }
+}
+
+
+void SecondaryView::update(const Timing & aTime)
+{
+    PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "SecondaryView::update()", CpuTime);
+
+    mCameraSystem.update(aTime.mDeltaDuration);
 }
 
 

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -77,18 +77,17 @@ void SecondaryView::allocateBuffers()
 }
 
 
-void SecondaryView::render(ViewerApplication & aViewerApp)
+void SecondaryView::render(const Scene & aScene, bool aLightsInCameraSpace, Storage & aStorage)
 {
     PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "SecondaryView::render()", CpuTime, GpuTime, BufferMemoryWritten);
 
     graphics::ScopedBind boundFbo{mDrawFramebuffer, graphics::FrameBufferTarget::Draw};
 
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    mGraph.renderFrame(aViewerApp.mScene,
+    mGraph.renderFrame(aScene,
                        mCameraSystem.mCamera,
-                       aViewerApp.mScene.getLightsInCamera(mCameraSystem.mCamera,
-                                                           !aViewerApp.mSceneGui.getOptions().mAreDirectionalLightsCameraSpace),
-                       aViewerApp.mStorage,
+                       aScene.getLightsInCamera(mCameraSystem.mCamera, !aLightsInCameraSpace),
+                       aStorage,
                        false,
                        mDrawFramebuffer);
 }

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -1,0 +1,41 @@
+#include "SecondaryView.h"
+
+#include "ViewerApplication.h"
+
+#include <graphics/CameraUtilities.h>
+
+#include <snac-renderer-V2/Profiling.h>
+
+
+namespace ad::renderer {
+
+
+SecondaryView::SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface) :
+    mAppInterface{std::move(aGlfwAppInterface)},
+    mCameraSystem{mAppInterface, nullptr /* no inhibiter*/, CameraSystem::Control::FirstPerson}
+{
+    mCameraSystem.mCamera.setupOrthographicProjection(Camera::OrthographicParameters{
+        .mAspectRatio = 1,
+        .mViewHeight = 2,
+        .mNearZ = 0,
+        .mFarZ = -100,
+    });
+    mCameraSystem.mCamera.setPose(
+        graphics::getCameraTransform<GLfloat>({0.f, 5.f, 0.f},
+                                              {0.f, -1.f, 0.f},
+                                              {0.f, 0.f, -1.f}));
+}
+
+void SecondaryView::render(ViewerApplication & aViewerApp)
+{
+    PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "SecondaryView::render()", CpuTime, GpuTime, BufferMemoryWritten);
+
+    aViewerApp.mGraph.renderFrame(aViewerApp.mScene,
+                                  mCameraSystem.mCamera,
+                                  aViewerApp.mScene.getLightsInCamera(mCameraSystem.mCamera,
+                                                                      !aViewerApp.mSceneGui.getOptions().mAreDirectionalLightsCameraSpace),
+                                  aViewerApp.mStorage);
+}
+
+
+} // namespace ad::renderer

--- a/src/apps/viewer/viewer/SecondaryView.cpp
+++ b/src/apps/viewer/viewer/SecondaryView.cpp
@@ -78,13 +78,6 @@ void SecondaryView::allocateBuffers()
 
 void SecondaryView::render(ViewerApplication & aViewerApp)
 {
-    mGraph.mTextureRepository[semantic::gFilteredRadianceEnvironmentTexture] = 
-        aViewerApp.mScene.mEnvironment->mFilteredRadiance;
-    mGraph.mTextureRepository[semantic::gIntegratedEnvironmentBrdf] = 
-        aViewerApp.mScene.mEnvironment->mIntegratedBrdf;
-    mGraph.mTextureRepository[semantic::gFilteredIrradianceEnvironmentTexture] = 
-        aViewerApp.mScene.mEnvironment->mFilteredIrradiance;
-
     PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "SecondaryView::render()", CpuTime, GpuTime, BufferMemoryWritten);
 
     graphics::ScopedBind boundFbo{mDrawFramebuffer, graphics::FrameBufferTarget::Draw};

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -3,6 +3,7 @@
 
 #include "CameraSystem.h"
 #include "TheGraph.h"
+#include "Timing.h"
 
 #include <graphics/AppInterface.h>
 
@@ -38,6 +39,8 @@ struct SecondaryView
 
     // Private
     void allocateBuffers();
+
+    void update(const Timing & aTime);
 
     void render(const Scene & aScene, bool aLightsInCameraSpace, Storage & aStorage);
 

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -5,6 +5,9 @@
 
 #include <graphics/AppInterface.h>
 
+#include <renderer/FrameBuffer.h>
+#include <renderer/Renderbuffer.h>
+
 #include <memory>
 
 
@@ -21,8 +24,21 @@ struct SecondaryView
     // TODO: const the viewer app
     void render(/*const*/ ViewerApplication & aViewerApp);
 
+    void blitIt(const graphics::FrameBuffer & aDestination);
+
     std::shared_ptr<graphics::AppInterface> mAppInterface;
     CameraSystem mCameraSystem;
+
+    // TODO further split: FBOs are not shared, so they should be generated and bound on their specific contexts
+    // (plus this will make this class more generic, usable even with single context)
+    graphics::FrameBuffer mDrawFramebuffer;
+    graphics::FrameBuffer mReadFramebuffer;
+    graphics::Renderbuffer mColorBuffer;
+    graphics::Renderbuffer mDepthBuffer;
+
+    math::Size<2, int> mRenderSize;
+
+    inline static constexpr GLint gColorAttachment = 0;
 };
 
 

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -30,6 +30,7 @@ struct SecondaryView
     SecondaryView(SecondaryView &&) = delete;
 
     SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+                  const imguiui::ImguiUi & aImguiUi,
                   // TODO #graph get rid of those, when addressing the problematic design of TheGraph coupling much too many things
                   Storage & aStorage,
                   const Loader & aLoader);

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -15,10 +15,11 @@
 namespace ad::renderer {
 
 
-struct Loader;
-struct Storage;
 struct ViewerApplication;
 
+// TODO #graph remove
+struct Loader;
+struct Storage;
 
 struct SecondaryView
 {
@@ -28,6 +29,7 @@ struct SecondaryView
     SecondaryView(SecondaryView &&) = delete;
 
     SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+                  // TODO #graph get rid of those, when addressing the problematic design of TheGraph coupling much too many things
                   Storage & aStorage,
                   const Loader & aLoader);
 

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -42,15 +42,12 @@ struct SecondaryView
     // TODO: const the viewer app
     void render(/*const*/ ViewerApplication & aViewerApp);
 
-    void blitIt(const graphics::FrameBuffer & aDestination);
-
     std::shared_ptr<graphics::AppInterface> mAppInterface;
     CameraSystem mCameraSystem;
 
     // TODO further split: FBOs are not shared, so they should be generated and bound on their specific contexts
     // (plus this will make this class more generic, usable even with single context)
     graphics::FrameBuffer mDrawFramebuffer;
-    graphics::FrameBuffer mReadFramebuffer;
     graphics::Renderbuffer mColorBuffer;
     graphics::Renderbuffer mDepthBuffer;
 
@@ -59,6 +56,18 @@ struct SecondaryView
     std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
 
     inline static constexpr GLint gColorAttachment = 0;
+};
+
+
+/// @brief Intended to blit a color buffer to a provided Framebuffer (default or FBO).
+/// @attention It has to be instantiated in the OpenGL context of the destination Framebuffer.
+struct ViewBlitter
+{
+    void blitIt(const graphics::Renderbuffer & aColorBuffer,
+                math::Rectangle<GLint> aViewport,
+                const graphics::FrameBuffer & aDestination);
+
+    graphics::FrameBuffer mReadFramebuffer;
 };
 
 

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -2,6 +2,7 @@
 
 
 #include "CameraSystem.h"
+#include "TheGraph.h"
 
 #include <graphics/AppInterface.h>
 
@@ -14,12 +15,27 @@
 namespace ad::renderer {
 
 
+struct Loader;
+struct Storage;
 struct ViewerApplication;
 
 
 struct SecondaryView
 {
-    SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface);
+    // Not easily copyable nor movable, due to the listener which binds to this.
+    // (Note: moving the subobject to the heap might be an easy workaround)
+    SecondaryView(const SecondaryView &) = delete;
+    SecondaryView(SecondaryView &&) = delete;
+
+    SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+                  Storage & aStorage,
+                  const Loader & aLoader);
+
+    
+    void resize(math::Size<2, int> aNewSize);
+
+    // Private
+    void allocateBuffers();
 
     // TODO: const the viewer app
     void render(/*const*/ ViewerApplication & aViewerApp);
@@ -37,6 +53,8 @@ struct SecondaryView
     graphics::Renderbuffer mDepthBuffer;
 
     math::Size<2, int> mRenderSize;
+    TheGraph mGraph;
+    std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
 
     inline static constexpr GLint gColorAttachment = 0;
 };

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -1,0 +1,29 @@
+#pragma once
+
+
+#include "CameraSystem.h"
+
+#include <graphics/AppInterface.h>
+
+#include <memory>
+
+
+namespace ad::renderer {
+
+
+struct ViewerApplication;
+
+
+struct SecondaryView
+{
+    SecondaryView(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface);
+
+    // TODO: const the viewer app
+    void render(/*const*/ ViewerApplication & aViewerApp);
+
+    std::shared_ptr<graphics::AppInterface> mAppInterface;
+    CameraSystem mCameraSystem;
+};
+
+
+} // namespace ad::renderer

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -39,8 +39,7 @@ struct SecondaryView
     // Private
     void allocateBuffers();
 
-    // TODO: const the viewer app
-    void render(/*const*/ ViewerApplication & aViewerApp);
+    void render(const Scene & aScene, bool aLightsInCameraSpace, Storage & aStorage);
 
     std::shared_ptr<graphics::AppInterface> mAppInterface;
     CameraSystem mCameraSystem;

--- a/src/apps/viewer/viewer/SecondaryView.h
+++ b/src/apps/viewer/viewer/SecondaryView.h
@@ -47,6 +47,7 @@ struct SecondaryView
 
     std::shared_ptr<graphics::AppInterface> mAppInterface;
     CameraSystem mCameraSystem;
+    CameraSystemGui mCameraGui;
 
     // TODO further split: FBOs are not shared, so they should be generated and bound on their specific contexts
     // (plus this will make this class more generic, usable even with single context)

--- a/src/apps/viewer/viewer/TheGraph.cpp
+++ b/src/apps/viewer/viewer/TheGraph.cpp
@@ -87,8 +87,7 @@ TheGraph::TheGraph(math::Size<2, int> aRenderSize,
     mInstanceStream{makeInstanceStream(aStorage, gMaxDrawInstances)},
     mRenderSize{aRenderSize},
     mTransparencyResolver{aLoader.loadShader("shaders/TransparencyResolve.frag")},
-    mSkybox{aLoader, aStorage},
-    mDebugRenderer{aStorage, aLoader}
+    mSkybox{aLoader, aStorage}
 {
     allocateTextures(mRenderSize);
     setupTextures();
@@ -288,6 +287,7 @@ void TheGraph::renderFrame(const Scene & aScene,
 }
 
 
+// TODO: rewrite using our model and abstractions
 void TheGraph::passSkyboxBase(const IntrospectProgram & aProgram, const Environment & aEnvironment, Storage & aStorage, GLenum aCulledFace) const
 {
     PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "pass_skybox", CpuTime, GpuTime);
@@ -340,15 +340,6 @@ void TheGraph::passDrawSkybox(const Environment & aEnvironment, Storage & aStora
     Handle<ConfiguredProgram> confProgram = getProgram(*mSkybox.mEffect, annotations);
 
     passSkyboxBase(confProgram->mProgram, aEnvironment, aStorage, aCulledFace);
-}
-
-
-void TheGraph::renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage)
-{
-    // Fullscreen viewport
-    glViewport(0, 0, mRenderSize.width(), mRenderSize.height());
-
-    mDebugRenderer.render(std::move(aDrawList), mUbos.mUboRepository, aStorage);
 }
 
 

--- a/src/apps/viewer/viewer/TheGraph.cpp
+++ b/src/apps/viewer/viewer/TheGraph.cpp
@@ -80,16 +80,12 @@ HardcodedUbos::HardcodedUbos(Storage & aStorage)
 //
 // TheGraph
 //
-TheGraph::TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+TheGraph::TheGraph(math::Size<2, int> aRenderSize,
                    Storage & aStorage,
                    const Loader & aLoader) :
-    mGlfwAppInterface{std::move(aGlfwAppInterface)},
     mUbos{aStorage},
     mInstanceStream{makeInstanceStream(aStorage, gMaxDrawInstances)},
-    mFramebufferSizeListener{mGlfwAppInterface->listenFramebufferResize(
-        std::bind(&TheGraph::onFramebufferResize, this, std::placeholders::_1))
-    },
-    mRenderSize{mGlfwAppInterface->getFramebufferSize()},
+    mRenderSize{aRenderSize},
     mTransparencyResolver{aLoader.loadShader("shaders/TransparencyResolve.frag")},
     mSkybox{aLoader, aStorage},
     mDebugRenderer{aStorage, aLoader}
@@ -105,7 +101,7 @@ TheGraph::TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
 }
 
 
-void TheGraph::onFramebufferResize(math::Size<2, int> aNewSize)
+void TheGraph::resize(math::Size<2, int> aNewSize)
 {
     // Note: for the moment, we keep the render size in sync with the framebuffer size
     // (this is not necessarily true in renderers where the rendered image is blitted to the default framebuffer)

--- a/src/apps/viewer/viewer/TheGraph.h
+++ b/src/apps/viewer/viewer/TheGraph.h
@@ -147,10 +147,6 @@ struct TheGraph
 
     // Skybox rendering
     Skybox mSkybox;
-
-    // Debug rendering
-    DebugRenderer mDebugRenderer;
-
 };
 
 

--- a/src/apps/viewer/viewer/TheGraph.h
+++ b/src/apps/viewer/viewer/TheGraph.h
@@ -61,7 +61,9 @@ struct TheGraph
     void renderFrame(const Scene & aScene,
                      const Camera & aCamera,
                      const LightsData & aLights_camera,
-                     Storage & aStorage);
+                     Storage & aStorage,
+                     bool aShowTextures,
+                     const graphics::FrameBuffer & aFramebuffer = graphics::FrameBuffer::Default());
 
     void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage);
 

--- a/src/apps/viewer/viewer/TheGraph.h
+++ b/src/apps/viewer/viewer/TheGraph.h
@@ -70,13 +70,21 @@ struct TheGraph
     void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage);
 
     // Note: Storage cannot be const, as it might be modified to insert missing VAOs, etc
-    void passOpaqueDepth(const ViewerPartList & aPartList, Storage & mStorage);
+    void passOpaqueDepth(const ViewerPartList & aPartList,
+                         const RepositoryTexture & aTextureRepository,
+                         Storage & mStorage);
     void passForward(const ViewerPartList & aPartList,
+                     const RepositoryTexture & aTextureRepository,
                      Storage & aStorage,
                      bool aEnvironmentMappingconst);
-    void passTransparencyAccumulation(const ViewerPartList & aPartList, Storage & mStorage);
-    void passTransparencyResolve(const ViewerPartList & aPartList, Storage & mStorage);
-    void passDrawSkybox(const Environment & aEnvironment, Storage & aStorage, GLenum aCulledFace = GL_FRONT) const;
+    void passTransparencyAccumulation(const ViewerPartList & aPartList,
+                                      const RepositoryTexture & aTextureRepository,
+                                      Storage & mStorage);
+    void passTransparencyResolve(const ViewerPartList & aPartList, 
+                                 Storage & mStorage);
+    void passDrawSkybox(const Environment & aEnvironment,
+                        Storage & aStorage,
+                        GLenum aCulledFace = GL_FRONT) const;
 
     void passSkyboxBase(const IntrospectProgram & aProgram, const Environment & aEnvironment, Storage & aStorage, GLenum aCulledFace) const;
 
@@ -115,7 +123,6 @@ struct TheGraph
     Controls mControls;
 
     HardcodedUbos mUbos;
-    RepositoryTexture mTextureRepository;
 
     GenericStream mInstanceStream;
 

--- a/src/apps/viewer/viewer/TheGraph.h
+++ b/src/apps/viewer/viewer/TheGraph.h
@@ -48,22 +48,24 @@ void loadCameraUbo(const graphics::UniformBufferObject & aUbo, const Camera & aC
 /// @brief The specific Render Graph for this viewer application.
 struct TheGraph
 {
-    TheGraph(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+    TheGraph(math::Size<2, int> aRenderSize,
              Storage & aStorage,
              const Loader & aLoader);
 
-    void onFramebufferResize(math::Size<2, int> aNewSize);
+    void resize(math::Size<2, int> aNewSize);
 
     void allocateTextures(math::Size<2, int> aSize);
 
     void setupTextures();
 
+    /// @param aFramebuffer Will be bound to DRAW for final image rendering.
+    /// Its renderable size should match the current render size of this, as defined via resize().
     void renderFrame(const Scene & aScene,
                      const Camera & aCamera,
                      const LightsData & aLights_camera,
                      Storage & aStorage,
                      bool aShowTextures,
-                     const graphics::FrameBuffer & aFramebuffer = graphics::FrameBuffer::Default());
+                     const graphics::FrameBuffer & aFramebuffer);
 
     void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList, Storage & aStorage);
 
@@ -112,16 +114,12 @@ struct TheGraph
     };
     Controls mControls;
 
-    std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
-
     HardcodedUbos mUbos;
     RepositoryTexture mTextureRepository;
 
     GenericStream mInstanceStream;
 
     graphics::BufferAny mIndirectBuffer;
-
-    std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
 
     math::Size<2, int> mRenderSize;
 

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -461,7 +461,7 @@ namespace {
 
 
     // TODO Ad 2024/08/08: This should be moved to a more general library
-    /// @brief Render the view frustum of a camera, provided the inverse of its view-projection matrix.
+    /// @brief Debug-draw the view frustum of a camera, provided the inverse of its view-projection matrix.
     void debugDrawCameraFrustum(const math::Matrix<4, 4, float> & aViewProjectionInverse)
     {
         std::array<math::Position<4, float>, 8> ndcCorners{{

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -260,7 +260,8 @@ PrimaryView::PrimaryView(const std::shared_ptr<graphics::AppInterface> & aGlfwAp
 ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
                                      std::shared_ptr<graphics::AppInterface> aSecondViewAppInterface,
                                      const std::filesystem::path & aSceneFile,
-                                     const imguiui::ImguiUi & aImguiUi) :
+                                     const imguiui::ImguiUi & aImguiUi,
+                                     const imguiui::ImguiUi & aSecondViewImguiUi) :
     mGlfwAppInterface{std::move(aGlfwAppInterface)},
     mSecondViewAppInterface{std::move(aSecondViewAppInterface)},
     // TODO How do we handle the dynamic nature of the number of instance that might be renderered?
@@ -270,7 +271,7 @@ ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGl
     // Track the size of the default framebuffer, which will be the destination of mGraph::render().
     mDebugRenderer{mStorage, mLoader},
     mPrimaryView{mGlfwAppInterface, aImguiUi, mLoader, mStorage},
-    mSecondaryView{mSecondViewAppInterface, mStorage, mLoader}
+    mSecondaryView{mSecondViewAppInterface, aSecondViewImguiUi, mStorage, mLoader}
 {
     // TODO #graph This aspect is very problematic: the instance stream should be unique, as its buffers are deeply associated to models
     // on load. This means all "graphs" should use the same at the moment.

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -126,7 +126,8 @@ namespace {
     }
 
 
-    Handle<Effect> makeSimpleEffect(Storage & aStorage)
+    // GCC complains about unused functions in unnamed namespaces
+    [[maybe_unused]] Handle<Effect> makeSimpleEffect(Storage & aStorage)
     {
         aStorage.mProgramConfigs.emplace_back();
         // Compiler error (msvc) workaround, by taking the initializer list out

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -494,7 +494,7 @@ void ViewerApplication::update(const Timing & aTime)
 }
 
 
-void ViewerApplication::drawUi(const renderer::Timing & aTime)
+void ViewerApplication::drawMainUi(const renderer::Timing & aTime)
 {
     if(ImGui::Button("Recompile effects"))
     {
@@ -591,6 +591,12 @@ void ViewerApplication::drawUi(const renderer::Timing & aTime)
             mSecondViewAppInterface->hideWindow();
         }
     }
+}
+
+
+void ViewerApplication::drawSecondaryUi()
+{
+    mSecondaryView.mCameraGui.presentSection(mSecondaryView.mCameraSystem);
 }
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -257,7 +257,10 @@ ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGl
     // At the moment, hardcode a maximum number
     mLoader{makeResourceFinder()},
     mCameraSystem{mGlfwAppInterface, &aImguiUi, CameraSystem::Control::FirstPerson},
-    mGraph{mGlfwAppInterface, mStorage, mLoader}
+    mGraph{mGlfwAppInterface->getFramebufferSize(), mStorage, mLoader},
+    // Track the size of the default framebuffer, which will be the destination of mGraph::render().
+    mFramebufferSizeListener{mGlfwAppInterface->listenFramebufferResize(
+        std::bind(&TheGraph::resize, &mGraph, std::placeholders::_1))}
 {
     if(aSceneFile.extension() == ".sew")
     {
@@ -564,7 +567,8 @@ void ViewerApplication::render()
                        mScene.getLightsInCamera(mCameraSystem.mCamera,
                                                 !mSceneGui.getOptions().mAreDirectionalLightsCameraSpace),
                        mStorage,
-                       false);
+                       false,
+                       graphics::FrameBuffer::Default());
 
     mGraph.renderDebugDrawlist(snac::DebugDrawer::EndFrame(), mStorage);
 }

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -260,7 +260,8 @@ ViewerApplication::ViewerApplication(std::shared_ptr<graphics::AppInterface> aGl
     mGraph{mGlfwAppInterface->getFramebufferSize(), mStorage, mLoader},
     // Track the size of the default framebuffer, which will be the destination of mGraph::render().
     mFramebufferSizeListener{mGlfwAppInterface->listenFramebufferResize(
-        std::bind(&TheGraph::resize, &mGraph, std::placeholders::_1))}
+        std::bind(&TheGraph::resize, &mGraph, std::placeholders::_1))},
+    mDebugRenderer{mStorage, mLoader}
 {
     if(aSceneFile.extension() == ".sew")
     {
@@ -561,8 +562,22 @@ void ViewerApplication::render()
                        false,
                        graphics::FrameBuffer::Default());
 
-    mGraph.renderDebugDrawlist(snac::DebugDrawer::EndFrame(), mStorage);
+    renderDebugDrawlist(snac::DebugDrawer::EndFrame());
 }
 
+
+void ViewerApplication::renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList)
+{
+    // Fullscreen viewport
+    glViewport(0,
+               0, 
+               mGlfwAppInterface->getFramebufferSize().width(),
+               mGlfwAppInterface->getFramebufferSize().height());
+
+    // TODO Ad 2024/08/02: #graph This need to access the ubo repo in the graph is another design smell
+    // It is needed for the viewing block, so we hope it is left at the camera
+    // note: it will break with multiple camera / viewport
+    mDebugRenderer.render(std::move(aDrawList), mGraph.mUbos.mUboRepository, mStorage);
+}
 
 } // namespace ad::renderer

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -489,6 +489,7 @@ void ViewerApplication::update(const Timing & aTime)
     }
 
     mPrimaryView.update(aTime);
+    mSecondaryView.update(aTime);
 }
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -459,6 +459,16 @@ void showPointLights(const LightsData & aLights)
 void PrimaryView::update(const Timing & aTime)
 {
     mCameraSystem.update(aTime.mDeltaDuration);
+
+    // Debugdraw the camera basis
+    {
+        auto cameraToWorld = mCameraSystem.mCamera.getParentToCamera().inverse();
+        // TODO we might want to used another channel for that
+        DBGDRAW_INFO(drawer::gLight).addBasis({
+            .mPosition = cameraToWorld.getAffine().as<math::Position>(),
+            .mOrientation = math::toQuaternion(cameraToWorld.getLinear()),
+        });
+    }
 }
 
 
@@ -615,6 +625,17 @@ void ViewerApplication::render()
         // TODO Ad 2024/08/02: #graph This need to access the ubo repo in the graph is another design smell
         // It is needed for the viewing block, so we hope it is left at the camera position
         mPrimaryView.mGraph.mUbos.mUboRepository);
+
+    {
+        graphics::ScopedBind boundFbo{mSecondaryView.mDrawFramebuffer};
+        renderDebugDrawlist(
+            drawList,
+            // Fullscreen viewport
+            math::Rectangle<int>::AtOrigin(mSecondaryView.mRenderSize),
+            // TODO Ad 2024/08/02: #graph This need to access the ubo repo in the graph is another design smell
+            // It is needed for the viewing block, so we hope it is left at the camera position
+            mSecondaryView.mGraph.mUbos.mUboRepository);
+    }
 }
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -563,7 +563,8 @@ void ViewerApplication::render()
                        mCameraSystem.mCamera,
                        mScene.getLightsInCamera(mCameraSystem.mCamera,
                                                 !mSceneGui.getOptions().mAreDirectionalLightsCameraSpace),
-                       mStorage);
+                       mStorage,
+                       false);
 
     mGraph.renderDebugDrawlist(snac::DebugDrawer::EndFrame(), mStorage);
 }

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -457,7 +457,7 @@ void ViewerApplication::update(const Timing & aTime)
     handleAnimations(mScene.mRoot, aTime);
 
     // handle lights
-    if(mSceneGui.mOptions.mShowPointLights)
+    if(mSceneGui.getOptions().mShowPointLights)
     {
         showPointLights(mScene.mLights_world);
     }
@@ -562,7 +562,7 @@ void ViewerApplication::render()
     mGraph.renderFrame(mScene,
                        mCameraSystem.mCamera,
                        mScene.getLightsInCamera(mCameraSystem.mCamera,
-                                                !mSceneGui.mOptions.mAreDirectionalLightsCameraSpace),
+                                                !mSceneGui.getOptions().mAreDirectionalLightsCameraSpace),
                        mStorage);
 
     mGraph.renderDebugDrawlist(snac::DebugDrawer::EndFrame(), mStorage);

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -323,7 +323,7 @@ void ViewerApplication::setEnvironmentCubemap(std::filesystem::path aEnvironment
     const GLint gFilteredRadianceSide = 512;
     const GLint gIntegratedBrdfSide = 512;
     const GLint gFilteredIrradianceSide = 128;
-    // That approach is smelly: we use the Environment to compute an value we will set on the Environment
+    // That approach is smelly: we use the Environment to compute a value we then assign to the Environment
     mScene.mEnvironment->mFilteredRadiance =
         filterEnvironmentMapSpecular(*mScene.mEnvironment, mGraph, mStorage, gFilteredRadianceSide);
     glObjectLabel(GL_TEXTURE, *mScene.mEnvironment->mFilteredRadiance, -1, "filtered_radiance_env");

--- a/src/apps/viewer/viewer/ViewerApplication.cpp
+++ b/src/apps/viewer/viewer/ViewerApplication.cpp
@@ -295,10 +295,9 @@ namespace {
         Handle<const graphics::Texture> texture = &aApp.mStorage.mTextures.back();
         aApp.mScene.mEnvironment = Environment{
             .mType = aType,
-            .mMap = texture,
+            .mTextureRepository{ {semantic::gEnvironmentTexture, texture}, },
             .mMapFile = std::move(aPath),
         };
-        aApp.mGraph.mTextureRepository[semantic::gEnvironmentTexture] = texture;
     }
 
 } // unnamed namespace
@@ -323,24 +322,16 @@ void ViewerApplication::setEnvironmentCubemap(std::filesystem::path aEnvironment
     const GLint gFilteredRadianceSide = 512;
     const GLint gIntegratedBrdfSide = 512;
     const GLint gFilteredIrradianceSide = 128;
+
     // That approach is smelly: we use the Environment to compute a value we then assign to the Environment
-    mScene.mEnvironment->mFilteredRadiance =
+    mScene.mEnvironment->mTextureRepository[semantic::gFilteredRadianceEnvironmentTexture] =
         filterEnvironmentMapSpecular(*mScene.mEnvironment, mGraph, mStorage, gFilteredRadianceSide);
-    glObjectLabel(GL_TEXTURE, *mScene.mEnvironment->mFilteredRadiance, -1, "filtered_radiance_env");
-    mGraph.mTextureRepository[semantic::gFilteredRadianceEnvironmentTexture] = 
-        mScene.mEnvironment->mFilteredRadiance;
 
-    mScene.mEnvironment->mIntegratedBrdf =
+    mScene.mEnvironment->mTextureRepository[semantic::gIntegratedEnvironmentBrdf] =
         integrateEnvironmentBrdf(mStorage, gIntegratedBrdfSide, mLoader);
-    glObjectLabel(GL_TEXTURE, *mScene.mEnvironment->mIntegratedBrdf, -1, "integrated_env_brdf");
-    mGraph.mTextureRepository[semantic::gIntegratedEnvironmentBrdf] = 
-        mScene.mEnvironment->mIntegratedBrdf;
 
-    mScene.mEnvironment->mFilteredIrradiance =
+    mScene.mEnvironment->mTextureRepository[semantic::gFilteredIrradianceEnvironmentTexture] =
         filterEnvironmentMapDiffuse(*mScene.mEnvironment, mGraph, mStorage, gFilteredIrradianceSide);
-    glObjectLabel(GL_TEXTURE, *mScene.mEnvironment->mFilteredIrradiance, -1, "filtered_irradiance_env");
-    mGraph.mTextureRepository[semantic::gFilteredIrradianceEnvironmentTexture] = 
-        mScene.mEnvironment->mFilteredIrradiance;
 }
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -42,6 +42,8 @@ struct ViewerApplication
     void update(const Timing & aTime);
     void render();
 
+    void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList);
+
     void drawUi(const Timing & aTime);
 
     std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
@@ -56,6 +58,8 @@ struct ViewerApplication
 
     TheGraph mGraph;
     std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
+
+    DebugRenderer mDebugRenderer;
 };
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -3,6 +3,7 @@
 
 #include "CameraSystem.h"
 #include "GraphGui.h"
+#include "SecondaryView.h"
 #include "Scene.h"
 #include "SceneGui.h"
 #include "TheGraph.h"
@@ -51,6 +52,7 @@ struct PrimaryView
 struct ViewerApplication
 {
     ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
+                      std::shared_ptr<graphics::AppInterface> aSecondViewAppInterface,
                       const std::filesystem::path & aSceneFile,
                       const imguiui::ImguiUi & aImguiUi);
 
@@ -68,6 +70,7 @@ struct ViewerApplication
     void drawUi(const Timing & aTime);
 
     std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
+    std::shared_ptr<graphics::AppInterface> mSecondViewAppInterface;
     Storage mStorage;
     Loader mLoader;
     Scene mScene;
@@ -76,6 +79,7 @@ struct ViewerApplication
     DebugRenderer mDebugRenderer;
 
     PrimaryView mPrimaryView;
+    SecondaryView mSecondaryView;
 };
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -24,13 +24,32 @@ namespace ad::renderer {
 struct PassCache;
 
 
-struct ViewerApplication
+// An attempt to separate what is related to the main view from what is transverse to views.
+struct PrimaryView
 {
     // Not easily copyable nor movable, due to the listener which binds to a subobject.
     // (Note: moving the subobject to the heap might be an easy workaround)
-    ViewerApplication(const ViewerApplication &) = delete;
-    ViewerApplication(ViewerApplication &&) = delete;
+    PrimaryView(const PrimaryView &) = delete;
+    PrimaryView(PrimaryView &&) = delete;
 
+    PrimaryView(const std::shared_ptr<graphics::AppInterface> & aGlfwAppInterface, const imguiui::ImguiUi & aImguiUi, Loader & aLoader, Storage & aStorage);
+
+    void update(const Timing & aTime);
+
+    void render(const Scene & aScene, bool aLightsInCameraSpace, Storage & aStorage);
+
+    CameraSystem mCameraSystem;
+    CameraSystemGui mCameraGui;
+
+    TheGraph mGraph;
+    GraphGui mGraphGui;
+
+    std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
+};
+
+
+struct ViewerApplication
+{
     ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
                       const std::filesystem::path & aSceneFile,
                       const imguiui::ImguiUi & aImguiUi);
@@ -42,24 +61,21 @@ struct ViewerApplication
     void update(const Timing & aTime);
     void render();
 
-    void renderDebugDrawlist(snac::DebugDrawer::DrawList aDrawList);
+    void renderDebugDrawlist(const snac::DebugDrawer::DrawList & aDrawList,
+                             math::Rectangle<int> aViewport,
+                             const RepositoryUbo & aUboRepo);
 
     void drawUi(const Timing & aTime);
 
     std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
     Storage mStorage;
-    Scene mScene;
     Loader mLoader;
-    SceneGui mSceneGui{mLoader.loadEffect("effects/Highlight.sefx", mStorage), mStorage};
-    GraphGui mGraphGui;
-
-    CameraSystem mCameraSystem;
-    CameraSystemGui mCameraGui;
-
-    TheGraph mGraph;
-    std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
+    Scene mScene;
+    SceneGui mSceneGui;
 
     DebugRenderer mDebugRenderer;
+
+    PrimaryView mPrimaryView;
 };
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -71,7 +71,9 @@ struct ViewerApplication
                              math::Rectangle<int> aViewport,
                              const RepositoryUbo & aUboRepo);
 
-    void drawUi(const Timing & aTime);
+    void drawMainUi(const Timing & aTime);
+
+    void drawSecondaryUi();
 
     std::shared_ptr<graphics::AppInterface> mGlfwAppInterface;
     std::shared_ptr<graphics::AppInterface> mSecondViewAppInterface;

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -26,6 +26,11 @@ struct PassCache;
 
 struct ViewerApplication
 {
+    // Not easily copyable nor movable, due to the listener which binds to a subobject.
+    // (Note: moving the subobject to the heap might be an easy workaround)
+    ViewerApplication(const ViewerApplication &) = delete;
+    ViewerApplication(ViewerApplication &&) = delete;
+
     ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
                       const std::filesystem::path & aSceneFile,
                       const imguiui::ImguiUi & aImguiUi);
@@ -50,6 +55,7 @@ struct ViewerApplication
     CameraSystemGui mCameraGui;
 
     TheGraph mGraph;
+    std::shared_ptr<graphics::AppInterface::SizeListener> mFramebufferSizeListener;
 };
 
 

--- a/src/apps/viewer/viewer/ViewerApplication.h
+++ b/src/apps/viewer/viewer/ViewerApplication.h
@@ -33,7 +33,10 @@ struct PrimaryView
     PrimaryView(const PrimaryView &) = delete;
     PrimaryView(PrimaryView &&) = delete;
 
-    PrimaryView(const std::shared_ptr<graphics::AppInterface> & aGlfwAppInterface, const imguiui::ImguiUi & aImguiUi, Loader & aLoader, Storage & aStorage);
+    PrimaryView(const std::shared_ptr<graphics::AppInterface> & aGlfwAppInterface,
+                const imguiui::ImguiUi & aImguiUi,
+                Loader & aLoader,
+                Storage & aStorage);
 
     void update(const Timing & aTime);
 
@@ -54,7 +57,8 @@ struct ViewerApplication
     ViewerApplication(std::shared_ptr<graphics::AppInterface> aGlfwAppInterface,
                       std::shared_ptr<graphics::AppInterface> aSecondViewAppInterface,
                       const std::filesystem::path & aSceneFile,
-                      const imguiui::ImguiUi & aImguiUi);
+                      const imguiui::ImguiUi & aMainImguiUi,
+                      const imguiui::ImguiUi & aSecondViewImguiUi);
 
     void setEnvironmentCubemap(std::filesystem::path aEnvironmentStrip);
     void setEnvironmentEquirectangular(std::filesystem::path aEnvironmentEquirect);

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -185,6 +185,13 @@ int runApplication(int argc, char * argv[])
     // Used as memory from one call to the next
     std::ostringstream profilerOut;
 
+    auto secondWindow = graphics::ApplicationGlfw{glfwApp, "Secondary", 800, 600};
+    glfwSwapInterval(0); // Disable V-sync
+
+    // Immediately make the main window context current
+    // It is essential when generating queries, which apparently are not shared
+    glfwApp.makeContextCurrent();
+
     while (glfwApp.handleEvents())
     {
         PROFILER_BEGIN_FRAME(gRenderProfiler);
@@ -225,6 +232,22 @@ int runApplication(int argc, char * argv[])
 
         PROFILER_END_SECTION(frameSection);
         PROFILER_END_FRAME(gRenderProfiler);
+
+        if(!secondWindow.shouldClose())
+        {
+            if(secondWindow.isVisible())
+            {
+                secondWindow.makeContextCurrent();
+                glClear(GL_COLOR_BUFFER_BIT);
+                secondWindow.swapBuffers();
+                glfwApp.makeContextCurrent();
+            }
+        }
+        else
+        {
+            secondWindow.hide();
+            secondWindow.markWindowShouldClose(GLFW_FALSE);
+        }
 
         // Note: the printing of the profiler content happens out of the frame, so its time is excluded from profiler's frame time
         profilerOut.str("");

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -195,6 +195,8 @@ int runApplication(int argc, char * argv[])
     glfwApp.makeContextCurrent();
 
     renderer::SecondaryView secondaryView{secondWindow.getAppInterface(), application.mStorage, application.mLoader};
+    // TODO #graph This aspect is very problematic: the instance stream should be unique, as its buffers are deeply associated to models
+    // on load. This means all "graphs" should use the same at the moment.
     secondaryView.mGraph.mInstanceStream = application.mGraph.mInstanceStream;
 
     while (glfwApp.handleEvents())

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -188,6 +188,7 @@ int runApplication(int argc, char * argv[])
 
     auto secondWindow = graphics::ApplicationGlfw{glfwApp, "Secondary", 800, 600};
     glfwSwapInterval(0); // Disable V-sync
+    renderer::ViewBlitter blitter; // Created in the GL context of the destination window
 
     // Immediately make the main window context current
     // It is essential when generating queries, which apparently are not shared
@@ -251,7 +252,9 @@ int runApplication(int argc, char * argv[])
             {
                 secondWindow.makeContextCurrent();
                 glClear(GL_COLOR_BUFFER_BIT);
-                secondaryView.blitIt(graphics::FrameBuffer::Default());
+                blitter.blitIt(secondaryView.mColorBuffer,
+                               math::Rectangle<GLint>::AtOrigin(secondaryView.mRenderSize),
+                               graphics::FrameBuffer::Default());
                 secondWindow.swapBuffers();
                 glfwApp.makeContextCurrent();
             }

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -73,7 +73,9 @@ void showGui(imguiui::ImguiUi & imguiUi,
              const std::string & aProfilerOutput,
              const renderer::Timing & aTime)
 {
-    PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "imgui ui", renderer::CpuTime, renderer::GpuTime);
+    PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "imgui main ui", renderer::CpuTime, renderer::GpuTime);
+
+    assert(ImGui::GetCurrentContext() == nullptr);
 
     imguiUi.newFrame();
 
@@ -115,12 +117,19 @@ void showGui(imguiui::ImguiUi & imguiUi,
 
     imguiUi.render();
     imguiUi.renderBackend();
+
+    // We want to make sure the context is always explicitly set by our ImguiUi implementation
+    ImGui::SetCurrentContext(nullptr);
 }
 
 
 void showSecondGui(imguiui::ImguiUi & imguiUi,
                    renderer::ViewerApplication & aApplication)
 {
+    PROFILER_SCOPE_RECURRING_SECTION(gRenderProfiler, "imgui secondary ui", renderer::CpuTime);
+
+    assert(ImGui::GetCurrentContext() == nullptr);
+
     imguiUi.newFrame();
 
     ImGui::Begin("Debug");
@@ -131,6 +140,9 @@ void showSecondGui(imguiui::ImguiUi & imguiUi,
 
     imguiUi.render();
     imguiUi.renderBackend();
+
+    // We want to make sure the context is always explicitly set by our ImguiUi implementation
+    ImGui::SetCurrentContext(nullptr);
 }
 
 
@@ -158,7 +170,7 @@ int runApplication(int argc, char * argv[])
     __itt_task_begin(itt_domain, __itt_null, __itt_null, itt_handleGlfwApp);
     graphics::ApplicationGlfw glfwApp{
         getVersionedName(),
-        1920, 1024,
+        1280, 1024,
         glfwFlags,
         4, 6,
         { {GLFW_SAMPLES, gMsaaSamples} },

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -198,7 +198,7 @@ int runApplication(int argc, char * argv[])
     renderer::SecondaryView secondaryView{secondWindow.getAppInterface(), application.mStorage, application.mLoader};
     // TODO #graph This aspect is very problematic: the instance stream should be unique, as its buffers are deeply associated to models
     // on load. This means all "graphs" should use the same at the moment.
-    secondaryView.mGraph.mInstanceStream = application.mGraph.mInstanceStream;
+    secondaryView.mGraph.mInstanceStream = application.mPrimaryView.mGraph.mInstanceStream;
 
     while (glfwApp.handleEvents())
     {

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -1,4 +1,5 @@
 #include "Logging.h"
+#include "SecondaryView.h"
 #include "Timing.h"
 #include "ViewerApplication.h"
 
@@ -188,6 +189,8 @@ int runApplication(int argc, char * argv[])
     auto secondWindow = graphics::ApplicationGlfw{glfwApp, "Secondary", 800, 600};
     glfwSwapInterval(0); // Disable V-sync
 
+    renderer::SecondaryView secondaryView{secondWindow.getAppInterface()};
+
     // Immediately make the main window context current
     // It is essential when generating queries, which apparently are not shared
     glfwApp.makeContextCurrent();
@@ -227,6 +230,11 @@ int runApplication(int argc, char * argv[])
         // would be better to show current frame 
         // (but this implies to end the profiler frame earlier, thus not profiling ImGui UI)
         showGui(imguiUi, application, profilerOut.str(), timing);
+
+        if(secondWindow.isVisible())
+        {
+            secondaryView.render(application);
+        }
 
         glfwApp.swapBuffers();
 

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -189,11 +189,13 @@ int runApplication(int argc, char * argv[])
     auto secondWindow = graphics::ApplicationGlfw{glfwApp, "Secondary", 800, 600};
     glfwSwapInterval(0); // Disable V-sync
 
-    renderer::SecondaryView secondaryView{secondWindow.getAppInterface()};
-
     // Immediately make the main window context current
     // It is essential when generating queries, which apparently are not shared
+    // Also, SecondaryView initialize objects that have to be on the main context
     glfwApp.makeContextCurrent();
+
+    renderer::SecondaryView secondaryView{secondWindow.getAppInterface(), application.mStorage, application.mLoader};
+    secondaryView.mGraph.mInstanceStream = application.mGraph.mInstanceStream;
 
     while (glfwApp.handleEvents())
     {

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -79,7 +79,7 @@ void showGui(imguiui::ImguiUi & imguiUi,
 
     ImGui::Begin("Main control");
     {
-        aApplication.drawUi(aTime);
+        aApplication.drawMainUi(aTime);
 
         static bool showProfiler = false;
         if(imguiui::addCheckbox("Profiler", showProfiler))
@@ -118,11 +118,15 @@ void showGui(imguiui::ImguiUi & imguiUi,
 }
 
 
-void showSecondGui(imguiui::ImguiUi & imguiUi)
+void showSecondGui(imguiui::ImguiUi & imguiUi,
+                   renderer::ViewerApplication & aApplication)
 {
     imguiUi.newFrame();
 
-    ImGui::Begin("Second control");
+    ImGui::Begin("Debug");
+    {
+        aApplication.drawSecondaryUi();
+    }
     ImGui::End();
 
     imguiUi.render();
@@ -273,7 +277,7 @@ int runApplication(int argc, char * argv[])
                                math::Rectangle<GLint>::AtOrigin(application.mSecondaryView.mRenderSize),
                                graphics::FrameBuffer::Default());
                 // Prepare the GUI for the 2nd window.
-                showSecondGui(secondImguiUi);
+                showSecondGui(secondImguiUi, application);
                 secondWindow.swapBuffers();
                 glfwApp.makeContextCurrent();
             }

--- a/src/apps/viewer/viewer/main.cpp
+++ b/src/apps/viewer/viewer/main.cpp
@@ -247,6 +247,7 @@ int runApplication(int argc, char * argv[])
             {
                 secondWindow.makeContextCurrent();
                 glClear(GL_COLOR_BUFFER_BIT);
+                secondaryView.blitIt(graphics::FrameBuffer::Default());
                 secondWindow.swapBuffers();
                 glfwApp.makeContextCurrent();
             }

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.cpp
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.cpp
@@ -11,6 +11,7 @@ namespace {
 
     void initializeDebugDrawers_impl()
     {
+        snac::DebugDrawer::AddDrawer(drawer::gCamera);
         snac::DebugDrawer::AddDrawer(drawer::gLight);
         snac::DebugDrawer::AddDrawer(drawer::gRig);
     }

--- a/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.h
+++ b/src/libs/snac-renderer-V2/snac-renderer-V2/debug/DebugDrawing.h
@@ -7,6 +7,7 @@ namespace ad::renderer {
 
 namespace drawer
 {
+    constexpr const char * gCamera = "camera";
     constexpr const char * gLight = "light";
     constexpr const char * gRig = "rig";
 }


### PR DESCRIPTION
closes #136.
- Show a trivial a second window, naively added in main().
- Start implementing a secondary view, as a top-down ortho camera.
- Take the draw FBO as parameter of Graph::render().
- Decouple TheGraph render size from default framebuffer size.
- Get the secondary window resize behaviour, at the cost of many hacks.
- fixup
- Abstract the environment texture repo in Environment class.
- fixup
- Document (TODOs) some remaining problems with the graph design.
- Separate the blitting class from the secondary view.
- Move debug rendering from TheGraph to ViewerApplication.
- Separate the primary view in a distinct struct, out of ViewerApp.
- Move secondary view in ViewerApplication, handle window via GUI.
- Draw debug in the secondary view, add primary camera basis.
- Accept the initial orbital pose on CameraSystem construction.
- Prototype showing a separate ImGui context in secondary window.
- Add debug camera controls to secondary window GUI.
- Fix bug in Camera projection change detection.
- Show camera view frustum via debug drawer.
- Upgrade dependencies.
